### PR TITLE
Adding reference to Hangfire.TinyIoC project in Hangfire readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Related Projects
 * [Hangfire.Ninject](https://github.com/HangfireIO/Hangfire.Ninject)
 * [Hangfire.SimpleInjector](https://github.com/devmondo/Hangfire.SimpleInjector) by [@devmondo](https://github.com/devmondo)
 * [Hangfire.Windsor](https://github.com/BredStik/Hangfire.Windsor) by [@BredStik](https://github.com/BredStik)
+* [Hangfire.TinyIoC](https://github.com/richclement/HangFire.TinyIoC) by [@richclement](https://github.com/richclement)
 * [Hangfire.Azure.QueueStorage](https://github.com/HangfireIO/Hangfire.Azure.QueueStorage)
 * [Hangfire.Azure.ServiceBusQueue](https://github.com/HangfireIO/Hangfire.Azure.ServiceBusQueue)
 


### PR DESCRIPTION
Created a job activator that supports the [TinyIoC](https://github.com/grumpydev/TinyIoC) container.
