### PR TITLE
Support for generics in job types

### DIFF
--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -372,5 +372,15 @@ namespace Hangfire.Common
 
             return CachedExpressionCompiler.Evaluate(expression);
         }
+
+        /// <summary>
+        /// Get a name of the job type class with a method to invoke in a readable format
+        /// Handles generic types
+        /// </summary>
+        /// <returns></returns>
+        public string GetTypeAndMethod()
+        {
+            return String.Format("{0}.{1}", Type.ToGenericTypeString(), Method.Name);
+        }
     }
 }

--- a/src/Hangfire.Core/Common/TypeExtensions.cs
+++ b/src/Hangfire.Core/Common/TypeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+
+namespace Hangfire.Common
+{
+    public static class TypeExtensions
+    {
+        public static string ToGenericTypeString(this Type t)
+        {
+            if (!t.IsGenericType)
+                return t.Name;
+            string genericTypeName = t.GetGenericTypeDefinition().Name;
+            genericTypeName = genericTypeName.Substring(0, genericTypeName.IndexOf('`'));
+            string genericArgs = string.Join(",", t.GetGenericArguments().Select(ta => ToGenericTypeString(ta)).ToArray());
+            return genericTypeName + "<" + genericArgs + ">";
+        }
+    }
+}

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -50,7 +50,7 @@ namespace Hangfire.Dashboard
 
             if (displayNameAttribute == null || displayNameAttribute.DisplayName == null)
             {
-                return String.Format("{0}.{1}", job.Type.Name, job.Method.Name);
+                return job.GetTypeAndMethod().Replace("<", "&lt;").Replace(">", "&gt;");
             }
 
             try

--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -41,7 +41,7 @@ namespace Hangfire.Dashboard
 
             if (!job.Method.IsStatic)
             {
-                var serviceName = job.Type.Name;
+                var serviceName = job.Type.ToGenericTypeString();
 
                 if (job.Type.IsInterface && serviceName[0] == 'I' && Char.IsUpper(serviceName[1]))
                 {
@@ -50,11 +50,11 @@ namespace Hangfire.Dashboard
 
                 serviceName = Char.ToLower(serviceName[0]) + serviceName.Substring(1);
 
-                builder.Append(WrapType(job.Type.Name));
+                builder.Append(WrapType(job.Type.ToGenericTypeString()));
                 builder.AppendFormat(
                     " {0} = Activate<{1}>();",
                     Encode(serviceName),
-                    WrapType(Encode(job.Type.Name)));
+                    WrapType(Encode(job.Type.ToGenericTypeString())));
 
                 builder.AppendLine();
 
@@ -62,7 +62,7 @@ namespace Hangfire.Dashboard
             }
             else
             {
-                builder.Append(WrapType(Encode(job.Type.Name)));
+                builder.Append(WrapType(Encode(job.Type.ToGenericTypeString())));
             }
 
             builder.Append(".");

--- a/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
+++ b/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
@@ -33,10 +33,7 @@ namespace Hangfire
 
         public void OnPerforming(PerformingContext filterContext)
         {
-            var resource = String.Format(
-                "{0}.{1}",
-                filterContext.Job.Type.FullName,
-                filterContext.Job.Method.Name);
+            var resource = filterContext.Job.GetTypeAndMethod();
 
             var timeout = TimeSpan.FromSeconds(_timeoutInSeconds);
 

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -81,6 +81,7 @@
     <Compile Include="AutomaticRetryAttribute.cs" />
     <Compile Include="BackgroundJobServer.cs" />
     <Compile Include="BackgroundJobServerOptions.cs" />
+    <Compile Include="Common\TypeExtensions.cs" />
     <Compile Include="Cron.cs" />
     <Compile Include="Dashboard\BatchCommandDispatcher.cs" />
     <Compile Include="Dashboard\CombinedResourceDispatcher.cs" />

--- a/src/Hangfire.Core/RecurringJob.cs
+++ b/src/Hangfire.Core/RecurringJob.cs
@@ -97,7 +97,7 @@ namespace Hangfire
 
         private static string GetRecurringJobId(Job job)
         {
-            return String.Format("{0}.{1}", job.Type.Name, job.Method.Name);
+            return job.GetTypeAndMethod();
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -437,6 +437,17 @@ namespace Hangfire.Core.Tests.Common
             Assert.True(cachedAttributes[0] is TestMethodAttribute);
         }
 
+        [Fact]
+        public void Jobs_With_Generics_Have_Different_Ids()
+        {
+            var job1 = Job.FromExpression<JobClassWrapper<Instance>>(x => x.Dispose());
+            var job2 = Job.FromExpression<JobClassWrapper<BrokenDispose>>(x => x.Dispose());
+            var id1 = job1.GetTypeAndMethod();
+            var id2 = job2.GetTypeAndMethod();
+
+            Assert.NotEqual(id1, id2);
+        }
+
         private static void PrivateMethod()
         {
         }
@@ -532,6 +543,13 @@ namespace Hangfire.Core.Tests.Common
             public void Dispose()
             {
                 throw new InvalidOperationException();
+            }
+        }
+
+        public class JobClassWrapper<T> : IDisposable where T : IDisposable
+        {
+            public void Dispose()
+            {
             }
         }
 


### PR DESCRIPTION
This patch allows generic types to be used in jobs. Currently it is not  possible to schedule recurring jobs like this:

``` C#
            RecurringJob.AddOrUpdate<ELScheduledTask<UpdateReports>>("UpdateReports", r => r.Execute(), Cron.Daily(3));
            RecurringJob.AddOrUpdate<ELScheduledTask<UpdateActiveLoansTask>>("UpdateActiveLoans", r => r.Execute(), Cron.Daily(3));
```

Because it generates same job id  - **ELScheduledTask`1**. And this typename is displayed in dashboard. Logic that formats type name and method name is extracted to **Job.GetTypeAndMethod** and it is called from   **RecurringJob** and **HtmlHelper**. Unit tests were added too.
