### PR TITLE
Add missing assertion in CronFacts.cs

### DIFF
--- a/tests/Hangfire.Core.Tests/CronFacts.cs
+++ b/tests/Hangfire.Core.Tests/CronFacts.cs
@@ -30,6 +30,7 @@ namespace Hangfire.Core.Tests
         {
             string expected = "5 * * * *";
             string actual = Cron.Hourly(5);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]


### PR DESCRIPTION
I just noticed that one of the new Cron tests was missing the assertion, so this is a very quick PR.
