### PR TITLE
Add ability to automatically delete job when retry attempts exceeded

### DIFF
--- a/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
@@ -39,12 +39,12 @@ namespace Hangfire.Core.Tests
                 () => new AutomaticRetryAttribute { Attempts = -1 });
         }
 
-	    [Fact]
-	    public void Ctor_SetsOnAttemptsExceededAction_ByDefault()
-	    {
-		    var filter = new AutomaticRetryAttribute();
-			Assert.Equal(AttemptsExceededAction.Fail, filter.OnAttemptsExceeded);
-	    }
+        [Fact]
+        public void Ctor_SetsOnAttemptsExceededAction_ByDefault()
+        {
+            var filter = new AutomaticRetryAttribute();
+            Assert.Equal(AttemptsExceededAction.Fail, filter.OnAttemptsExceeded);
+        }
 
         [Fact]
         public void OnStateElection_DoesNotChangeState_IfRetryAttemptsIsSetToZero()
@@ -76,7 +76,7 @@ namespace Hangfire.Core.Tests
             _context.CandidateStateValue = state.Object;
 
             filter.OnStateElection(_context.Object);
-            
+
             Assert.Same(state.Object, _context.Object.CandidateState);
         }
 
@@ -91,38 +91,38 @@ namespace Hangfire.Core.Tests
             Assert.Same(_failedState, _context.Object.CandidateState);
         }
 
-	    [Fact]
-	    public void OnStateElection_ChangesStateToDeleted_IfRetryAttemptsNumberExceededAndOnAttemptsExceededIsSetToDelete()
-	    {
+        [Fact]
+        public void OnStateElection_ChangesStateToDeleted_IfRetryAttemptsNumberExceededAndOnAttemptsExceededIsSetToDelete()
+        {
             _connection.Setup(x => x.GetJobParameter(JobId, "RetryCount")).Returns("1");
-            var filter = new AutomaticRetryAttribute {Attempts = 1, OnAttemptsExceeded = AttemptsExceededAction.Delete};
+            var filter = new AutomaticRetryAttribute { Attempts = 1, OnAttemptsExceeded = AttemptsExceededAction.Delete };
 
-		    filter.OnStateElection(_context.Object);
+            filter.OnStateElection(_context.Object);
 
             Assert.IsType<DeletedState>(_context.Object.CandidateState);
-	    }
+        }
 
-	    [Fact]
-	    public void OnStateElection_ChangesStateToFailed_IfRetryAttemptsNumberExceededAndOnAttemptsExceedIsSetToFail()
-	    {
+        [Fact]
+        public void OnStateElection_ChangesStateToFailed_IfRetryAttemptsNumberExceededAndOnAttemptsExceedIsSetToFail()
+        {
             _connection.Setup(x => x.GetJobParameter(JobId, "RetryCount")).Returns("1");
-            var filter = new AutomaticRetryAttribute {Attempts = 1, OnAttemptsExceeded = AttemptsExceededAction.Fail};
+            var filter = new AutomaticRetryAttribute { Attempts = 1, OnAttemptsExceeded = AttemptsExceededAction.Fail };
 
-		    filter.OnStateElection(_context.Object);
+            filter.OnStateElection(_context.Object);
 
             Assert.IsType<FailedState>(_context.Object.CandidateState);
-	    }
+        }
 
-	    [Fact]
-	    public void OnStateElection_ChangesStateToDeleted_IfRetryAttemptsNumberIsZeroAndOnAttemptsExceedIsSetToDelete()
-	    {
+        [Fact]
+        public void OnStateElection_ChangesStateToDeleted_IfRetryAttemptsNumberIsZeroAndOnAttemptsExceedIsSetToDelete()
+        {
             _connection.Setup(x => x.GetJobParameter(JobId, "RetryCount")).Returns("0");
-            var filter = new AutomaticRetryAttribute {Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete};
+            var filter = new AutomaticRetryAttribute { Attempts = 0, OnAttemptsExceeded = AttemptsExceededAction.Delete };
 
-		    filter.OnStateElection(_context.Object);
+            filter.OnStateElection(_context.Object);
 
             Assert.IsType<DeletedState>(_context.Object.CandidateState);
-	    }
+        }
 
         private static AutomaticRetryAttribute CreateFilter()
         {


### PR DESCRIPTION
Updated `AutomaticRetryAttribute` to add the ability to automatically delete the job if the retry count is exceeded. The implementation is based off the discussion in #104.

@odinserj I can see from the diff on github that the formatting is off somewhat. If you let me know what your tabs/spaces are set to, I'll fix it up and push an update onto the branch.

TODO:
- [x] Fix formatting
- [x] Fix any other issues raised by @odinserj 
