### PR TITLE
.NET 4.0 support

### DIFF
--- a/Hangfire.Mono.net40.sln
+++ b/Hangfire.Mono.net40.sln
@@ -1,23 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core", "src\Hangfire.Core\Hangfire.Core.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis", "src\Hangfire.Redis\Hangfire.Redis.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer", "src\Hangfire.SqlServer\Hangfire.SqlServer.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
-EndProject
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.net40", "src\Hangfire.Core\Hangfire.Core.net40.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.net40", "src\Hangfire.Redis\Hangfire.Redis.net40.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.net40", "src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.net40", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net40.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.net40", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net40.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests.net40", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net40.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests.net40", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.net40.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests.net40", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net40.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,27 +43,30 @@ Global
 		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.Build.0 = Release|Any CPU
-		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E13C3543-39A3-475C-BB43-2E311E634843} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
-		{25909EE6-2A56-4EAC-9D0E-436FF2435E88} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
 		{2654D751-33D5-411D-A187-D057FED9CD25} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\Hangfire.Core\Hangfire.Core.csproj

--- a/Hangfire.Mono.net45.sln
+++ b/Hangfire.Mono.net45.sln
@@ -1,0 +1,74 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.net45", "src\Hangfire.Core\Hangfire.Core.net45.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.net45", "src\Hangfire.Redis\Hangfire.Redis.net45.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.net45", "src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.net45", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net45.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.net45", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net45.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests.net45", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net45.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests.net45", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net45.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests.net45", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.net45.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E13C3543-39A3-475C-BB43-2E311E634843} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
+		{2654D751-33D5-411D-A187-D057FED9CD25} = {9FC4F973-0AA1-4E6E-AF9A-561629BE50EC}
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = src\Hangfire.Core\Hangfire.Core.csproj
+	EndGlobalSection
+EndGlobal

--- a/Hangfire.net40.sln
+++ b/Hangfire.net40.sln
@@ -3,12 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSample", "samples\ConsoleSample\ConsoleSample.csproj", "{C02BB718-2AE4-434C-8668-C894FF663FCE}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core", "src\Hangfire.Core\Hangfire.Core.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcSample", "samples\MvcSample\MvcSample.csproj", "{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5D10161C-05D9-4976-8D45-A0379E4D07BF}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
@@ -17,10 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5D1016
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{119DA7FA-B94C-4B63-AEC9-428EF834E0D8}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis", "src\Hangfire.Redis\Hangfire.Redis.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer", "src\Hangfire.SqlServer\Hangfire.SqlServer.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{766BE831-F758-46BC-AFD3-BBEEFE0F686F}"
 EndProject
