### PR TITLE
Remove Russian language html setting

### DIFF
--- a/src/HangFire.Core/Dashboard/Pages/LayoutPage.generated.cs
+++ b/src/HangFire.Core/Dashboard/Pages/LayoutPage.generated.cs
@@ -61,7 +61,7 @@ WriteLiteral("\r\n");
 
 
 
-WriteLiteral("<!DOCTYPE html>\r\n\r\n<html>\r\n<head>\r\n    <title>");
+WriteLiteral("<!DOCTYPE html>\r\n\r\n<html lang=\"en\">\r\n<head>\r\n    <title>");
 
 
             


### PR DESCRIPTION
With `<html lang="ru">` Chrome keeps asking me if I want to translate the page. I believe this setting is not needed.
