### PR TITLE
Expose deserialized job arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Building the sources
 
 To build a solution and get assembly files, just run the following command. All build artifacts, including `*.pdb` files will be placed into the `build` folder. **Before proposing a pull request, please use this command to ensure everything is ok.** Btw, you can execute this command from Package Manager Console window.
 
+Note that the build command will run the unit and integration tests as well so by default you will need SQL Server Express installed (not LocalDB) with default instance name of SQLExpress. Also ensure your dev machine has MSMQ installed so that the MSMQ unit tests pass. If you don't have MSMQ installed then it will try to run the RabbitMQ tests.
+
 ```
 build
 ```

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -102,12 +102,11 @@ namespace Hangfire.Common
             object result = null;
             try
             {
+                var deserializedArguments = DeserializeArguments(cancellationToken);
                 if (!Method.IsStatic)
                 {
                     instance = Activate(activator);
-                }
-
-                var deserializedArguments = DeserializeArguments(cancellationToken);
+                }                
                 result = InvokeMethod(instance, deserializedArguments);
             }
             finally
@@ -245,7 +244,7 @@ namespace Hangfire.Common
         {
             try
             {
-                var instance = activator.ActivateJob(Type);
+                var instance = activator.ActivateJob(Type, this);
 
                 if (instance == null)
                 {

--- a/src/Hangfire.Core/JobActivator.cs
+++ b/src/Hangfire.Core/JobActivator.cs
@@ -15,6 +15,7 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using Hangfire.Common;
 
 namespace Hangfire
 {
@@ -41,6 +42,18 @@ namespace Hangfire
         }
 
         public virtual object ActivateJob(Type jobType)
+        {
+            return Activator.CreateInstance(jobType);
+        }
+
+        /// <summary>
+        /// Override that allows the Job details to be passed in so that implementor 
+        /// can retrieve more information about the job to properly create the given type
+        /// </summary>
+        /// <param name="jobType"></param>
+        /// <param name="job">The job that is about to be created</param>
+        /// <returns></returns>
+        public virtual object ActivateJob(Type jobType, Job job)
         {
             return Activator.CreateInstance(jobType);
         }

--- a/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
@@ -18,7 +18,7 @@ namespace Hangfire.Core.Tests.Common
 		public JobArgumentFacts()
 		{
 			_activator = new Mock<JobActivator>();
-			_activator.Setup(x => x.ActivateJob(It.IsAny<Type>()))
+			_activator.Setup(x => x.ActivateJob(It.IsAny<Type>(), It.IsAny<Job>()))
 				      .Returns(() => new JobArgumentFacts());
 
 			_token = new Mock<IJobCancellationToken>();

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -356,7 +356,7 @@ namespace Hangfire.Core.Tests.Common
         public void Perform_ThrowsPerformanceException_WhenActivatorThrowsAnException()
         {
             var exception = new InvalidOperationException();
-            _activator.Setup(x => x.ActivateJob(It.IsAny<Type>())).Throws(exception);
+            _activator.Setup(x => x.ActivateJob(It.IsAny<Type>(), It.IsAny<Job>())).Throws(exception);
 
             var job = Job.FromExpression(() => InstanceMethod());
 
@@ -369,7 +369,7 @@ namespace Hangfire.Core.Tests.Common
         [Fact]
         public void Perform_ThrowsPerformanceException_WhenActivatorReturnsNull()
         {
-            _activator.Setup(x => x.ActivateJob(It.IsNotNull<Type>())).Returns(null);
+            _activator.Setup(x => x.ActivateJob(It.IsNotNull<Type>(), It.IsNotNull<Job>())).Returns(null);
             var job = Job.FromExpression(() => InstanceMethod());
 
             var thrownException = Assert.Throws<JobPerformanceException>(


### PR DESCRIPTION
The Job object now exposed the de-serialized arguments rather than just the string array of arguments. Makes it easier for person implementing the JobActivator to get back to the original intent of things.