@@ -48,26 +38,30 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspecs", "nuspecs", "{5E68
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{37E2BF00-C473-48A5-B2A7-5A3DE0910FCF}"
-	ProjectSection(SolutionItems) = preProject
-		content\HangfireConfig.cs.pp = content\HangfireConfig.cs.pp
-		content\web.config.transform = content\web.config.transform
-	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.net40", "src\Hangfire.Core\Hangfire.Core.net40.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.net40", "src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Tests", "tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.csproj", "{6DFFA275-C483-4501-823A-741AC9EC0846}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.net40", "src\Hangfire.Redis\Hangfire.Redis.net40.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Sample.Highlighter", "samples\Hangfire.Sample.Highlighter\Hangfire.Sample.Highlighter.csproj", "{B5476D92-46B1-4A65-A1FD-675342B7BB64}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.net40", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net40.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.net40", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net40.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.Tests", "tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.csproj", "{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests.net40", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net40.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests.net40", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net40.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Tests.net40", "tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.net40.csproj", "{6DFFA275-C483-4501-823A-741AC9EC0846}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.Tests.net40", "tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.net40.csproj", "{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests.net40", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.net40.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSample.net40", "samples\ConsoleSample\ConsoleSample.net40.csproj", "{C02BB718-2AE4-434C-8668-C894FF663FCE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcSample.net40", "samples\MvcSample\MvcSample.net40.csproj", "{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,26 +69,26 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -107,14 +101,6 @@ Global
 		{6DFFA275-C483-4501-823A-741AC9EC0846}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6DFFA275-C483-4501-823A-741AC9EC0846}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DFFA275-C483-4501-823A-741AC9EC0846}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Release|Any CPU.Build.0 = Release|Any CPU
-		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -123,22 +109,25 @@ Global
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{C02BB718-2AE4-434C-8668-C894FF663FCE} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
-		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
 		{E13C3543-39A3-475C-BB43-2E311E634843} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
 		{25909EE6-2A56-4EAC-9D0E-436FF2435E88} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
 		{6DFFA275-C483-4501-823A-741AC9EC0846} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
-		{B5476D92-46B1-4A65-A1FD-675342B7BB64} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
 		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
 		{2654D751-33D5-411D-A187-D057FED9CD25} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+		{C02BB718-2AE4-434C-8668-C894FF663FCE} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
 	EndGlobalSection
 EndGlobal

--- a/Hangfire.net45.sln
+++ b/Hangfire.net45.sln
@@ -1,0 +1,144 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSample.net45", "samples\ConsoleSample\ConsoleSample.net45.csproj", "{C02BB718-2AE4-434C-8668-C894FF663FCE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.net45", "src\Hangfire.Core\Hangfire.Core.net45.csproj", "{C995EA9E-56EE-4951-8260-D94260A7F4C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcSample.net45", "samples\MvcSample\MvcSample.net45.csproj", "{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5D10161C-05D9-4976-8D45-A0379E4D07BF}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{119DA7FA-B94C-4B63-AEC9-428EF834E0D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.net45", "src\Hangfire.Redis\Hangfire.Redis.net45.csproj", "{8F46F57B-3247-4AA7-B330-57AC088547EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.net45", "src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj", "{A523C0E3-097D-4869-977F-15A717EA3E83}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{766BE831-F758-46BC-AFD3-BBEEFE0F686F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{15E186DF-8918-44F1-9285-9756EDAECA5D}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		build\Build.proj = build\Build.proj
+		build\Build.tasks = build\Build.tasks
+		build\Hangfire.Projects.Properties.proj = build\Hangfire.Projects.Properties.proj
+		src\Common\Hangfire.ruleset = src\Common\Hangfire.ruleset
+		src\Common\Hangfire.targets = src\Common\Hangfire.targets
+		build\Hangfire.versions.targets = build\Hangfire.versions.targets
+		build\ILMerge.CSharp.targets = build\ILMerge.CSharp.targets
+		src\Common\SharedAssemblyInfo.cs = src\Common\SharedAssemblyInfo.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspecs", "nuspecs", "{5E687025-A525-4534-8869-CB685C7B11C4}"
+	ProjectSection(SolutionItems) = preProject
+		nuspecs\Hangfire.Core.nuspec = nuspecs\Hangfire.Core.nuspec
+		nuspecs\Hangfire.nuspec = nuspecs\Hangfire.nuspec
+		nuspecs\Hangfire.Redis.nuspec = nuspecs\Hangfire.Redis.nuspec
+		nuspecs\Hangfire.SqlServer.MSMQ.nuspec = nuspecs\Hangfire.SqlServer.MSMQ.nuspec
+		nuspecs\Hangfire.SqlServer.nuspec = nuspecs\Hangfire.SqlServer.nuspec
+		nuspecs\Hangfire.SqlServer.RabbitMQ.nuspec = nuspecs\Hangfire.SqlServer.RabbitMQ.nuspec
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{37E2BF00-C473-48A5-B2A7-5A3DE0910FCF}"
+	ProjectSection(SolutionItems) = preProject
+		content\HangfireConfig.cs.pp = content\HangfireConfig.cs.pp
+		content\web.config.transform = content\web.config.transform
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Core.Tests.net45", "tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net45.csproj", "{E13C3543-39A3-475C-BB43-2E311E634843}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Redis.Tests.net45", "tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net45.csproj", "{25909EE6-2A56-4EAC-9D0E-436FF2435E88}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Tests.net45", "tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.net45.csproj", "{6DFFA275-C483-4501-823A-741AC9EC0846}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Sample.Highlighter.net45", "samples\Hangfire.Sample.Highlighter\Hangfire.Sample.Highlighter.net45.csproj", "{B5476D92-46B1-4A65-A1FD-675342B7BB64}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.net45", "src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net45.csproj", "{762BE479-0AEC-47E0-8F9C-34FA54641749}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.Msmq.Tests.net45", "tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.net45.csproj", "{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.Tests.net45", "tests\Hangfire.SqlServer.RabbitMq.Tests\Hangfire.SqlServer.RabbitMq.Tests.net45.csproj", "{2654D751-33D5-411D-A187-D057FED9CD25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.SqlServer.RabbitMq.net45", "src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net45.csproj", "{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C02BB718-2AE4-434C-8668-C894FF663FCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C995EA9E-56EE-4951-8260-D94260A7F4C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F46F57B-3247-4AA7-B330-57AC088547EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A523C0E3-097D-4869-977F-15A717EA3E83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E13C3543-39A3-475C-BB43-2E311E634843}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DFFA275-C483-4501-823A-741AC9EC0846}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DFFA275-C483-4501-823A-741AC9EC0846}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DFFA275-C483-4501-823A-741AC9EC0846}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DFFA275-C483-4501-823A-741AC9EC0846}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5476D92-46B1-4A65-A1FD-675342B7BB64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{762BE479-0AEC-47E0-8F9C-34FA54641749}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2654D751-33D5-411D-A187-D057FED9CD25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C02BB718-2AE4-434C-8668-C894FF663FCE} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
+		{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
+		{E13C3543-39A3-475C-BB43-2E311E634843} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+		{25909EE6-2A56-4EAC-9D0E-436FF2435E88} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+		{6DFFA275-C483-4501-823A-741AC9EC0846} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+		{B5476D92-46B1-4A65-A1FD-675342B7BB64} = {119DA7FA-B94C-4B63-AEC9-428EF834E0D8}
+		{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+		{2654D751-33D5-411D-A187-D057FED9CD25} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
+	EndGlobalSection
+EndGlobal

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 export EnableNuGetPackageRestore="true"
-xbuild Hangfire.Mono.sln
-mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Core.Tests/bin/Debug/Hangfire.Core.Tests.dll
-mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Redis.Tests/bin/Debug/Hangfire.Redis.Tests.dll
-mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.SqlServer.RabbitMq.Tests/bin/Debug/Hangfire.SqlServer.RabbitMq.Tests.dll
+xbuild Hangfire.Mono.net40.sln
+xbuild Hangfire.Mono.net45.sln
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Core.Tests/bin/Debug/net40/Hangfire.Core.Tests.dll
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Core.Tests/bin/Debug/net45/Hangfire.Core.Tests.dll
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Redis.Tests/bin/Debug/net40/Hangfire.Redis.Tests.dll
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.Redis.Tests/bin/Debug/net45/Hangfire.Redis.Tests.dll
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.SqlServer.RabbitMq.Tests/bin/Debug/net40/Hangfire.SqlServer.RabbitMq.Tests.dll
+mono --runtime=v4.0 tools/xunit/xunit.console.clr4.x86.exe tests/Hangfire.SqlServer.RabbitMq.Tests/bin/Debug/net45/Hangfire.SqlServer.RabbitMq.Tests.dll

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -53,11 +53,6 @@
     <!-- Add any src projects that have not been defined manually -->
     <Projects Include="$(ProjectRoot)\src\**\*.csproj" Exclude="@(Projects)" />
 
-    <Projects Include="$(ProjectRoot)\samples\Hangfire.Sample.Highlighter\Hangfire.Sample.Highlighter.csproj">
-      <BuildDeploymentPackage>false</BuildDeploymentPackage>
-      <Sample>true</Sample>
-    </Projects>
-
     <!-- Add any sample projects that have not been defined manually -->
     <Projects Include="$(ProjectRoot)\samples\**\*.csproj" Exclude="@(Projects)">
       <Sample>true</Sample>
@@ -65,13 +60,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <UnitTestProjects Include="$(ProjectRoot)\tests\Hangfire.Core.Tests\Hangfire.Core.Tests.csproj"></UnitTestProjects>
+    <UnitTestProjects Include="$(ProjectRoot)\tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net40.csproj"></UnitTestProjects>
+	<UnitTestProjects Include="$(ProjectRoot)\tests\Hangfire.Core.Tests\Hangfire.Core.Tests.net45.csproj"></UnitTestProjects>
   </ItemGroup>
   
   <ItemGroup>
-    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.csproj"></IntegrationTestProjects>
-    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.csproj"></IntegrationTestProjects>
-    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.csproj"></IntegrationTestProjects>
+    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net40.csproj"></IntegrationTestProjects>
+	<IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.Redis.Tests\Hangfire.Redis.Tests.net45.csproj"></IntegrationTestProjects>
+    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.net40.csproj"></IntegrationTestProjects>
+	<IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.net45.csproj"></IntegrationTestProjects>
+    <IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.net40.csproj"></IntegrationTestProjects>
+	<IntegrationTestProjects Include="$(ProjectRoot)\tests\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.net45.csproj"></IntegrationTestProjects>
   </ItemGroup>
 
   <ItemGroup>
@@ -143,16 +142,26 @@
   <Target Name="RunUnitTests" DependsOnTargets="BuildNetUnitTests">
     
     <!-- Core tests -->
-    
+
     <xunit Condition=" '$(BuildEnvironment)' == 'local' "
-           Assembly="$(ProjectArtifactsDir)\Hangfire.Core.Tests\Hangfire.Core.Tests.dll"
+           Assembly="$(ProjectArtifactsDir)\Hangfire.Core.Tests.net40\net40\Hangfire.Core.Tests.dll"
            Xml="$(TestResultsPath)\Hangfire.Core.Tests.XunitResults.xml"
            Verbose="true" />
   
     <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
-          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Core.Tests\Hangfire.Core.Tests.dll&quot; /appveyor"
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Core.Tests.net40\net40\Hangfire.Core.Tests.dll&quot; /appveyor"
           LogStandardErrorAsError="true">
-	  </Exec>
+	</Exec>
+	  
+	<xunit Condition=" '$(BuildEnvironment)' == 'local' "
+           Assembly="$(ProjectArtifactsDir)\Hangfire.Core.Tests.net45\net45\Hangfire.Core.Tests.dll"
+           Xml="$(TestResultsPath)\Hangfire.Core.Tests.XunitResults.xml"
+           Verbose="true" />
+  
+    <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Core.Tests.net45\net45\Hangfire.Core.Tests.dll&quot; /appveyor"
+          LogStandardErrorAsError="true">
+	</Exec>
   </Target>
   
   <Target Name="RunIntegrationTests" DependsOnTargets="DoIntegrationTests; CleanUpAfterIntegrationTests">
@@ -163,36 +172,66 @@
     <!-- Redis integration tests -->    
 
     <xunit Condition=" '$(BuildEnvironment)' == 'local' "
-           Assembly="$(ProjectArtifactsDir)\Hangfire.Redis.Tests\Hangfire.Redis.Tests.dll"
+           Assembly="$(ProjectArtifactsDir)\Hangfire.Redis.Tests.net40\net40\Hangfire.Redis.Tests.dll"
            Xml="$(TestResultsPath)\Hangfire.Redis.Tests.XunitResults.xml"
            Verbose="true" />
     
     <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
-          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Redis.Tests\Hangfire.Redis.Tests.dll&quot; /appveyor"
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Redis.Tests.net40\net40\Hangfire.Redis.Tests.dll&quot; /appveyor"
+          LogStandardErrorAsError="true">
+    </Exec>
+	
+	<xunit Condition=" '$(BuildEnvironment)' == 'local' "
+           Assembly="$(ProjectArtifactsDir)\Hangfire.Redis.Tests.net45\net45\Hangfire.Redis.Tests.dll"
+           Xml="$(TestResultsPath)\Hangfire.Redis.Tests.XunitResults.xml"
+           Verbose="true" />
+    
+    <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.Redis.Tests.net45\net45\Hangfire.Redis.Tests.dll&quot; /appveyor"
           LogStandardErrorAsError="true">
     </Exec>
     
     <!-- SQL Server integration tests -->
 
     <xunit Condition=" '$(BuildEnvironment)' == 'local' "
-           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.dll"
+           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests.net40\net40\Hangfire.SqlServer.Tests.dll"
            Xml="$(TestResultsPath)\Hangfire.SqlServer.Tests.XunitResults.xml"
            Verbose="true" />
   
     <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
-          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests\Hangfire.SqlServer.Tests.dll&quot; /appveyor"
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests.net40\net40\Hangfire.SqlServer.Tests.dll&quot; /appveyor"
+          LogStandardErrorAsError="true">
+    </Exec>
+	
+	<xunit Condition=" '$(BuildEnvironment)' == 'local' "
+           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests.net45\net45\Hangfire.SqlServer.Tests.dll"
+           Xml="$(TestResultsPath)\Hangfire.SqlServer.Tests.XunitResults.xml"
+           Verbose="true" />
+  
+    <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Tests.net45\net45\Hangfire.SqlServer.Tests.dll&quot; /appveyor"
           LogStandardErrorAsError="true">
     </Exec>
 
     <!-- MSMQ integration tests -->
 
     <xunit Condition=" '$(BuildEnvironment)' == 'local' "
-           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.dll"
+           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests.net40\net40\Hangfire.SqlServer.Msmq.Tests.dll"
            Xml="$(TestResultsPath)\Hangfire.SqlServer.Msmq.Tests.XunitResults.xml"
            Verbose="true" />
 
     <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
-          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests\Hangfire.SqlServer.Msmq.Tests.dll&quot; /appveyor"
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests.net40\net40\Hangfire.SqlServer.Msmq.Tests.dll&quot; /appveyor"
+          LogStandardErrorAsError="true">
+    </Exec>
+	
+	<xunit Condition=" '$(BuildEnvironment)' == 'local' "
+           Assembly="$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests.net45\net45\Hangfire.SqlServer.Msmq.Tests.dll"
+           Xml="$(TestResultsPath)\Hangfire.SqlServer.Msmq.Tests.XunitResults.xml"
+           Verbose="true" />
+
+    <Exec Condition=" '$(BuildEnvironment)' == 'appveyor' "
+          Command="xunit.console.clr4 &quot;$(ProjectArtifactsDir)\Hangfire.SqlServer.Msmq.Tests.net45\net45\Hangfire.SqlServer.Msmq.Tests.dll&quot; /appveyor"
           LogStandardErrorAsError="true">
     </Exec>
   </Target>
@@ -223,11 +262,17 @@
   <Target Name="CopyArtifacts" DependsOnTargets="Build">
     <ItemGroup>
       <!-- Copy remaining package artifacts to artifacts/{Configuration}/package-src/{Platform}/ -->
-      <Artifacts Include="$(ProjectArtifactsDir)\%(Projects.FileName)\Hangfire.*.dll;
-                          $(ProjectArtifactsDir)\%(Projects.FileName)\Hangfire.*.pdb;
-                          $(ProjectArtifactsDir)\%(Projects.FileName)\Hangfire.*.xml"
+      <Artifacts Include="$(ProjectArtifactsDir)\%(Projects.FileName)\net40\Hangfire.*.dll;
+                          $(ProjectArtifactsDir)\%(Projects.FileName)\net40\Hangfire.*.pdb;
+                          $(ProjectArtifactsDir)\%(Projects.FileName)\net40\Hangfire.*.xml"
                  Condition="%(Projects.CopyArtifacts) And !%(Projects.Sample)">
-        <Destination>$(PackageSrcDir)\%(Projects.Platform)</Destination>
+        <Destination>$(PackageSrcDir)\net40</Destination>
+      </Artifacts>
+	  <Artifacts Include="$(ProjectArtifactsDir)\%(Projects.FileName)\net45\Hangfire.*.dll;
+                          $(ProjectArtifactsDir)\%(Projects.FileName)\net45\Hangfire.*.pdb;
+                          $(ProjectArtifactsDir)\%(Projects.FileName)\net45\Hangfire.*.xml"
+                 Condition="%(Projects.CopyArtifacts) And !%(Projects.Sample)">
+        <Destination>$(PackageSrcDir)\net45</Destination>
       </Artifacts>
       <!-- Copy exe's to artifacts/{Configuration}/package-src/tools/ -->
       <Artifacts Include="$(ProjectArtifactsDir)\%(Projects.FileName)\*.exe"

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,13 +14,23 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
     <dependencies>
-      <dependency id="Owin" version="1.0" />
-      <dependency id="Common.Logging" version="2.2.0" />
-      <dependency id="Newtonsoft.Json" version="5.0.0" />
+      <group targetFramework="net45">
+	    <dependency id="Owin" version="1.0" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="Newtonsoft.Json" version="5.0.0" />
+	  </group>
+	  <group targetFramework="net40">
+	    <dependency id="Owin" version="1.0" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="Newtonsoft.Json" version="5.0.0" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Hangfire.Core.dll" target="lib\net45" />
-    <file src="Net45\Hangfire.Core.xml" target="lib\net45" />
+    <file src="net45\Hangfire.Core.dll" target="lib\net45" />
+    <file src="net45\Hangfire.Core.xml" target="lib\net45" />
+	<file src="net40\Hangfire.Core.dll" target="lib\net40" />
+    <file src="net40\Hangfire.Core.xml" target="lib\net40" />
   </files>
 </package>

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -23,7 +23,9 @@
 	    <dependency id="Owin" version="1.0" />
         <dependency id="Common.Logging" version="2.2.0" />
         <dependency id="Newtonsoft.Json" version="5.0.0" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuspecs/Hangfire.Redis.nuspec
+++ b/nuspecs/Hangfire.Redis.nuspec
@@ -27,7 +27,9 @@
         <dependency id="ServiceStack.Text" version="[3.9.69,4.0)" />
         <dependency id="ServiceStack.Common" version="[3.9.69,4.0)" />
         <dependency id="ServiceStack.Redis" version="[3.9.69,4.0)" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuspecs/Hangfire.Redis.nuspec
+++ b/nuspecs/Hangfire.Redis.nuspec
@@ -14,15 +14,27 @@
     <tags>Hangfire Redis</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
     <dependencies>
-      <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Common.Logging" version="2.2.0" />
-      <dependency id="ServiceStack.Text" version="[3.9.69,4.0)" />
-      <dependency id="ServiceStack.Common" version="[3.9.69,4.0)" />
-      <dependency id="ServiceStack.Redis" version="[3.9.69,4.0)" />
+	  <group targetFramework="net45">
+        <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="ServiceStack.Text" version="[3.9.69,4.0)" />
+        <dependency id="ServiceStack.Common" version="[3.9.69,4.0)" />
+        <dependency id="ServiceStack.Redis" version="[3.9.69,4.0)" />
+	  </group>
+	  <group targetFramework="net40">
+	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="ServiceStack.Text" version="[3.9.69,4.0)" />
+        <dependency id="ServiceStack.Common" version="[3.9.69,4.0)" />
+        <dependency id="ServiceStack.Redis" version="[3.9.69,4.0)" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Hangfire.Redis.dll" target="lib\net45" />
-    <file src="Net45\Hangfire.Redis.xml" target="lib\net45" />
+    <file src="net45\Hangfire.Redis.dll" target="lib\net45" />
+    <file src="net45\Hangfire.Redis.xml" target="lib\net45" />
+	<file src="net40\Hangfire.Redis.dll" target="lib\net40" />
+    <file src="net40\Hangfire.Redis.xml" target="lib\net40" />
   </files>
 </package>

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -14,12 +14,21 @@
     <tags>Hangfire SqlServer MSMQ</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
     <dependencies>
-      <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+	  <group targetFramework="net45">
+       <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+       <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+	  </group>
+	  <group targetFramework="net40">
+	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Hangfire.SqlServer.Msmq.dll" target="lib\net45" />
-    <file src="Net45\Hangfire.SqlServer.Msmq.xml" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.Msmq.dll" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.Msmq.xml" target="lib\net45" />
+	<file src="net40\Hangfire.SqlServer.Msmq.dll" target="lib\net40" />
+    <file src="net40\Hangfire.SqlServer.Msmq.xml" target="lib\net40" />
   </files>
 </package>

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -21,7 +21,9 @@
 	  <group targetFramework="net40">
 	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
@@ -14,13 +14,23 @@
     <tags>Hangfire SqlServer RabbitMQ</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
     <dependencies>
-      <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="RabbitMQ.Client" version="3.3.0" />
+	  <group targetFramework="net45">
+        <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="RabbitMQ.Client" version="3.3.0" />
+	  </group>
+	  <group targetFramework="net40">
+	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="RabbitMQ.Client" version="3.3.0" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Hangfire.SqlServer.RabbitMQ.dll" target="lib\net45" />
-    <file src="Net45\Hangfire.SqlServer.RabbitMQ.xml" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.RabbitMQ.dll" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.RabbitMQ.xml" target="lib\net45" />
+	<file src="net40\Hangfire.SqlServer.RabbitMQ.dll" target="lib\net40" />
+    <file src="net40\Hangfire.SqlServer.RabbitMQ.xml" target="lib\net40" />
   </files>
 </package>

--- a/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
@@ -23,7 +23,9 @@
 	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="RabbitMQ.Client" version="3.3.0" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -14,14 +14,24 @@
     <tags>Hangfire SqlServer SqlAzure</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
     <dependencies>
-      <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Common.Logging" version="2.2.0" />
-      <dependency id="Dapper" version="1.13" />
+	  <group targetFramework="net45">
+        <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="Dapper" version="1.13" />
+	  </group>
+	  <group targetFramework="net40">
+	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Common.Logging" version="2.2.0" />
+        <dependency id="Dapper" version="1.13" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Hangfire.SqlServer.dll" target="lib\net45" />
-    <file src="Net45\Hangfire.SqlServer.xml" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.dll" target="lib\net45" />
+    <file src="net45\Hangfire.SqlServer.xml" target="lib\net45" />
+	<file src="net40\Hangfire.SqlServer.dll" target="lib\net40" />
+    <file src="net40\Hangfire.SqlServer.xml" target="lib\net40" />
     <file src="Tools\Install.sql" target="tools\install.sql" />
   </files>
 </package>

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -23,7 +23,9 @@
 	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="Common.Logging" version="2.2.0" />
         <dependency id="Dapper" version="1.13" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -36,9 +36,17 @@
 * Fixed – Redis.FetchedJobsWatcher prohibits jobs from running longer than 15 minutes.
     </releaseNotes>
     <dependencies>
-      <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
-      <dependency id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" />
+	  <group targetFramework="net45">
+        <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" />
+      </group>
+	  <group targetFramework="net40">
+	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
+        <dependency id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" />
+        <dependency id="Microsoft.Bcl.Async" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -45,7 +45,9 @@
 	    <dependency id="Hangfire.Core" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="Hangfire.SqlServer" version="__HANGFIRE_PACKAGE_VERSION__" />
         <dependency id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" />
-        <dependency id="Microsoft.Bcl.Async" />
+        <dependency id="Microsoft.Bcl" version="1.1.9"/>
+		<dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+		<dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
       </group>
     </dependencies>
   </metadata>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -6,6 +6,7 @@
   <repository path="..\samples\MvcSample\packages.config" />
   <repository path="..\src\Hangfire.Core\packages.config" />
   <repository path="..\src\Hangfire.Redis\packages.config" />
+  <repository path="..\src\Hangfire.SqlServer.Msmq\packages.config" />
   <repository path="..\src\Hangfire.SqlServer.RabbitMq\packages.config" />
   <repository path="..\src\Hangfire.SqlServer\packages.config" />
   <repository path="..\tests\Hangfire.Core.Tests\packages.config" />

--- a/samples/ConsoleSample/ConsoleSample.net40.csproj
+++ b/samples/ConsoleSample/ConsoleSample.net40.csproj
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C02BB718-2AE4-434C-8668-C894FF663FCE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleSample</RootNamespace>
+    <AssemblyName>ConsoleSample</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>2cd8e398</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net40.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net40.csproj">
+      <Project>{4cc51f69-0311-4485-b7de-9ecab3a1b5e5}</Project>
+      <Name>Hangfire.SqlServer.RabbitMq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\HangFire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/ConsoleSample/ConsoleSample.net45.csproj
+++ b/samples/ConsoleSample/ConsoleSample.net45.csproj
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C02BB718-2AE4-434C-8668-C894FF663FCE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ConsoleSample</RootNamespace>
+    <AssemblyName>ConsoleSample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net45.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.net45.csproj">
+      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
+      <Name>Hangfire.Redis.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\HangFire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/samples/ConsoleSample/app.config
+++ b/samples/ConsoleSample/app.config
@@ -1,13 +1,21 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/ConsoleSample/packages.config
+++ b/samples/ConsoleSample/packages.config
@@ -2,4 +2,7 @@
 <packages>
   <package id="Common.Logging" version="2.2.0" targetFramework="net40" />
   <package id="Common.Logging.Core" version="2.2.0" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
 </packages>

--- a/samples/Hangfire.Sample.Highlighter/Hangfire.Sample.Highlighter.net45.csproj
+++ b/samples/Hangfire.Sample.Highlighter/Hangfire.Sample.Highlighter.net45.csproj
@@ -203,13 +203,13 @@
     <Folder Include="App_Data\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
       <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
       <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
+      <Name>Hangfire.SqlServer.net45</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/MvcSample/MvcSample.net40.csproj
+++ b/samples/MvcSample/MvcSample.net40.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MvcSample</RootNamespace>
     <AssemblyName>MvcSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -22,6 +22,8 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>d965ffbc</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,12 +55,24 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net40\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.2.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.2.1.0\lib\net40\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -69,20 +83,24 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.13\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.13\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
@@ -107,9 +125,7 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
@@ -124,6 +140,7 @@
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\FilterConfig.cs" />
@@ -159,25 +176,29 @@
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.csproj">
-      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
-      <Name>Hangfire.SqlServer.Msmq</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.csproj">
-      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
-      <Name>Hangfire.Redis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
-      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
       <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net40</Name>
     </ProjectReference>
-    <ProjectReference Include="..\ConsoleSample\ConsoleSample.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.net40.csproj">
+      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
+      <Name>Hangfire.Redis.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net40.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net40.csproj">
+      <Project>{4cc51f69-0311-4485-b7de-9ecab3a1b5e5}</Project>
+      <Name>Hangfire.SqlServer.RabbitMq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConsoleSample\ConsoleSample.net40.csproj">
       <Project>{c02bb718-2ae4-434c-8668-c894ff663fce}</Project>
-      <Name>ConsoleSample</Name>
+      <Name>ConsoleSample.net40</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
@@ -208,12 +229,14 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="..\..\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\build\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\build\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/samples/MvcSample/MvcSample.net45.csproj
+++ b/samples/MvcSample/MvcSample.net45.csproj
@@ -1,0 +1,223 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{FE5EAE49-2627-42B6-8C2B-EBE4D45B4D97}</ProjectGuid>
+    <ProjectTypeGuids>{E3E379DF-F4C6-4180-9B81-6769533ABE47};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MvcSample</RootNamespace>
+    <AssemblyName>MvcSample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MvcBuildViews>false</MvcBuildViews>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.2.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.1\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.13\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.13\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.2.0.30506.0\lib\net40\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest">
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\FilterConfig.cs" />
+    <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Content\Site.css" />
+    <Content Include="Web.config" />
+    <Content Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Views\Web.config" />
+    <Content Include="Views\_ViewStart.cshtml" />
+    <Content Include="Views\Shared\Error.cshtml" />
+    <Content Include="Views\Shared\_Layout.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+    <Folder Include="Controllers\" />
+    <Folder Include="Models\" />
+    <Folder Include="Scripts\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net45.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.net45.csproj">
+      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
+      <Name>Hangfire.Redis.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ConsoleSample\ConsoleSample.net45.csproj">
+      <Project>{c02bb718-2ae4-434c-8668-c894ff663fce}</Project>
+      <Name>ConsoleSample.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>0</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:56909/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Import Project="..\..\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\build\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\build\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target> -->
+</Project>

--- a/samples/MvcSample/Web.config
+++ b/samples/MvcSample/Web.config
@@ -58,6 +58,18 @@
         <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/samples/MvcSample/packages.config
+++ b/samples/MvcSample/packages.config
@@ -6,9 +6,9 @@
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.3" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.10" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.13" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />

--- a/src/Common/Hangfire.targets
+++ b/src/Common/Hangfire.targets
@@ -4,6 +4,18 @@
     <OutputPath Condition="$(UseBinPath) == ''">$(ArtifactsDir)\$(MSBuildProjectName)</OutputPath>
     <OutputPath Condition="$(UseBinPath) == 'true'">$(ArtifactsDir)\$(MSBuildProjectName)\bin</OutputPath>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(ArtifactsDir)' == ''">
+    <OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">bin\$(Configuration)\net40\</OutputPath>
+	<OutputPath Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">bin\$(Configuration)\net45\</OutputPath>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+	<DocumentationFile Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">bin\$(Configuration)\net40\$(AssemblyName).xml</DocumentationFile>
+	<DocumentationFile Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">bin\$(Configuration)\net45\$(AssemblyName).xml</DocumentationFile>
+	<IntermediateOutputPath Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">obj\$(Configuration)\net40\</IntermediateOutputPath>
+	<IntermediateOutputPath Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">obj\$(Configuration)\net45\</IntermediateOutputPath>
+  </PropertyGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Hangfire.ruleset</CodeAnalysisRuleSet>
@@ -27,6 +39,11 @@
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(KeyFile)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">NET40</DefineConstants>
+	<DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">NET45</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)GlobalSuppressions.cs')">
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs">
@@ -35,6 +52,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <CodeAnalysisDictionary Include="$(MSBuildThisFileDirectory)CodeAnalysisDictionary.xml" />
+	<CodeAnalysisDictionary Include="$(MSBuildThisFileDirectory)CodeAnalysisDictionary.xml" />
   </ItemGroup>
 </Project>

--- a/src/Common/Hangfire.targets
+++ b/src/Common/Hangfire.targets
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(ArtifactsDir)' != ''">
-    <OutputPath Condition="$(UseBinPath) == ''">$(ArtifactsDir)\$(MSBuildProjectName)</OutputPath>
-    <OutputPath Condition="$(UseBinPath) == 'true'">$(ArtifactsDir)\$(MSBuildProjectName)\bin</OutputPath>
+  <PropertyGroup Condition="'$(ArtifactsDir)' != '' AND '$(TargetFrameworkVersion)' == 'v4.0' ">
+    <OutputPath Condition="$(UseBinPath) == ''">$(ArtifactsDir)\$(MSBuildProjectName)\net40</OutputPath>
+    <OutputPath Condition="$(UseBinPath) == 'true'">$(ArtifactsDir)\$(MSBuildProjectName)\bin\net40</OutputPath>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(ArtifactsDir)' != '' AND '$(TargetFrameworkVersion)' == 'v4.5' ">
+    <OutputPath Condition="$(UseBinPath) == ''">$(ArtifactsDir)\$(MSBuildProjectName)\net45</OutputPath>
+    <OutputPath Condition="$(UseBinPath) == 'true'">$(ArtifactsDir)\$(MSBuildProjectName)\bin\net45</OutputPath>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(ArtifactsDir)' == ''">

--- a/src/Hangfire.Core/Dashboard/CommandDispatcher.cs
+++ b/src/Hangfire.Core/Dashboard/CommandDispatcher.cs
@@ -37,7 +37,7 @@ namespace Hangfire.Dashboard
             if (owinContext.Request.Method != WebRequestMethods.Http.Post)
             {
                 owinContext.Response.StatusCode = (int)HttpStatusCode.MethodNotAllowed;
-                return Task.FromResult(false);
+                return Net40CompatibilityHelper.Task.FromResult(false);
             }
 
             if (_command(context))
@@ -49,7 +49,7 @@ namespace Hangfire.Dashboard
                 owinContext.Response.StatusCode = 422;
             }
 
-            return Task.FromResult(true);
+            return Net40CompatibilityHelper.Task.FromResult(true);
         }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardMiddleware.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardMiddleware.cs
@@ -59,7 +59,7 @@ namespace Hangfire.Dashboard
                 if (!filter.Authorize(context.Environment))
                 {
                     context.Response.StatusCode = (int) HttpStatusCode.Unauthorized;
-                    return Task.FromResult(false);
+                    return Net40CompatibilityHelper.Task.FromResult(false);
                 }
             }
 

--- a/src/Hangfire.Core/Dashboard/EmbeddedResourceDispatcher.cs
+++ b/src/Hangfire.Core/Dashboard/EmbeddedResourceDispatcher.cs
@@ -50,7 +50,7 @@ namespace Hangfire.Dashboard
 
             WriteResponse(owinContext.Response);
 
-            return Task.FromResult(true);
+            return Net40CompatibilityHelper.Task.FromResult(true);
         }
 
         protected virtual void WriteResponse(IOwinResponse response)

--- a/src/Hangfire.Core/Hangfire.Core.net40.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.net40.csproj
@@ -9,33 +9,30 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire</RootNamespace>
     <AssemblyName>Hangfire.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
     <ILMerge>True</ILMerge>
+    <NuGetPackageImportStamp>b0405ca4</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\Hangfire.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\Debug\Hangfire.Core.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Hangfire.Core.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
@@ -50,24 +47,43 @@
       <HintPath>..\..\packages\CronExpressionDescriptor.1.10.1\lib\net35\CronExpressionDescriptor.dll</HintPath>
       <ILMerge>True</ILMerge>
     </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="NCrontab">
       <HintPath>..\..\packages\ncrontab.1.0.0\lib\NCrontab.dll</HintPath>
       <ILMerge>True</ILMerge>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.Owin">
-      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net40\Microsoft.Owin.dll</HintPath>
       <ILMerge>True</ILMerge>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5">
@@ -198,6 +214,7 @@
     <Compile Include="Dashboard\RazorPageDispatcher.cs" />
     <Compile Include="Dashboard\RequestExtensions.cs" />
     <Compile Include="IBootstrapperConfiguration.cs" />
+    <Compile Include="Net40CompatibilityHelper.cs" />
     <Compile Include="OwinBootstrapper.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="RecurringJob.cs" />
@@ -444,6 +461,13 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\build\ILMerge.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Hangfire.Core/Hangfire.Core.net45.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.net45.csproj
@@ -1,0 +1,451 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire</RootNamespace>
+    <AssemblyName>Hangfire.Core</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <ILMerge>True</ILMerge>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\Hangfire.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="CronExpressionDescriptor">
+      <HintPath>..\..\packages\CronExpressionDescriptor.1.10.1\lib\net35\CronExpressionDescriptor.dll</HintPath>
+      <ILMerge>True</ILMerge>
+    </Reference>
+    <Reference Include="NCrontab">
+      <HintPath>..\..\packages\ncrontab.1.0.0\lib\NCrontab.dll</HintPath>
+      <ILMerge>True</ILMerge>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <ILMerge>True</ILMerge>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="AutomaticRetryAttribute.cs" />
+    <Compile Include="BackgroundJobServer.cs" />
+    <Compile Include="BackgroundJobServerOptions.cs" />
+    <Compile Include="Cron.cs" />
+    <Compile Include="Dashboard\BatchCommandDispatcher.cs" />
+    <Compile Include="Dashboard\CombinedResourceDispatcher.cs" />
+    <Compile Include="Dashboard\CommandDispatcher.cs" />
+    <Compile Include="Dashboard\DashboardMiddleware.cs" />
+    <Compile Include="Dashboard\RequestDispatcherContext.cs" />
+    <Compile Include="Dashboard\IAuthorizationFilter.cs" />
+    <Compile Include="Dashboard\LocalRequestsOnlyAuthorizationFilter.cs" />
+    <Compile Include="Dashboard\DashboardOwinExtensions.cs" />
+    <Compile Include="Dashboard\RouteCollection.cs" />
+    <Compile Include="Dashboard\RouteCollectionExtensions.cs" />
+    <Compile Include="Dashboard\EmbeddedResourceDispatcher.cs" />
+    <Compile Include="Dashboard\DashboardRoutes.cs" />
+    <Compile Include="Dashboard\HtmlHelper.cs" />
+    <Compile Include="Dashboard\JobHistoryRenderer.cs" />
+    <Compile Include="Dashboard\JobMethodCallRenderer.cs" />
+    <Compile Include="Dashboard\JsonStats.cs" />
+    <Compile Include="Dashboard\NonEscapedString.cs" />
+    <Compile Include="Dashboard\IRequestDispatcher.cs" />
+    <Compile Include="Dashboard\Pager.cs" />
+    <Compile Include="Dashboard\Pages\DashboardPage.generated.cs">
+      <DependentUpon>DashboardPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\DeletedJobsPage.generated.cs">
+      <DependentUpon>DeletedJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\EnqueuedJobsPage.cs">
+      <DependentUpon>EnqueuedJobsPage.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\EnqueuedJobsPage.generated.cs">
+      <DependentUpon>EnqueuedJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\FailedJobsPage.generated.cs">
+      <DependentUpon>FailedJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\FetchedJobsPage.cs">
+      <DependentUpon>FetchedJobsPage.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\FetchedJobsPage.generated.cs">
+      <DependentUpon>FetchedJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\JobDetailsPage.cs">
+      <DependentUpon>JobDetailsPage.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\JobDetailsPage1.generated.cs">
+      <DependentUpon>JobDetailsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\LayoutPage.cs">
+      <DependentUpon>LayoutPage.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\LayoutPage.generated.cs">
+      <DependentUpon>LayoutPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\ProcessingJobsPage.generated.cs">
+      <DependentUpon>ProcessingJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\QueuesPage.generated.cs">
+      <DependentUpon>QueuesPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\RazorPage.cs" />
+    <Compile Include="Dashboard\Pages\RecurringJobsPage.generated.cs">
+      <DependentUpon>RecurringJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\ScheduledJobsPage.generated.cs">
+      <DependentUpon>ScheduledJobsPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\ServersPage.generated.cs">
+      <DependentUpon>ServersPage.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\SucceededJobs1.generated.cs">
+      <DependentUpon>SucceededJobs.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\_Paginator.cs">
+      <DependentUpon>_Paginator.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\_Paginator.generated.cs">
+      <DependentUpon>_Paginator.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\Pages\_PerPageSelector.cs">
+      <DependentUpon>_PerPageSelector.cshtml</DependentUpon>
+    </Compile>
+    <Compile Include="Dashboard\Pages\_PerPageSelector.generated.cs">
+      <DependentUpon>_PerPageSelector.cshtml</DependentUpon>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <Compile Include="Dashboard\RazorPageDispatcher.cs" />
+    <Compile Include="Dashboard\RequestExtensions.cs" />
+    <Compile Include="IBootstrapperConfiguration.cs" />
+    <Compile Include="Net40CompatibilityHelper.cs" />
+    <Compile Include="OwinBootstrapper.cs" />
+    <Compile Include="Properties\Annotations.cs" />
+    <Compile Include="RecurringJob.cs" />
+    <Compile Include="RecurringJobManager.cs" />
+    <Compile Include="Server\AutomaticRetryServerComponentWrapper.cs" />
+    <Compile Include="Server\EveryMinuteThrottler.cs" />
+    <Compile Include="Server\IScheduleInstant.cs" />
+    <Compile Include="Server\IScheduleInstantFactory.cs" />
+    <Compile Include="Server\IThrottler.cs" />
+    <Compile Include="Server\JobAbortedException.cs" />
+    <Compile Include="JobCancellationToken.cs" />
+    <Compile Include="Client\IJobCreationProcess.cs" />
+    <Compile Include="BackgroundJobClientExtensions.cs" />
+    <Compile Include="Common\CachedExpressionCompiler.cs" />
+    <Compile Include="Client\CreateJobFailedException.cs" />
+    <Compile Include="IJobCancellationToken.cs" />
+    <Compile Include="DisableConcurrentExecutionAttribute.cs" />
+    <Compile Include="IBackgroundJobClient.cs" />
+    <Compile Include="Client\JobCreationProcess.cs" />
+    <Compile Include="Client\CreateContext.cs" />
+    <Compile Include="Common\Job.cs" />
+    <Compile Include="Common\JobLoadException.cs" />
+    <Compile Include="Common\ExpressionUtil\BinaryExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\CachedExpressionCompiler.cs" />
+    <Compile Include="Common\ExpressionUtil\ConditionalExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\ConstantExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\DefaultExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\ExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\ExpressionFingerprintChain.cs" />
+    <Compile Include="Common\ExpressionUtil\FingerprintingExpressionVisitor.cs" />
+    <Compile Include="Common\ExpressionUtil\HashCodeCombiner.cs" />
+    <Compile Include="Common\ExpressionUtil\Hoisted.cs" />
+    <Compile Include="Common\ExpressionUtil\HoistingExpressionVisitor.cs" />
+    <Compile Include="Common\ExpressionUtil\IndexExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\LambdaExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\MemberExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\MethodCallExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\ParameterExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\TypeBinaryExpressionFingerprint.cs" />
+    <Compile Include="Common\ExpressionUtil\UnaryExpressionFingerprint.cs" />
+    <Compile Include="Common\JobFilter.cs" />
+    <Compile Include="Common\JobFilterProviderCollection.cs" />
+    <Compile Include="Common\JobFilterProviders.cs" />
+    <Compile Include="Common\JobFilterScope.cs" />
+    <Compile Include="Common\ReflectedAttributeCache.cs" />
+    <Compile Include="Client\ClientExceptionContext.cs" />
+    <Compile Include="Common\GlobalJobFilterCollection.cs" />
+    <Compile Include="Client\IClientExceptionFilter.cs" />
+    <Compile Include="Common\IJobFilterProvider.cs" />
+    <Compile Include="Server\RecurringJobScheduler.cs" />
+    <Compile Include="Server\ScheduleInstant.cs" />
+    <Compile Include="Server\ScheduleInstantFactory.cs" />
+    <Compile Include="Server\ServerJobCancellationToken.cs" />
+    <Compile Include="Server\ServerOwinExtensions.cs" />
+    <Compile Include="Server\SharedWorkerContext.cs" />
+    <Compile Include="StartupConfiguration.cs" />
+    <Compile Include="BootstrapperConfigurationExtensions.cs" />
+    <Compile Include="States\DeletedState.cs" />
+    <Compile Include="States\IElectStateFilter.cs" />
+    <Compile Include="Common\JobFilterAttribute.cs" />
+    <Compile Include="Common\JobFilterAttributeFilterProvider.cs" />
+    <Compile Include="Common\JobFilterInfo.cs" />
+    <Compile Include="States\IStateChangeProcess.cs" />
+    <Compile Include="States\IStateMachineFactory.cs" />
+    <Compile Include="States\StateChangeProcess.cs" />
+    <Compile Include="States\StateHandlerCollection.cs" />
+    <Compile Include="Server\SchedulePoller.cs" />
+    <Compile Include="Server\ServerWatchdog.cs" />
+    <Compile Include="Server\ServerWatchdogOptions.cs" />
+    <Compile Include="Server\IServerExceptionFilter.cs" />
+    <Compile Include="Client\CreatedContext.cs" />
+    <Compile Include="Client\CreatingContext.cs" />
+    <Compile Include="Server\IServerComponent.cs" />
+    <Compile Include="Server\IServerSupervisor.cs" />
+    <Compile Include="Server\JobPerformanceException.cs" />
+    <Compile Include="Server\ServerBootstrapper.cs" />
+    <Compile Include="Server\IJobPerformanceProcess.cs" />
+    <Compile Include="Server\PerformContext.cs" />
+    <Compile Include="Server\ServerExceptionContext.cs" />
+    <Compile Include="Server\PerformedContext.cs" />
+    <Compile Include="Server\PerformingContext.cs" />
+    <Compile Include="GlobalJobFilters.cs" />
+    <Compile Include="States\IApplyStateFilter.cs" />
+    <Compile Include="GlobalStateHandlers.cs" />
+    <Compile Include="Server\ServerSupervisor.cs" />
+    <Compile Include="Server\ServerSupervisorCollection.cs" />
+    <Compile Include="Server\ServerSupervisorOptions.cs" />
+    <Compile Include="Server\ServerContext.cs" />
+    <Compile Include="Server\ServerHeartbeat.cs" />
+    <Compile Include="Server\Worker.cs" />
+    <Compile Include="Server\WorkerManager.cs" />
+    <Compile Include="States\IStateMachine.cs" />
+    <Compile Include="States\StateMachineFactory.cs" />
+    <Compile Include="Storage\InvocationData.cs" />
+    <Compile Include="Storage\IMonitoringApi.cs" />
+    <Compile Include="Storage\IFetchedJob.cs" />
+    <Compile Include="Storage\Monitoring\DeletedJobDto.cs" />
+    <Compile Include="Storage\Monitoring\FetchedJobDto.cs" />
+    <Compile Include="Storage\Monitoring\EnqueuedJobDto.cs" />
+    <Compile Include="Storage\Monitoring\FailedJobDto.cs" />
+    <Compile Include="Storage\Monitoring\JobDetailsDto.cs" />
+    <Compile Include="Storage\Monitoring\JobList.cs" />
+    <Compile Include="Storage\Monitoring\ProcessingJobDto.cs" />
+    <Compile Include="Storage\Monitoring\QueueWithTopEnqueuedJobsDto.cs" />
+    <Compile Include="Storage\Monitoring\ScheduledJobDto.cs" />
+    <Compile Include="Storage\Monitoring\ServerDto.cs" />
+    <Compile Include="Storage\Monitoring\StateHistoryDto.cs" />
+    <Compile Include="Storage\Monitoring\StatisticsDto.cs" />
+    <Compile Include="Storage\Monitoring\SucceededJobDto.cs" />
+    <Compile Include="Server\IJobPerformer.cs" />
+    <Compile Include="JobStorage.cs" />
+    <Compile Include="States\EnqueuedState.cs" />
+    <Compile Include="States\FailedState.cs" />
+    <Compile Include="States\IState.cs" />
+    <Compile Include="Client\IClientFilter.cs" />
+    <Compile Include="Common\IJobFilter.cs" />
+    <Compile Include="Server\IServerFilter.cs" />
+    <Compile Include="CaptureCultureAttribute.cs" />
+    <Compile Include="BackgroundJob.cs" />
+    <Compile Include="QueueAttribute.cs" />
+    <Compile Include="JobActivator.cs" />
+    <Compile Include="Server\JobPerformanceProcess.cs" />
+    <Compile Include="BackgroundJobClient.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Common\JobHelper.cs" />
+    <Compile Include="Server\WorkerContext.cs" />
+    <Compile Include="States\IStateHandler.cs" />
+    <Compile Include="States\ProcessingState.cs" />
+    <Compile Include="States\ScheduledState.cs" />
+    <Compile Include="States\ApplyStateContext.cs" />
+    <Compile Include="States\ElectStateContext.cs" />
+    <Compile Include="States\StateContext.cs" />
+    <Compile Include="States\StateMachine.cs" />
+    <Compile Include="States\SucceededState.cs" />
+    <Compile Include="StatisticsHistoryAttribute.cs" />
+    <Compile Include="Storage\IWriteOnlyTransaction.cs" />
+    <Compile Include="Storage\IStorageConnection.cs" />
+    <Compile Include="Storage\JobData.cs" />
+    <Compile Include="Storage\RecurringJobDto.cs" />
+    <Compile Include="Storage\StateData.cs" />
+    <Compile Include="Storage\StorageConnectionExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.eot" />
+    <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.ttf" />
+    <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.woff" />
+    <None Include="Dashboard\Pages\DashboardPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>DashboardPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\DeletedJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>DeletedJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\EnqueuedJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>EnqueuedJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\FailedJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>FailedJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\FetchedJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>FetchedJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\JobDetailsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>JobDetailsPage1.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\LayoutPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>LayoutPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\ProcessingJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>ProcessingJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\QueuesPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>QueuesPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\RecurringJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>RecurringJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\ScheduledJobsPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>ScheduledJobsPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\ServersPage.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>ServersPage.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\SucceededJobs.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>SucceededJobs1.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\_Paginator.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>_Paginator.generated.cs</LastGenOutput>
+    </None>
+    <None Include="Dashboard\Pages\_PerPageSelector.cshtml">
+      <Generator>RazorGenerator</Generator>
+      <LastGenOutput>_PerPageSelector.generated.cs</LastGenOutput>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\css\bootstrap.min.css" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\css\hangfire.css" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\css\rickshaw.min.css" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.svg" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\bootstrap.min.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\d3.layout.min.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\d3.min.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\hangfire.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\jquery-1.10.2.min.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\moment.min.js" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Dashboard\Content\js\rickshaw.min.js" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="..\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\build\ILMerge.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Hangfire.Core/Net40CompatibilityHelper.cs
+++ b/src/Hangfire.Core/Net40CompatibilityHelper.cs
@@ -1,0 +1,123 @@
+﻿using Microsoft.Owin;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire
+{
+    public static class Net40CompatibilityHelper
+    {
+        /// <summary>
+        /// Adds Timeout.InfiniteTimeSpan which is not available in .NET 4.0 
+        /// </summary>
+        public static class Timeout
+        {
+            public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, -1);
+        }
+        /// <summary>
+        /// Calls Task.FromResult in .NET 4.5 or replicates this method in .NET 4.0
+        /// </summary>
+        public static class Task
+        {
+            public static Task<T> FromResult<T>(T value)
+            {
+#if NET45
+                return System.Threading.Tasks.Task.FromResult(value);
+#else
+                var tcs = new TaskCompletionSource<T>();
+                tcs.SetResult(value);
+                return tcs.Task;
+#endif
+            }
+        }
+#if NET40
+        /// <summary>
+        /// Extension method to add OwinRequest.ReadFormAsync which is not available in .NET 4.0
+        /// </summary>
+        public static async Task<IFormCollection> ReadFormAsync(this IOwinRequest owinRequest)
+        {
+            var form = owinRequest.Get<IFormCollection>("Microsoft.Owin.Form#collection");
+            if (form == null)
+            {
+                string text;
+                using (var reader = new StreamReader(owinRequest.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4 * 1024))
+                {
+                    text = await reader.ReadToEndAsync();
+                }
+                form = OwinHelpers.GetForm(text);
+                owinRequest.Set("Microsoft.Owin.Form#collection", form);
+            }
+
+            return form;
+        }
+        private class OwinHelpers
+        {
+            internal static IFormCollection GetForm(string text)
+            {
+                IDictionary<string, string[]> form = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+                var accumulator = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+                ParseDelimited(text, new[] { '&' }, AppendItemCallback, accumulator);
+                foreach (var kv in accumulator)
+                {
+                    form.Add(kv.Key, kv.Value.ToArray());
+                }
+                return new FormCollection(form);
+            }
+
+            private static readonly Action<string, string, object> AppendItemCallback = (name, value, state) =>
+            {
+                var dictionary = (IDictionary<string, List<String>>)state;
+
+                List<string> existing;
+                if (!dictionary.TryGetValue(name, out existing))
+                {
+                    dictionary.Add(name, new List<string>(1) { value });
+                }
+                else
+                {
+                    existing.Add(value);
+                }
+            };
+            internal static void ParseDelimited(string text, char[] delimiters, Action<string, string, object> callback, object state)
+            {
+                int textLength = text.Length;
+                int equalIndex = text.IndexOf('=');
+                if (equalIndex == -1)
+                {
+                    equalIndex = textLength;
+                }
+                int scanIndex = 0;
+                while (scanIndex < textLength)
+                {
+                    int delimiterIndex = text.IndexOfAny(delimiters, scanIndex);
+                    if (delimiterIndex == -1)
+                    {
+                        delimiterIndex = textLength;
+                    }
+                    if (equalIndex < delimiterIndex)
+                    {
+                        while (scanIndex != equalIndex && char.IsWhiteSpace(text[scanIndex]))
+                        {
+                            ++scanIndex;
+                        }
+                        string name = text.Substring(scanIndex, equalIndex - scanIndex);
+                        string value = text.Substring(equalIndex + 1, delimiterIndex - equalIndex - 1);
+                        callback(
+                            Uri.UnescapeDataString(name.Replace('+', ' ')),
+                            Uri.UnescapeDataString(value.Replace('+', ' ')),
+                            state);
+                        equalIndex = text.IndexOf('=', delimiterIndex);
+                        if (equalIndex == -1)
+                        {
+                            equalIndex = textLength;
+                        }
+                    }
+                    scanIndex = delimiterIndex + 1;
+                }
+            }
+        }
+#endif
+    }
+}

