### PR TITLE
Updated UseRabbitMq extension method to actually use the VirtualHost property

### DIFF
--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
@@ -15,6 +15,7 @@ namespace Hangfire.SqlServer.RabbitMQ
             configureAction(conf);
 
             ConnectionFactory cf = new ConnectionFactory();
+            cf.VirtualHost = conf.VirtualHost;
             cf.HostName = conf.HostName;
             cf.Port = conf.Port;
             cf.UserName = conf.Username;


### PR DESCRIPTION
The VirtualHost property was never actually passed to the connection and hence VirtualHosts weren't working when using RabbitMQ.
