### PR TITLE
Changed html lang from ru to en

### DIFF
--- a/src/HangFire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/HangFire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -7,7 +7,7 @@
 @inherits RazorPage
 <!DOCTYPE html>
 
-<html lang="ru">
+<html lang="en">
 <head>
     <title>@Title - HangFire</title>
     <meta charset="utf-8" />


### PR DESCRIPTION
Google translate is constantly suggesting to translate the dashboard pages from russian because the html lang is set to "ru" :)
