### PR TITLE
Force IE compatibility to edge for Intranet sites

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -10,6 +10,7 @@
 <html lang="en">
 <head>
     <title>@Title - Hangfire</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="@Request.LinkTo("/css")" />


### PR DESCRIPTION
By default Internet Explorer is configured to render in compatibility mode, effectively IE 7 mode, when it encounters a known Intranet site. Telling IE to run in "edge" mode will cause IE 9 to run in IE 9 mode, IE 10 to run in IE 10 mode, and so on.

More on IE's "smart defaults":
http://tesmond.blogspot.com/2011/10/ie9-intranet-compatibility-mode-in.html
http://blogs.msdn.com/b/ie/archive/2009/06/17/compatibility-view-and-smart-defaults.aspx

More on setting the compatibility mode:
https://www.modern.ie/en-us/performance/how-to-use-x-ua-compatible
