### PR TITLE
1.3.3 Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.3.2-build-0{build}
+version: 1.3.3-build-0{build}
 
 #---------------------------------#
 #    environment configuration    #

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,6 +14,9 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases
     
+1.3.3
+* Fixed – Enqueued job is not being processed with MSMQ or RabbitMQ.
+    
 1.3.2
 * Fixed – Fatal error occurred during execution of 'Server Core' component.
 * Fixed – Hangfire version freezes at 1.0.0.0 on Dashboard.

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -12,7 +12,11 @@
     <description>MSMQ queues support for SQL Server job storage implementation for Hangfire (background job system for ASP.NET applications).</description>
     <copyright>Copyright © 2014 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer MSMQ</tags>
-    <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
+    <releaseNotes>https://github.com/HangfireIO/Hangfire/releases
+    
+1.3.3
+* Fixed – Enqueued job is not being processed with MSMQ or RabbitMQ.    
+    </releaseNotes>
     <dependencies>
       <dependency id="Hangfire.Core" version="[0.0.0]" />
       <dependency id="Hangfire.SqlServer" version="1.2.2" />

--- a/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.RabbitMQ.nuspec
@@ -12,7 +12,11 @@
     <description>RabbitMQ queues support for SQL Server job storage implementation for Hangfire (background job system for ASP.NET applications).</description>
     <copyright>Copyright © 2014 Denny Ferrassoli</copyright>
     <tags>Hangfire SqlServer RabbitMQ</tags>
-    <releaseNotes>https://github.com/HangfireIO/Hangfire/releases</releaseNotes>
+    <releaseNotes>https://github.com/HangfireIO/Hangfire/releases
+    
+1.3.3
+* Fixed – Enqueued job is not being processed with MSMQ or RabbitMQ.  
+    </releaseNotes>
     <dependencies>
       <dependency id="Hangfire.Core" version="[0.0.0]" />
       <dependency id="Hangfire.SqlServer" version="[0.0.0]" />

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <package >
   <metadata>
     <id>Hangfire.SqlServer</id>
@@ -13,6 +13,9 @@
     <copyright>Copyright © 2013-2014 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer SqlAzure LocalDB</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases
+    
+1.3.3
+* Fixed – Enqueued job is not being processed with MSMQ or RabbitMQ.  
     
 1.3.2
 * Fixed – Sql Timeouts in ExpirationManager.

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -18,6 +18,9 @@
     <tags>Hangfire AspNet OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>https://github.com/HangfireIO/Hangfire/releases
     
+1.3.3
+* Fixed – Enqueued job is not being processed with MSMQ or RabbitMQ.
+    
 1.3.2
 * Fixed – Fatal error occurred during execution of 'Server Core' component.
 * Fixed – Hangfire version freezes at 1.0.0.0 on Dashboard.

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.3.2")]
+[assembly: AssemblyVersion("1.3.3")]
 [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This is a correcting release. Fixed a bug related to MSMQ or RabbitMQ extensions, when enqueued job is not being processed and "stucked" in the *Enqueued* state indefinitely until we retry it manually.

* **Fixed** – Enqueued job is not being processed with MSMQ or RabbitMQ (#294).