### PR TITLE
Remove the `with tablock` hint from the expiration cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hangfire 
 =========
 
-#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
+#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |[Twitter](https://twitter.com/hangfireio) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
 
 | Windows / .NET | Linux / Mono
 | --- | ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hangfire 
 =========
 
-#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) | [Twitter](https://twitter.com/hangfire_net) | [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
+#### [Official Site](http://hangfire.io) | [Blog](http://odinserj.net) | [Documentation](http://docs.hangfire.io) | [Forum](http://discuss.hangfire.io) |  [NuGet Packages](https://www.nuget.org/packages?q=hangfire)
 
 | Windows / .NET | Linux / Mono
 | --- | ---

--- a/src/Hangfire.SqlServer/ExpirationManager.cs
+++ b/src/Hangfire.SqlServer/ExpirationManager.cs
@@ -69,7 +69,7 @@ namespace Hangfire.SqlServer
                         removedCount = storageConnection.Connection.Execute(
                             String.Format(@"
 set transaction isolation level read committed;
-delete top (@count) from HangFire.[{0}] with (tablock) where ExpireAt < @now;", table),
+delete top (@count) from HangFire.[{0}] where ExpireAt < @now;", table),
                             new { now = DateTime.UtcNow, count = NumberOfRecordsInSinglePass });
                     }
 


### PR DESCRIPTION
retargeting dev branch.