--- a/src/Hangfire.Core/packages.config
+++ b/src/Hangfire.Core/packages.config
@@ -3,6 +3,9 @@
   <package id="Common.Logging" version="2.2.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
   <package id="CronExpressionDescriptor" version="1.10.1" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
   <package id="ncrontab" version="1.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />

--- a/src/Hangfire.Redis/Hangfire.Redis.net40.csproj
+++ b/src/Hangfire.Redis/Hangfire.Redis.net40.csproj
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8F46F57B-3247-4AA7-B330-57AC088547EB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.Redis</RootNamespace>
+    <AssemblyName>Hangfire.Redis</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>694a14d9</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging">
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Redis">
+      <HintPath>..\..\packages\ServiceStack.Redis.3.9.69\lib\net35\ServiceStack.Redis.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="DeletedStateHandler.cs" />
+    <Compile Include="FetchedJobsWatcherOptions.cs" />
+    <Compile Include="FetchedJobsWatcher.cs" />
+    <Compile Include="Properties\Annotations.cs" />
+    <Compile Include="RedisFetchedJob.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RedisWriteOnlyTransaction.cs" />
+    <Compile Include="RedisStorage.cs" />
+    <Compile Include="RedisMonitoringApi.cs" />
+    <Compile Include="RedisConnection.cs" />
+    <Compile Include="RedisStorageOptions.cs" />
+    <Compile Include="FailedStateHandler.cs" />
+    <Compile Include="ProcessingStateHandler.cs" />
+    <Compile Include="RedisBootstrapperConfigurationExtensions.cs" />
+    <Compile Include="SucceededStateHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Hangfire.Redis/Hangfire.Redis.net45.csproj
+++ b/src/Hangfire.Redis/Hangfire.Redis.net45.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8F46F57B-3247-4AA7-B330-57AC088547EB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.Redis</RootNamespace>
+    <AssemblyName>Hangfire.Redis</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging">
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Redis">
+      <HintPath>..\..\packages\ServiceStack.Redis.3.9.69\lib\net35\ServiceStack.Redis.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="DeletedStateHandler.cs" />
+    <Compile Include="FetchedJobsWatcherOptions.cs" />
+    <Compile Include="FetchedJobsWatcher.cs" />
+    <Compile Include="Properties\Annotations.cs" />
+    <Compile Include="RedisFetchedJob.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RedisWriteOnlyTransaction.cs" />
+    <Compile Include="RedisStorage.cs" />
+    <Compile Include="RedisMonitoringApi.cs" />
+    <Compile Include="RedisConnection.cs" />
+    <Compile Include="RedisStorageOptions.cs" />
+    <Compile Include="FailedStateHandler.cs" />
+    <Compile Include="ProcessingStateHandler.cs" />
+    <Compile Include="RedisBootstrapperConfigurationExtensions.cs" />
+    <Compile Include="SucceededStateHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="..\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Hangfire.Redis/packages.config
+++ b/src/Hangfire.Redis/packages.config
@@ -2,6 +2,9 @@
 <packages>
   <package id="Common.Logging" version="2.2.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="ServiceStack.Common" version="3.9.69" targetFramework="net40" />
   <package id="ServiceStack.Redis" version="3.9.69" targetFramework="net40" />
   <package id="ServiceStack.Text" version="3.9.69" targetFramework="net40" />

