### PR TITLE
Add a job activation context.

### DIFF
--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -75,13 +75,16 @@ namespace Hangfire.Common
             object result = null;
             try
             {
-                if (!Method.IsStatic)
+                using (var jobActivationContext = new JobActivationContext())
                 {
-                    instance = Activate(activator);
-                }
+                    if (!Method.IsStatic)
+                    {
+                        instance = Activate(activator, jobActivationContext);
+                    }
 
-                var deserializedArguments = DeserializeArguments(cancellationToken);
-                result = InvokeMethod(instance, deserializedArguments);
+                    var deserializedArguments = DeserializeArguments(cancellationToken);
+                    result = InvokeMethod(instance, deserializedArguments);
+                }
             }
             finally
             {
@@ -209,11 +212,11 @@ namespace Hangfire.Common
             }
         }
 
-        private object Activate(JobActivator activator)
+        private object Activate(JobActivator activator, IJobActivationContext jobActivationContext)
         {
             try
             {
-                var instance = activator.ActivateJob(Type);
+                var instance = activator.ActivateJob(Type, jobActivationContext);
 
                 if (instance == null)
                 {

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -78,6 +78,7 @@
     <Compile Include="..\Common\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="JobActivationContext.cs" />
     <Compile Include="AutomaticRetryAttribute.cs" />
     <Compile Include="BackgroundJobServer.cs" />
     <Compile Include="BackgroundJobServerOptions.cs" />
@@ -197,6 +198,7 @@
     </Compile>
     <Compile Include="Dashboard\RazorPageDispatcher.cs" />
     <Compile Include="Dashboard\RequestExtensions.cs" />
+    <Compile Include="IJobActivationContext.cs" />
     <Compile Include="IBootstrapperConfiguration.cs" />
     <Compile Include="OwinBootstrapper.cs" />
     <Compile Include="Properties\Annotations.cs" />

--- a/src/Hangfire.Core/IJobActivationContext.cs
+++ b/src/Hangfire.Core/IJobActivationContext.cs
@@ -1,0 +1,25 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+namespace Hangfire
+{
+    using System;
+
+    public interface IJobActivationContext
+    {
+        event EventHandler ContextEnded;
+    }
+}

--- a/src/Hangfire.Core/JobActivationContext.cs
+++ b/src/Hangfire.Core/JobActivationContext.cs
@@ -14,35 +14,24 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-
 namespace Hangfire
 {
-    public class JobActivator
+    using System;
+
+    public sealed class JobActivationContext : IJobActivationContext, IDisposable
     {
-        private static JobActivator _current = new JobActivator();
+        public event EventHandler ContextEnded;
 
-        /// <summary>
-        /// Gets or sets the current <see cref="JobActivator"/> instance 
-        /// that will be used to activate jobs during performance.
-        /// </summary>
-        public static JobActivator Current
+        public void Dispose()
         {
-            get { return _current; }
-            set
+            var contextEndedEventHandler = this.ContextEnded;
+
+            if (contextEndedEventHandler != null)
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-
-                _current = value;
+                contextEndedEventHandler(this, EventArgs.Empty);
             }
-        }
 
-        public virtual object ActivateJob(Type jobType, IJobActivationContext jobActivationContext)
-        {
-            return Activator.CreateInstance(jobType);
+            this.ContextEnded = null;
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
@@ -17,7 +17,7 @@ namespace Hangfire.Core.Tests.Common
 		public JobArgumentFacts()
 		{
 			_activator = new Mock<JobActivator>();
-			_activator.Setup(x => x.ActivateJob(It.IsAny<Type>()))
+			_activator.Setup(x => x.ActivateJob(It.IsAny<Type>(), It.IsAny<IJobActivationContext>()))
 				      .Returns(() => new JobArgumentFacts());
 
 			_token = new Mock<IJobCancellationToken>();

--- a/tests/Hangfire.Core.Tests/JobActivatorFacts.cs
+++ b/tests/Hangfire.Core.Tests/JobActivatorFacts.cs
@@ -3,6 +3,8 @@ using Xunit;
 
 namespace Hangfire.Core.Tests
 {
+    using Moq;
+
     public class JobActivatorFacts
     {
         [Fact, GlobalLock]
@@ -24,8 +26,9 @@ namespace Hangfire.Core.Tests
         public void DefaultActivator_CanCreateInstanceOfClassWithDefaultConstructor()
         {
             var activator = new JobActivator();
+            var context = new Mock<IJobActivationContext>();
 
-            var instance = activator.ActivateJob(typeof (DefaultConstructor));
+            var instance = activator.ActivateJob(typeof(DefaultConstructor), context.Object);
 
             Assert.NotNull(instance);
         }
@@ -34,9 +37,10 @@ namespace Hangfire.Core.Tests
         public void DefaultActivator_ThrowAnException_IfThereIsNoDefaultConstructor()
         {
             var activator = new JobActivator();
+            var context = new Mock<IJobActivationContext>();
 
             Assert.Throws<MissingMethodException>(
-                () => activator.ActivateJob(typeof (CustomConstructor)));
+                () => activator.ActivateJob(typeof(CustomConstructor), context.Object));
         }
 
         public class DefaultConstructor


### PR DESCRIPTION
To enable IoC containers to create per-job scopes they need to be able
to know when the job has finished so that the container can be
reclaimed.

A ``JobActivationContext`` exposes an event that can be used by a
``JobActivator`` to clean up a job-scoped container.