### PR TITLE
Monthly cron expression with specific day

### DIFF
--- a/src/Hangfire.Core/Cron.cs
+++ b/src/Hangfire.Core/Cron.cs
@@ -162,6 +162,38 @@ namespace Hangfire
         }
 
         /// <summary>
+        /// Returns cron expression that fires every month on the first specified day of the week.
+        /// </summary>
+        /// <param name="dayOfWeek">The day of week in which the schedule will be activated.</param>
+        public static string Monthly(DayOfWeek dayOfWeek)
+        {
+            return Monthly(dayOfWeek, 0);
+        }
+
+        /// <summary>
+        /// Returns cron expression that fires every month on the first specified day of the week 
+        /// and hour in UTC.
+        /// </summary>
+        /// <param name="dayOfWeek">The day of week in which the schedule will be activated.</param>
+        /// <param name="hour">The hour in which the schedule will be activated (0-23).</param>
+        public static string Monthly(DayOfWeek dayOfWeek, int hour)
+        {
+            return Monthly(dayOfWeek, 0, 0);
+        }
+
+        /// <summary>
+        /// Returns cron expression that fires every month on the first specified day of the week,
+        /// hour and minute in UTC.
+        /// </summary>
+        /// <param name="dayOfWeek">The day of week in which the schedule will be activated.</param>
+        /// <param name="hour">The hour in which the schedule will be activated (0-23).</param>
+        /// <param name="minute">The minute in which the schedule will be activated (0-59).</param>
+        public static string Monthly(DayOfWeek dayOfWeek, int hour, int minute)
+        {
+            return String.Format("{0} {1} 1-7 * {2}", minute, hour, (int)dayOfWeek);
+        }
+
+        /// <summary>
         /// Returns cron expression that fires every year on Jan, 1st at 00:00 UTC.
         /// </summary>
         public static string Yearly()

--- a/src/Hangfire.Core/Cron.cs
+++ b/src/Hangfire.Core/Cron.cs
@@ -178,7 +178,7 @@ namespace Hangfire
         /// <param name="hour">The hour in which the schedule will be activated (0-23).</param>
         public static string Monthly(DayOfWeek dayOfWeek, int hour)
         {
-            return Monthly(dayOfWeek, 0, 0);
+            return Monthly(dayOfWeek, hour, 0);
         }
 
         /// <summary>

--- a/tests/Hangfire.Core.Tests/CronFacts.cs
+++ b/tests/Hangfire.Core.Tests/CronFacts.cs
@@ -134,6 +134,36 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
+        public void Monthly_WithDayOfTheWeek_ReturnsFormattedStringWithDay()
+        {
+            DayOfWeek day = DayOfWeek.Tuesday;
+            string expected = "0 0 1-7 * " + ((int)day).ToString();
+            string actual = Cron.Monthly(day);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Monthly_WithDayOfTheWeek_ReturnsFormattedStringWithDayHour()
+        {
+            DayOfWeek day = DayOfWeek.Tuesday;
+            int hour = 5;
+            string expected = "0 " + hour.ToString() + " 1-7 * " + ((int)day).ToString();
+            string actual = Cron.Monthly(day, hour);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Monthly_WithDayOfTheWeek_ReturnsFormattedStringWithDayHourMinute()
+        {
+            DayOfWeek day = DayOfWeek.Tuesday;
+            int hour = 5;
+            int minute = 5;
+            string expected = minute.ToString() + " " + hour.ToString() + " 1-7 * " + ((int)day).ToString();
+            string actual = Cron.Monthly(day, hour, minute);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void Yearly_WithoutMonthDayHourMinute_ReturnsFormattedStringWithDefaults()
         {
             string expected = "0 0 1 1 *";


### PR DESCRIPTION
Added a set of cron expressions that will run on the first specified day in the month. 
e.g. First Tuesday of the month: `Cron.Monthly(DayOfTheWeek.Tuesday)` returns `0 0 1-7 * 2`. 

The key part of the expression is the `1-7` range for day. I used the Crontab syntax, I hope that is the correct for Hangfire.

Apart from the unit tests to confirm the expression output, how can I test that this correct?
