### PR TITLE
Include write isolation level in SqlStorageOptions

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -32,16 +32,19 @@ namespace Hangfire.SqlServer
     {
         private readonly SqlConnection _connection;
         private readonly PersistentJobQueueProviderCollection _queueProviders;
+        private readonly IsolationLevel _writeIsolationLevel;
 
         public SqlServerConnection(
             SqlConnection connection, 
-            PersistentJobQueueProviderCollection queueProviders)
+            PersistentJobQueueProviderCollection queueProviders,
+            IsolationLevel writeIsolationLevel)
         {
             if (connection == null) throw new ArgumentNullException("connection");
             if (queueProviders == null) throw new ArgumentNullException("queueProviders");
 
             _connection = connection;
             _queueProviders = queueProviders;
+            _writeIsolationLevel = writeIsolationLevel;
         }
 
         public void Dispose()
@@ -51,7 +54,7 @@ namespace Hangfire.SqlServer
 
         public IWriteOnlyTransaction CreateWriteTransaction()
         {
-            return new SqlServerWriteOnlyTransaction(_connection, _queueProviders);
+            return new SqlServerWriteOnlyTransaction(_connection, _queueProviders, _writeIsolationLevel);
         }
 
         public IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -93,7 +93,7 @@ namespace Hangfire.SqlServer
         {
             var connection = CreateAndOpenConnection();
 
-            return new SqlServerConnection(connection, QueueProviders);
+            return new SqlServerConnection(connection, QueueProviders, _options.WriteIsolationLevel);
         }
 
         public override IEnumerable<IServerComponent> GetComponents()

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -15,6 +15,7 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Transactions;
 
 namespace Hangfire.SqlServer
 {
@@ -26,7 +27,8 @@ namespace Hangfire.SqlServer
         {
             QueuePollInterval = TimeSpan.FromSeconds(15);
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
-
+            WriteIsolationLevel = IsolationLevel.Serializable;
+            
             PrepareSchemaIfNecessary = true;
         }
 
@@ -55,5 +57,7 @@ namespace Hangfire.SqlServer
         public TimeSpan InvisibilityTimeout { get; set; }
 
         public bool PrepareSchemaIfNecessary { get; set; }
+
+        public IsolationLevel WriteIsolationLevel { get; set; }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -32,16 +32,19 @@ namespace Hangfire.SqlServer
 
         private readonly SqlConnection _connection;
         private readonly PersistentJobQueueProviderCollection _queueProviders;
+        private readonly IsolationLevel _writeIsolationLevel;
 
         public SqlServerWriteOnlyTransaction( 
             SqlConnection connection,
-            PersistentJobQueueProviderCollection queueProviders)
+            PersistentJobQueueProviderCollection queueProviders,
+            IsolationLevel writeIsolationLevel)
         {
             if (connection == null) throw new ArgumentNullException("connection");
             if (queueProviders == null) throw new ArgumentNullException("queueProviders");
 
             _connection = connection;
             _queueProviders = queueProviders;
+            _writeIsolationLevel = writeIsolationLevel;
         }
 
         public void Dispose()
@@ -52,7 +55,7 @@ namespace Hangfire.SqlServer
         {
             using (var transaction = new TransactionScope(
                 TransactionScopeOption.Required,
-                new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))
+                new TransactionOptions { IsolationLevel = _writeIsolationLevel }))
             {
                 _connection.EnlistTransaction(Transaction.Current);
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -34,7 +34,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerConnection(null, _providers));
+                () => new SqlServerConnection(null, _providers, System.Transactions.IsolationLevel.Serializable));
 
             Assert.Equal("connection", exception.ParamName);
         }
@@ -43,7 +43,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenProvidersCollectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerConnection(ConnectionUtils.CreateConnection(), null));
+                () => new SqlServerConnection(ConnectionUtils.CreateConnection(), null, System.Transactions.IsolationLevel.Serializable));
 
             Assert.Equal("queueProviders", exception.ParamName);
         }
@@ -786,7 +786,7 @@ values (@key, @field, @value)";
         private void UseConnections(Action<SqlConnection, SqlServerConnection> action)
         {
             using (var sqlConnection = ConnectionUtils.CreateConnection())
-            using (var connection = new SqlServerConnection(sqlConnection, _providers))
+            using (var connection = new SqlServerConnection(sqlConnection, _providers, System.Transactions.IsolationLevel.Serializable))
             {
                 action(sqlConnection, connection);
             }
@@ -796,7 +796,8 @@ values (@key, @field, @value)";
         {
             using (var connection = new SqlServerConnection( 
                 ConnectionUtils.CreateConnection(),
-                _providers))
+                _providers,
+                System.Transactions.IsolationLevel.Serializable))
             {
                 action(connection);
             }

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -27,7 +27,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_IfConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerWriteOnlyTransaction(null, _queueProviders));
+                () => new SqlServerWriteOnlyTransaction(null, _queueProviders, System.Transactions.IsolationLevel.Serializable));
 
             Assert.Equal("connection", exception.ParamName);
         }
@@ -36,7 +36,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_IfProvidersCollectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerWriteOnlyTransaction(ConnectionUtils.CreateConnection(), null));
+                () => new SqlServerWriteOnlyTransaction(ConnectionUtils.CreateConnection(), null, System.Transactions.IsolationLevel.Serializable));
 
             Assert.Equal("queueProviders", exception.ParamName);
         }
@@ -682,7 +682,7 @@ select scope_identity() as Id";
             SqlConnection connection,
             Action<SqlServerWriteOnlyTransaction> action)
         {
-            using (var transaction = new SqlServerWriteOnlyTransaction(connection, _queueProviders))
+            using (var transaction = new SqlServerWriteOnlyTransaction(connection, _queueProviders, System.Transactions.IsolationLevel.Serializable))
             {
                 action(transaction);
                 transaction.Commit();


### PR DESCRIPTION
Hi, we had a problem with HangFire defaulting isolation level to Serialized, so I have made some changes to HangFire.SqlServer so the write job isolation level can be configured as part of SqlServerStorageOptions

original problem: http://discuss.hangfire.io/t/hangfire-sqlserver-defaults-write-isolation-level-to-serializable/224

Let me know what you think.

Thank you