--- a/src/Hangfire.SqlServer.Msmq/Hangfire.SqlServer.Msmq.net40.csproj
+++ b/src/Hangfire.SqlServer.Msmq/Hangfire.SqlServer.Msmq.net40.csproj
@@ -4,100 +4,89 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{25909EE6-2A56-4EAC-9D0E-436FF2435E88}</ProjectGuid>
+    <ProjectGuid>{762BE479-0AEC-47E0-8F9C-34FA54641749}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hangfire.Redis.Tests</RootNamespace>
-    <AssemblyName>Hangfire.Redis.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>Hangfire.SqlServer.Msmq</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.Msmq</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>0da80234</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Messaging" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Common">
-      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Interfaces">
-      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Redis">
-      <HintPath>..\..\packages\ServiceStack.Redis.3.9.69\lib\net35\ServiceStack.Redis.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Text">
-      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="FetchedJobsWatcherFacts.cs" />
-    <Compile Include="RedisConnectionFacts.cs" />
-    <Compile Include="RedisFetchedJobFacts.cs" />
-    <Compile Include="RedisStorageFacts.cs" />
-    <Compile Include="RedisStorageOptionsFacts.cs" />
-    <Compile Include="RedisTest.cs" />
-    <Compile Include="FailedStateHandlerFacts.cs" />
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="MsmqFetchedJob.cs" />
+    <Compile Include="MsmqJobQueue.cs" />
+    <Compile Include="MsmqJobQueueMonitoringApi.cs" />
+    <Compile Include="MsmqJobQueueProvider.cs" />
+    <Compile Include="MsmqSqlServerStorageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ProcessingStateHandlerFacts.cs" />
-    <Compile Include="RedisWriteOnlyTransactionFacts.cs" />
-    <Compile Include="DeletedStateHandlerFacts.cs" />
-    <Compile Include="SucceededStateHandlerFacts.cs" />
-    <Compile Include="Utils\CleanRedisAttribute.cs" />
-    <Compile Include="Utils\RedisUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
-      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.csproj">
-      <Project>{8F46F57B-3247-4AA7-B330-57AC088547EB}</Project>
-      <Name>Hangfire.Redis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Hangfire.Core.Tests\Hangfire.Core.Tests.csproj">
-      <Project>{E13C3543-39A3-475C-BB43-2E311E634843}</Project>
-      <Name>Hangfire.Core.Tests</Name>
+    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="..\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -105,7 +94,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Hangfire.SqlServer.Msmq/Hangfire.SqlServer.Msmq.net45.csproj
+++ b/src/Hangfire.SqlServer.Msmq/Hangfire.SqlServer.Msmq.net45.csproj
@@ -4,13 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}</ProjectGuid>
+    <ProjectGuid>{762BE479-0AEC-47E0-8F9C-34FA54641749}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hangfire.SqlServer.Msmq.Tests</RootNamespace>
-    <AssemblyName>Hangfire.SqlServer.Msmq.Tests</AssemblyName>
+    <RootNamespace>Hangfire.SqlServer.Msmq</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.Msmq</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -18,24 +19,20 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Messaging" />
@@ -44,40 +41,29 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="MsmqJobQueueFacts.cs" />
-    <Compile Include="MsmqJobQueueMonitoringApiFacts.cs" />
-    <Compile Include="MsmqJobQueueProviderFacts.cs" />
-    <Compile Include="MsmqSqlServerStorageExtensionsFacts.cs" />
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="MsmqFetchedJob.cs" />
+    <Compile Include="MsmqJobQueue.cs" />
+    <Compile Include="MsmqJobQueueMonitoringApi.cs" />
+    <Compile Include="MsmqJobQueueProvider.cs" />
+    <Compile Include="MsmqSqlServerStorageExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utils\CleanMsmqQueueAttribute.cs" />
-    <Compile Include="Utils\MsmqUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
-      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
+      <Name>Hangfire.Core.net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.csproj">
-      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
-      <Name>Hangfire.SqlServer.Msmq</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
-      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
+    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
+      <Project>{A523C0E3-097D-4869-977F-15A717EA3E83}</Project>
+      <Name>Hangfire.SqlServer.net45</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="..\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Hangfire.SqlServer.Msmq/packages.config
+++ b/src/Hangfire.SqlServer.Msmq/packages.config
@@ -3,5 +3,4 @@
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.net40.csproj
+++ b/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.net40.csproj
@@ -9,42 +9,58 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.SqlServer.RabbitMq</RootNamespace>
     <AssemblyName>Hangfire.SqlServer.RabbitMq</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>95102b2a</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Hangfire.SqlServer.RabbitMq.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Hangfire.SqlServer.RabbitMq.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="RabbitMQ.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\RabbitMQ.Client.3.3.0\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -64,17 +80,17 @@
     <Compile Include="RabbitMqSqlServerStorageExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.csproj">
