### PR TITLE
Making Product Version and File Version on the dll match the Assembly Version

### DIFF
--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -12,4 +12,3 @@ using System.Runtime.InteropServices;
 
 // Don't edit manually! Use `build.bat version` command instead!
 [assembly: AssemblyVersion("1.4.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Having the AssemblyFileVersion attribute defined causes the product version and file version in the dll properties to follow it. Removing it makes those properties follow the assembly version. This was causing issues within a MSI my project uses, since the MSI thinks the version is always 1.0.0.0 and skips deploying the new dll.