### PR TITLE
Update twitter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hangfire 
 =========
 
-#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
+#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |[Twitter](https://twitter.com/hangfireio) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
 
 | Windows / .NET | Linux / Mono
 | --- | ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hangfire 
 =========
 
-#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) | [Twitter](https://twitter.com/hangfire_net) | [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
+#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
 
 | Windows / .NET | Linux / Mono
 | --- | ---


### PR DESCRIPTION
The twitter link `[Twitter](https://twitter.com/hangfire_net) |` was dead. Removed that from the README.md