-      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
-      <Project>{A523C0E3-097D-4869-977F-15A717EA3E83}</Project>
-      <Name>Hangfire.SqlServer</Name>
-    </ProjectReference>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -84,7 +100,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.net45.csproj
+++ b/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.net45.csproj
@@ -1,43 +1,46 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{762BE479-0AEC-47E0-8F9C-34FA54641749}</ProjectGuid>
+    <ProjectGuid>{4CC51F69-0311-4485-B7DE-9ECAB3A1B5E5}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hangfire.SqlServer.Msmq</RootNamespace>
-    <AssemblyName>Hangfire.SqlServer.Msmq</AssemblyName>
+    <RootNamespace>Hangfire.SqlServer.RabbitMq</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.RabbitMq</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Hangfire.SqlServer.Msmq.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Hangfire.SqlServer.Msmq.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="RabbitMQ.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.3.0\lib\net30\RabbitMQ.Client.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Messaging" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -48,25 +51,36 @@
     <Compile Include="..\Common\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="MsmqFetchedJob.cs" />
-    <Compile Include="MsmqJobQueue.cs" />
-    <Compile Include="MsmqJobQueueMonitoringApi.cs" />
-    <Compile Include="MsmqJobQueueProvider.cs" />
-    <Compile Include="MsmqSqlServerStorageExtensions.cs" />
+    <Compile Include="RabbitMqConnectionConfiguration.cs" />
+    <Compile Include="RabbitMqFetchedJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RabbitMqJobQueue.cs" />
+    <Compile Include="RabbitMqJobQueueProvider.cs" />
+    <Compile Include="RabbitMqMonitoringApi.cs" />
+    <Compile Include="RabbitMqSqlServerStorageExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net45.csproj">
       <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
