### PR TITLE
Allow a URI to be used for RabbitMQConnectionConfiguration

### DIFF
--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqConnectionConfiguration.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqConnectionConfiguration.cs
@@ -26,6 +26,13 @@ namespace Hangfire.SqlServer.RabbitMQ
         {
         }
 
+        public RabbitMqConnectionConfiguration(Uri uri)
+        {
+            if (uri == null) throw new ArgumentNullException("uri");
+
+            Uri = uri;
+        }
+
         public RabbitMqConnectionConfiguration(string host, int port, string username, string password)
         {
             if (host == null) throw new ArgumentNullException("host");
@@ -48,5 +55,7 @@ namespace Hangfire.SqlServer.RabbitMQ
         public string VirtualHost { get; set; }
 
         public int Port { get; set; }
+
+        public Uri Uri { get; set; }
     }
 }

--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqSqlServerStorageExtensions.cs
@@ -15,12 +15,21 @@ namespace Hangfire.SqlServer.RabbitMQ
             configureAction(conf);
 
             ConnectionFactory cf = new ConnectionFactory();
-            cf.VirtualHost = conf.VirtualHost;
-            cf.HostName = conf.HostName;
-            cf.Port = conf.Port;
-            cf.UserName = conf.Username;
-            cf.Password = conf.Password;
-            
+
+            // Use configuration from URI, otherwise use properties
+            if (conf.Uri != null)
+            {
+                cf.uri = conf.Uri;
+            }
+            else
+            {
+                cf.HostName = conf.HostName;
+                cf.Port = conf.Port;
+                cf.UserName = conf.Username;
+                cf.Password = conf.Password;
+                cf.VirtualHost = conf.VirtualHost;
+            }
+
             var provider = new RabbitMqJobQueueProvider(queues, cf);
 
             storage.QueueProviders.Add(provider, queues);

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/RabbitMqConnectionConfigurationFacts.cs
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/RabbitMqConnectionConfigurationFacts.cs
@@ -48,10 +48,19 @@ namespace Hangfire.SqlServer.RabbitMq.Tests
         }
 
         [Fact]
+        public void Ctor_ThrowsException_WhenUriIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new RabbitMqConnectionConfiguration((Uri)null));
+
+            Assert.Equal("uri", exception.ParamName);
+        }
+
+        [Fact]
         public void Ctor_ThrowsException_WhenHostIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new RabbitMqConnectionConfiguration(null));
+                () => new RabbitMqConnectionConfiguration((string)null));
 
             Assert.Equal("host", exception.ParamName);
         }


### PR DESCRIPTION
This change allows a URI to be used for the RabbitMQConnectionConfiguration. Using an AMQP URI is less verbose than having to specify each configuration property. This is backwards compatible, if no URI is specified then the default properties are expected to be set.