+    <ProjectReference Include="..\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
       <Project>{A523C0E3-097D-4869-977F-15A717EA3E83}</Project>
-      <Name>Hangfire.SqlServer</Name>
+      <Name>Hangfire.SqlServer.net45</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Hangfire.SqlServer/App.config
+++ b/src/Hangfire.SqlServer/App.config
@@ -1,13 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework"/>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" /></startup>
+</configuration>

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.net40.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.net40.csproj
@@ -1,0 +1,144 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A523C0E3-097D-4869-977F-15A717EA3E83}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.SqlServer</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>1dbc8da5</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging">
+      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Dapper">
+      <HintPath>..\..\packages\Dapper.1.13\lib\net40\Dapper.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="EnqueuedAndFetchedCountDto.cs" />
+    <Compile Include="Entities\SqlHash.cs" />
+    <Compile Include="ExpirationManager.cs" />
+    <Compile Include="Entities\JobParameter.cs" />
+    <Compile Include="Entities\SqlJob.cs" />
+    <Compile Include="Entities\SqlState.cs" />
+    <Compile Include="Entities\Server.cs" />
+    <Compile Include="Entities\ServerData.cs" />
+    <Compile Include="IPersistentJobQueue.cs" />
+    <Compile Include="IPersistentJobQueueMonitoringApi.cs" />
+    <Compile Include="IPersistentJobQueueProvider.cs" />
+    <Compile Include="PersistentJobQueueProviderCollection.cs" />
+    <Compile Include="Properties\Annotations.cs" />
+    <Compile Include="SqlServerJobQueue.cs" />
+    <Compile Include="SqlServerFetchedJob.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlServerDistributedLock.cs" />
+    <Compile Include="SqlServerDistributedLockException.cs" />
+    <Compile Include="SqlServerJobQueueProvider.cs" />
+    <Compile Include="SqlServerMonitoringApi.cs" />
+    <Compile Include="SqlServerObjectsInstaller.cs" />
+    <Compile Include="SqlServerJobQueueMonitoringApi.cs" />
+    <Compile Include="SqlServerStorage.cs" />
+    <Compile Include="SqlServerStorageOptions.cs" />
+    <Compile Include="SqlServerConnection.cs" />
+    <Compile Include="SqlServerWriteOnlyTransaction.cs" />
+    <Compile Include="SqlServerBootstrapperConfigurationExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Install.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.net45.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.net45.csproj
@@ -19,21 +19,17 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Hangfire.SqlServer.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Hangfire.SqlServer.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
@@ -98,9 +94,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.net45.csproj">
       <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net45</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Hangfire.SqlServer/packages.config
+++ b/src/Hangfire.SqlServer/packages.config
@@ -3,4 +3,7 @@
   <package id="Common.Logging" version="2.2.0" targetFramework="net45" />
   <package id="Common.Logging.Core" version="2.2.0" targetFramework="net45" />
   <package id="Dapper" version="1.13" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
 </packages>

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.net40.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.net40.csproj
@@ -9,16 +9,17 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.Core.Tests</RootNamespace>
     <AssemblyName>Hangfire.Core.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>c4081dd8</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,12 +27,20 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
@@ -40,7 +49,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.5.7.10213\lib\nunit.framework.dll</HintPath>
@@ -53,6 +62,16 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -143,17 +162,19 @@
     <Compile Include="Utils\StaticLockAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
-      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
-    </ProjectReference>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\src\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -163,7 +184,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.net45.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.net45.csproj
@@ -1,0 +1,172 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E13C3543-39A3-475C-BB43-2E311E634843}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.Core.Tests</RootNamespace>
+    <AssemblyName>Hangfire.Core.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq.Sequences">
+      <HintPath>..\..\packages\Moq.Sequences.1.0.1.0\lib\net40\Moq.Sequences.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.2.5.7.10213\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.mocks">
+      <HintPath>..\..\packages\NUnit.2.5.7.10213\lib\nunit.mocks.dll</HintPath>
+    </Reference>
+    <Reference Include="pnunit.framework">
+      <HintPath>..\..\packages\NUnit.2.5.7.10213\lib\pnunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="NCrontab, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Condition="$(UseILMerge) != 'True'">
+      <HintPath>..\..\packages\ncrontab.1.0.0\lib\NCrontab.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BackgroundJobClientExtensionsFacts.cs" />
+    <Compile Include="BackgroundJobClientFacts.cs" />
+    <Compile Include="BackgroundJobFacts.cs" />
+    <Compile Include="BackgroundJobServerFacts.cs" />
+    <Compile Include="Client\ClientExceptionContextFacts.cs" />
+    <Compile Include="Client\CreateContextFacts.cs" />
+    <Compile Include="Client\CreatedContextFacts.cs" />
+    <Compile Include="Client\CreatingContextFacts.cs" />
+    <Compile Include="Client\JobCreationProcessFacts.cs" />
+    <Compile Include="Common\GlobalJobFilterCollectionFacts.cs" />
+    <Compile Include="Common\JobArgumentFacts.cs" />
+    <Compile Include="Common\JobFacts.cs" />
+    <Compile Include="Common\JobFilterAttributeFacts.cs" />
+    <Compile Include="Common\JobFilterAttributeFilterProviderFacts.cs" />
+    <Compile Include="Common\JobFilterFacts.cs" />
+    <Compile Include="Common\JobFilterProviderCollectionFacts.cs" />
+    <Compile Include="Common\JobHelperFacts.cs" />
+    <Compile Include="Common\JobLoadExceptionFacts.cs" />
+    <Compile Include="CronFacts.cs" />
+    <Compile Include="GlobalStateHandlersFacts.cs" />
+    <Compile Include="JobActivatorFacts.cs" />
+    <Compile Include="JobCancellationTokenFacts.cs" />
+    <Compile Include="JobStorageFacts.cs" />
+    <Compile Include="Mocks\ApplyStateContextMock.cs" />
+    <Compile Include="Mocks\ElectStateContextMock.cs" />
+    <Compile Include="Mocks\SharedWorkerContextMock.cs" />
+    <Compile Include="Mocks\StateContextMock.cs" />
+    <Compile Include="Mocks\WorkerContextMock.cs" />
+    <Compile Include="PreserveCultureAttributeFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueueAttributeFacts.cs" />
+    <Compile Include="RecurringJobManagerFacts.cs" />
+    <Compile Include="RetryAttributeFacts.cs" />
+    <Compile Include="Server\BackgroundJobServerOptionsFacts.cs" />
+    <Compile Include="Server\JobPerformanceProcessFacts.cs" />
+    <Compile Include="Server\RecurringJobSchedulerFacts.cs" />
+    <Compile Include="Server\ScheduleInstantFactoryFacts.cs" />
+    <Compile Include="Server\ScheduleInstantFacts.cs" />
+    <Compile Include="Server\ServerBootstrapperFacts.cs" />
+    <Compile Include="Server\PerformContextFacts.cs" />
+    <Compile Include="Server\SchedulePollerFacts.cs" />
+    <Compile Include="Server\ServerJobCancellationTokenFacts.cs" />
+    <Compile Include="Server\ServerSupervisorCollectionFacts.cs" />
+    <Compile Include="Server\ServerSupervisorFacts.cs" />
+    <Compile Include="Server\AutomaticRetryServerComponentWrapperFacts.cs" />
+    <Compile Include="Server\ServerHeartbeatFacts.cs" />
+    <Compile Include="Server\ServerWatchdogFacts.cs" />
+    <Compile Include="Server\SharedWorkerContextFacts.cs" />
+    <Compile Include="Server\WorkerContextFacts.cs" />
+    <Compile Include="Server\WorkerFacts.cs" />
+    <Compile Include="Server\WorkerManagerFacts.cs" />
+    <Compile Include="States\DeletedStateFacts.cs" />
+    <Compile Include="States\DeletedStateHandlerFacts.cs" />
+    <Compile Include="States\EnqueuedStateFacts.cs" />
+    <Compile Include="States\EnqueuedStateHandlerFacts.cs" />
+    <Compile Include="States\FailedStateFacts.cs" />
+    <Compile Include="States\ScheduledStateHandlerFacts.cs" />
+    <Compile Include="States\ProcessingStateFacts.cs" />
+    <Compile Include="States\ScheduledStateFacts.cs" />
+    <Compile Include="States\ApplyStateContextFacts.cs" />
+    <Compile Include="States\ElectStateContextFacts.cs" />
+    <Compile Include="States\StateChangeProcessFacts.cs" />
+    <Compile Include="States\StateContextFacts.cs" />
+    <Compile Include="States\StateHandlerCollectionFacts.cs" />
+    <Compile Include="States\StateMachineFactoryFacts.cs" />
+    <Compile Include="States\StateMachineFacts.cs" />
+    <Compile Include="States\SucceededStateFacts.cs" />
+    <Compile Include="States\SucceededStateHandlerFacts.cs" />
+    <Compile Include="StatisticsHistoryAttributeFacts.cs" />
+    <Compile Include="Storage\InvocationDataFacts.cs" />
+    <Compile Include="Storage\MonitoringTypeFacts.cs" />
+    <Compile Include="Utils\GlobalLockAttribute.cs" />
+    <Compile Include="Utils\PossibleHangingFactAttribute.cs" />
+    <Compile Include="Utils\SequenceAttribute.cs" />
+    <Compile Include="Utils\StaticLockAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Hangfire.Core.Tests/Server/SchedulePollerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/SchedulePollerFacts.cs
@@ -39,7 +39,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SchedulePoller(
-                    null, _stateMachineFactory.Object, Timeout.InfiniteTimeSpan));
+                    null, _stateMachineFactory.Object, Net40CompatibilityHelper.Timeout.InfiniteTimeSpan));
 
             Assert.Equal("storage", exception.ParamName);
         }
@@ -49,7 +49,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SchedulePoller(
-                    _storage.Object, null, Timeout.InfiniteTimeSpan));
+                    _storage.Object, null, Net40CompatibilityHelper.Timeout.InfiniteTimeSpan));
 
             Assert.Equal("stateMachineFactory", exception.ParamName);
         }
@@ -94,7 +94,7 @@ namespace Hangfire.Core.Tests.Server
 
         private SchedulePoller CreateScheduler()
         {
-            return new SchedulePoller(_storage.Object, _stateMachineFactory.Object, Timeout.InfiniteTimeSpan);
+            return new SchedulePoller(_storage.Object, _stateMachineFactory.Object, Net40CompatibilityHelper.Timeout.InfiniteTimeSpan);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/ServerBootstrapperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ServerBootstrapperFacts.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Threading;
-using Hangfire.Server;
+﻿using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
+using System;
+using System.Threading;
 using Xunit;
 
 namespace Hangfire.Core.Tests.Server
@@ -25,7 +25,8 @@ namespace Hangfire.Core.Tests.Server
             _supervisor = new Mock<IServerSupervisor>();
             _supervisorFactory = new Lazy<IServerSupervisor>(() => _supervisor.Object);
             _connection = new Mock<IStorageConnection>();
-            _cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            _cts = new CancellationTokenSource();
+            _cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
             _storage.Setup(x => x.GetConnection()).Returns(_connection.Object);
         }
@@ -80,7 +81,7 @@ namespace Hangfire.Core.Tests.Server
         public void Execute_GetsExactlyTwoConnections_AndClosesThem()
         {
             var server = CreateServer();
-            
+
             server.Execute(_cts.Token);
 
             _storage.Verify(x => x.GetConnection(), Times.Exactly(2));
@@ -110,7 +111,7 @@ namespace Hangfire.Core.Tests.Server
         public void Execute_RemovesServerFromServersList()
         {
             var server = CreateServer();
-            
+
             server.Execute(_cts.Token);
 
             _connection.Verify(x => x.RemoveServer(ServerId));

--- a/tests/Hangfire.Core.Tests/Server/ServerSupervisorFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ServerSupervisorFacts.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Threading;
-using Hangfire.Server;
+﻿using Hangfire.Server;
 using Moq;
+using System;
+using System.Threading;
 using Xunit;
 
 namespace Hangfire.Core.Tests.Server
@@ -16,7 +16,7 @@ namespace Hangfire.Core.Tests.Server
             _component = new Mock<IServerComponent>();
             _options = new ServerSupervisorOptions
             {
-                ShutdownTimeout = Timeout.InfiniteTimeSpan // Letting tests to timeout
+                ShutdownTimeout = Net40CompatibilityHelper.Timeout.InfiniteTimeSpan // Letting tests to timeout
             };
         }
 
@@ -91,7 +91,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             int timesExecuted = 0;
-            
+
             var supervisor = CreateSupervisor();
             _component.Setup(x => x.Execute(It.IsAny<CancellationToken>()))
                 .Callback(() => { timesExecuted++; Thread.Sleep(50); });
@@ -123,7 +123,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             int timesExecuted = 0;
-            
+
             var supervisor = CreateSupervisor();
             _component.Setup(x => x.Execute(It.IsAny<CancellationToken>()))
                 .Callback(() => { timesExecuted++; Thread.Sleep(50); });

--- a/tests/Hangfire.Core.Tests/Server/ServerWatchdogFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ServerWatchdogFacts.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Threading;
-using Hangfire.Server;
+﻿using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
+using System;
+using System.Threading;
 using Xunit;
 
 namespace Hangfire.Core.Tests.Server
@@ -12,7 +12,7 @@ namespace Hangfire.Core.Tests.Server
         private readonly Mock<JobStorage> _storage;
         private readonly Mock<IStorageConnection> _connection;
         private readonly ServerWatchdogOptions _options;
-		private readonly CancellationTokenSource _cts;
+        private readonly CancellationTokenSource _cts;
 
         public ServerWatchdogFacts()
         {
@@ -20,10 +20,10 @@ namespace Hangfire.Core.Tests.Server
             _connection = new Mock<IStorageConnection>();
             _options = new ServerWatchdogOptions
             {
-                CheckInterval = Timeout.InfiniteTimeSpan // To check that it exits by cancellation token
+                CheckInterval = Net40CompatibilityHelper.Timeout.InfiniteTimeSpan // To check that it exits by cancellation token
             };
-			_cts = new CancellationTokenSource();
-			_cts.Cancel();
+            _cts = new CancellationTokenSource();
+            _cts.Cancel();
 
             _storage.Setup(x => x.GetConnection()).Returns(_connection.Object);
         }
@@ -46,7 +46,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var watchdog = CreateWatchdog();
 
-			watchdog.Execute(_cts.Token);
+            watchdog.Execute(_cts.Token);
 
             _storage.Verify(x => x.GetConnection(), Times.Once);
             _connection.Verify(x => x.Dispose(), Times.Once);
@@ -58,7 +58,7 @@ namespace Hangfire.Core.Tests.Server
             _connection.Setup(x => x.RemoveTimedOutServers(It.IsAny<TimeSpan>())).Returns(1);
             var watchdog = CreateWatchdog();
 
-			watchdog.Execute(_cts.Token);
+            watchdog.Execute(_cts.Token);
 
             _connection.Verify(x => x.RemoveTimedOutServers(_options.ServerTimeout));
         }

--- a/tests/Hangfire.Core.Tests/packages.config
+++ b/tests/Hangfire.Core.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Moq.Sequences" version="1.0.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />

--- a/tests/Hangfire.Redis.Tests/Hangfire.Redis.Tests.net40.csproj
+++ b/tests/Hangfire.Redis.Tests/Hangfire.Redis.Tests.net40.csproj
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{25909EE6-2A56-4EAC-9D0E-436FF2435E88}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.Redis.Tests</RootNamespace>
+    <AssemblyName>Hangfire.Redis.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>d6e387d2</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Common">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Interfaces">
+      <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Redis">
+      <HintPath>..\..\packages\ServiceStack.Redis.3.9.69\lib\net35\ServiceStack.Redis.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FetchedJobsWatcherFacts.cs" />
+    <Compile Include="RedisConnectionFacts.cs" />
+    <Compile Include="RedisFetchedJobFacts.cs" />
+    <Compile Include="RedisStorageFacts.cs" />
+    <Compile Include="RedisStorageOptionsFacts.cs" />
+    <Compile Include="RedisTest.cs" />
+    <Compile Include="FailedStateHandlerFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProcessingStateHandlerFacts.cs" />
+    <Compile Include="RedisWriteOnlyTransactionFacts.cs" />
+    <Compile Include="DeletedStateHandlerFacts.cs" />
+    <Compile Include="SucceededStateHandlerFacts.cs" />
+    <Compile Include="Utils\CleanRedisAttribute.cs" />
+    <Compile Include="Utils\RedisUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.net40.csproj">
+      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
+      <Name>Hangfire.Redis.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Hangfire.Core.Tests\Hangfire.Core.Tests.net40.csproj">
+      <Project>{e13c3543-39a3-475c-bb43-2e311e634843}</Project>
+      <Name>Hangfire.Core.Tests.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Hangfire.Redis.Tests/Hangfire.Redis.Tests.net45.csproj
+++ b/tests/Hangfire.Redis.Tests/Hangfire.Redis.Tests.net45.csproj
@@ -4,49 +4,34 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8F46F57B-3247-4AA7-B330-57AC088547EB}</ProjectGuid>
+    <ProjectGuid>{25909EE6-2A56-4EAC-9D0E-436FF2435E88}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hangfire.Redis</RootNamespace>
-    <AssemblyName>Hangfire.Redis</AssemblyName>
+    <RootNamespace>Hangfire.Redis.Tests</RootNamespace>
+    <AssemblyName>Hangfire.Redis.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Hangfire.Redis.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Hangfire.Redis.xml</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging">
-      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Common.Logging.Core">
-      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ServiceStack.Text">
-      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,6 +40,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
     <Reference Include="ServiceStack.Common">
       <HintPath>..\..\packages\ServiceStack.Common.3.9.69\lib\net35\ServiceStack.Common.dll</HintPath>
     </Reference>
@@ -64,42 +52,58 @@
     <Reference Include="ServiceStack.Redis">
       <HintPath>..\..\packages\ServiceStack.Redis.3.9.69\lib\net35\ServiceStack.Redis.dll</HintPath>
     </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\..\packages\ServiceStack.Text.3.9.69\lib\net35\ServiceStack.Text.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Common\SharedAssemblyInfo.cs">
-      <Link>Properties\SharedAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="DeletedStateHandler.cs" />
-    <Compile Include="FetchedJobsWatcherOptions.cs" />
-    <Compile Include="FetchedJobsWatcher.cs" />
-    <Compile Include="Properties\Annotations.cs" />
-    <Compile Include="RedisFetchedJob.cs" />
+    <Compile Include="FetchedJobsWatcherFacts.cs" />
+    <Compile Include="RedisConnectionFacts.cs" />
+    <Compile Include="RedisFetchedJobFacts.cs" />
+    <Compile Include="RedisStorageFacts.cs" />
+    <Compile Include="RedisStorageOptionsFacts.cs" />
+    <Compile Include="RedisTest.cs" />
+    <Compile Include="FailedStateHandlerFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RedisWriteOnlyTransaction.cs" />
-    <Compile Include="RedisStorage.cs" />
-    <Compile Include="RedisMonitoringApi.cs" />
-    <Compile Include="RedisConnection.cs" />
-    <Compile Include="RedisStorageOptions.cs" />
-    <Compile Include="FailedStateHandler.cs" />
-    <Compile Include="ProcessingStateHandler.cs" />
-    <Compile Include="RedisBootstrapperConfigurationExtensions.cs" />
-    <Compile Include="SucceededStateHandler.cs" />
+    <Compile Include="ProcessingStateHandlerFacts.cs" />
+    <Compile Include="RedisWriteOnlyTransactionFacts.cs" />
+    <Compile Include="DeletedStateHandlerFacts.cs" />
+    <Compile Include="SucceededStateHandlerFacts.cs" />
+    <Compile Include="Utils\CleanRedisAttribute.cs" />
+    <Compile Include="Utils\RedisUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.csproj">
-      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
-      <Name>Hangfire.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="..\Common\Hangfire.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{C995EA9E-56EE-4951-8260-D94260A7F4C2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.net45.csproj">
+      <Project>{8F46F57B-3247-4AA7-B330-57AC088547EB}</Project>
+      <Name>Hangfire.Redis.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Hangfire.Core.Tests\Hangfire.Core.Tests.net45.csproj">
+      <Project>{E13C3543-39A3-475C-BB43-2E311E634843}</Project>
+      <Name>Hangfire.Core.Tests.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Hangfire.Redis.Tests/packages.config
+++ b/tests/Hangfire.Redis.Tests/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="Redis-32" version="2.6.12.1" targetFramework="net40" />
   <package id="ServiceStack.Common" version="3.9.69" targetFramework="net45" />
   <package id="ServiceStack.Redis" version="3.9.69" targetFramework="net45" />
   <package id="ServiceStack.Text" version="3.9.69" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="Redis-32" version="2.6.12.1" targetFramework="net40" />
 </packages>

--- a/tests/Hangfire.SqlServer.Msmq.Tests/Hangfire.SqlServer.Msmq.Tests.net40.csproj
+++ b/tests/Hangfire.SqlServer.Msmq.Tests/Hangfire.SqlServer.Msmq.Tests.net40.csproj
@@ -1,0 +1,117 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.SqlServer.Msmq.Tests</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.Msmq.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>eda9c716</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Messaging" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MsmqJobQueueFacts.cs" />
+    <Compile Include="MsmqJobQueueMonitoringApiFacts.cs" />
+    <Compile Include="MsmqJobQueueProviderFacts.cs" />
+    <Compile Include="MsmqSqlServerStorageExtensionsFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\CleanMsmqQueueAttribute.cs" />
+    <Compile Include="Utils\MsmqUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net40.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Hangfire.SqlServer.Msmq.Tests/Hangfire.SqlServer.Msmq.Tests.net45.csproj
+++ b/tests/Hangfire.SqlServer.Msmq.Tests/Hangfire.SqlServer.Msmq.Tests.net45.csproj
@@ -4,86 +4,86 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C02BB718-2AE4-434C-8668-C894FF663FCE}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <ProjectGuid>{DBC6BC12-06AD-4597-9E0F-B77BE754FA2C}</ProjectGuid>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ConsoleSample</RootNamespace>
-    <AssemblyName>ConsoleSample</AssemblyName>
+    <RootNamespace>Hangfire.SqlServer.Msmq.Tests</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.Msmq.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Messaging" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="MsmqJobQueueFacts.cs" />
+    <Compile Include="MsmqJobQueueMonitoringApiFacts.cs" />
+    <Compile Include="MsmqJobQueueProviderFacts.cs" />
+    <Compile Include="MsmqSqlServerStorageExtensionsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Services.cs" />
+    <Compile Include="Utils\CleanMsmqQueueAttribute.cs" />
+    <Compile Include="Utils\MsmqUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.csproj">
-      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
-      <Name>Hangfire.SqlServer.Msmq</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.Redis\Hangfire.Redis.csproj">
-      <Project>{8f46f57b-3247-4aa7-b330-57ac088547eb}</Project>
-      <Name>Hangfire.Redis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
-      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
       <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.Msmq\Hangfire.SqlServer.Msmq.net45.csproj">
+      <Project>{762be479-0aec-47e0-8f9c-34fa54641749}</Project>
+      <Name>Hangfire.SqlServer.Msmq.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net45</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Hangfire.SqlServer.Msmq.Tests/packages.config
+++ b/tests/Hangfire.SqlServer.Msmq.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.net40.csproj
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.net40.csproj
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2654D751-33D5-411D-A187-D057FED9CD25}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.SqlServer.RabbitMq.Tests</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.RabbitMq.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>0e23ae87</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="RabbitMQ.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.3.0\lib\net30\RabbitMQ.Client.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RabbitMqConnectionConfigurationFacts.cs" />
+    <Compile Include="RabbitMqSqlServerStorageExtensionsFacts.cs" />
+    <Compile Include="RabbitMqMonitoringApiFacts.cs" />
+    <Compile Include="RabbitMqJobQueueFacts.cs" />
+    <Compile Include="RabbitMqJobQueueProviderFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\CleanRabbitMqQueueAttribute.cs" />
+    <Compile Include="Utils\RabbitMqUtils.cs" />
+    <Compile Include="Utils\RabbitMqChannel.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net40.csproj">
+      <Project>{4cc51f69-0311-4485-b7de-9ecab3a1b5e5}</Project>
+      <Name>Hangfire.SqlServer.RabbitMq.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.net45.csproj
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.net45.csproj
@@ -18,7 +18,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +26,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -63,17 +61,17 @@
     <Compile Include="Utils\RabbitMqChannel.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
       <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
+      <Name>Hangfire.Core.net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer.RabbitMq\Hangfire.SqlServer.RabbitMq.net45.csproj">
       <Project>{4cc51f69-0311-4485-b7de-9ecab3a1b5e5}</Project>
-      <Name>Hangfire.SqlServer.RabbitMq</Name>
+      <Name>Hangfire.SqlServer.RabbitMq.net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.csproj">
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
       <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
+      <Name>Hangfire.SqlServer.net45</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -82,6 +80,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <Import Project="..\..\src\Common\Hangfire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="RabbitMQ.Client" version="3.3.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.net40.csproj
+++ b/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.net40.csproj
@@ -9,16 +9,17 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hangfire.SqlServer.Tests</RootNamespace>
     <AssemblyName>Hangfire.SqlServer.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>b71f34cc</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,7 +27,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,14 +34,33 @@
   <ItemGroup>
     <Reference Include="Dapper, Version=1.12.1.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
+      <HintPath>..\..\packages\Dapper.1.13\lib\net40\Dapper.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
     <Reference Include="System.Messaging" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -70,17 +89,17 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\HangFire.Core\Hangfire.Core.csproj">
-      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
-      <Name>Hangfire.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\HangFire.SqlServer\Hangfire.SqlServer.csproj">
-      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
-      <Name>Hangfire.SqlServer</Name>
-    </ProjectReference>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net40.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net40</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net40.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net40</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\src\Common\HangFire.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -90,7 +109,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.net45.csproj
+++ b/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.net45.csproj
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6DFFA275-C483-4501-823A-741AC9EC0846}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.SqlServer.Tests</RootNamespace>
+    <AssemblyName>Hangfire.SqlServer.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Dapper, Version=1.12.1.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Messaging" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PersistentJobQueueProviderCollectionFacts.cs" />
+    <Compile Include="SqlServerConnectionFacts.cs" />
+    <Compile Include="ExpirationManagerFacts.cs" />
+    <Compile Include="SqlServerJobQueueFacts.cs" />
+    <Compile Include="SqlServerFetchedJobFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlServerDistributedLockFacts.cs" />
+    <Compile Include="StorageFacts.cs" />
+    <Compile Include="StorageOptionsFacts.cs" />
+    <Compile Include="Utils\ConnectionUtils.cs" />
+    <Compile Include="Utils\CleanDatabaseAttribute.cs" />
+    <Compile Include="SqlServerWriteOnlyTransactionFacts.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hangfire.Core\Hangfire.Core.net45.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core.net45</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Hangfire.SqlServer\Hangfire.SqlServer.net45.csproj">
+      <Project>{a523c0e3-097d-4869-977f-15a717ea3e83}</Project>
+      <Name>Hangfire.SqlServer.net45</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="..\..\src\Common\HangFire.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -78,7 +78,8 @@ namespace Hangfire.SqlServer.Tests
         {
             UseConnection(connection =>
             {
-                var cts = new CancellationTokenSource(200);
+                var cts = new CancellationTokenSource();
+                cts.CancelAfter(200);
                 var queue = CreateJobQueue(connection);
 
                 Assert.Throws<OperationCanceledException>(
@@ -295,7 +296,8 @@ values (scope_identity(), @queue)";
 
         private static CancellationToken CreateTimingOutCancellationToken()
         {
-            var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var source = new CancellationTokenSource();
+            source.CancelAfter(TimeSpan.FromSeconds(10));
             return source.Token;
         }
 

--- a/tests/Hangfire.SqlServer.Tests/packages.config
+++ b/tests/Hangfire.SqlServer.Tests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.13" targetFramework="net45" />
+  <package id="Dapper" version="1.13" targetFramework="net45" requireReinstallation="True" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR is an update to #216  and fixes #207.

Support for .NET 4.0 is now added through dedicated project files, rather than using conditionals. Additionally .NET 4.0 tests are built and run in the build scripts.

Unfortunately I have had to add this as another PR, as GitHub doesnt support changing the branch of the original PR. 

- [ ] AppVeyor build and tests passing
- [x] Mono build and tests passing