### PR TITLE
Outer context for job execution by UnitOfWorkManager.

### DIFF
--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using Hangfire.Logging;
 using Hangfire.Server;
 using Hangfire.States;
+using Hangfire.UnitOfWork;
 
 namespace Hangfire
 {
@@ -146,6 +147,7 @@ namespace Hangfire
                 _storage,
                 new JobPerformanceProcess(),
                 JobActivator.Current,
+                UnitOfWorkManager.Current,
                 stateMachineFactory);
 
             yield return new WorkerManager(sharedWorkerContext, _options.WorkerCount);

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Dashboard\RazorPageDispatcher.cs" />
     <Compile Include="Dashboard\RequestExtensions.cs" />
     <Compile Include="IBootstrapperConfiguration.cs" />
+    <Compile Include="UnitOfWork\IUnitOfWorkManager.cs" />
     <Compile Include="OwinBootstrapper.cs" />
     <Compile Include="Properties\Annotations.cs" />
     <Compile Include="RecurringJob.cs" />
@@ -331,6 +332,7 @@
     <Compile Include="Storage\RecurringJobDto.cs" />
     <Compile Include="Storage\StateData.cs" />
     <Compile Include="Storage\StorageConnectionExtensions.cs" />
+    <Compile Include="UnitOfWork\UnitOfWorkManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.eot" />

--- a/src/Hangfire.Core/IBootstrapperConfiguration.cs
+++ b/src/Hangfire.Core/IBootstrapperConfiguration.cs
@@ -16,6 +16,7 @@
 
 using System;
 using Hangfire.Dashboard;
+using Hangfire.UnitOfWork;
 
 namespace Hangfire
 {
@@ -58,8 +59,15 @@ namespace Hangfire
         /// Tells bootstrapper to register the given instance of the
         /// <see cref="JobActivator"/> class globally.
         /// </summary>
-        /// <param name="activator">Job storage</param>
+        /// <param name="activator">Job activator</param>
         void UseActivator(JobActivator activator);
+
+        /// <summary>
+        /// Tells bootstrapper to register the given instance of the
+        /// <see cref="IUnitOfWorkManager"/> class globally.
+        /// </summary>
+        /// <param name="unitOfWorkManager">Unit of work manager</param>
+        void UseUnitOfWorkManager(IUnitOfWorkManager unitOfWorkManager);
 
         /// <summary>
         /// Tells bootstrapper to start the given job server on application

--- a/src/Hangfire.Core/OwinBootstrapper.cs
+++ b/src/Hangfire.Core/OwinBootstrapper.cs
@@ -18,6 +18,7 @@ using System;
 using Hangfire.Annotations;
 using Hangfire.Dashboard;
 using Hangfire.Server;
+using Hangfire.UnitOfWork;
 using Owin;
 
 namespace Hangfire
@@ -44,6 +45,11 @@ namespace Hangfire
             if (configuration.Activator != null)
             {
                 JobActivator.Current = configuration.Activator;
+            }
+
+            if (configuration.UnitOfWorkManager != null)
+            {
+                UnitOfWorkManager.Current = configuration.UnitOfWorkManager;
             }
 
             if (configuration.Storage == null)

--- a/src/Hangfire.Core/Server/IJobPerformer.cs
+++ b/src/Hangfire.Core/Server/IJobPerformer.cs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
+using Hangfire.UnitOfWork;
+
 namespace Hangfire.Server
 {
     public interface IJobPerformer
     {
-        object Perform(JobActivator activator, IJobCancellationToken cancellationToken);
+        object Perform(JobActivator activator, IUnitOfWorkManager unitOfWorkManager, IJobCancellationToken cancellationToken);
     }
 }

--- a/src/Hangfire.Core/Server/JobPerformanceProcess.cs
+++ b/src/Hangfire.Core/Server/JobPerformanceProcess.cs
@@ -83,7 +83,7 @@ namespace Hangfire.Server
             var preContext = new PerformingContext(context);
             Func<PerformedContext> continuation = () =>
             {
-                result = performer.Perform(context.Activator, context.CancellationToken);
+                result = performer.Perform(context.Activator, context.UnitOfWorkManager, context.CancellationToken);
                 return new PerformedContext(context, result, false, null);
             };
 

--- a/src/Hangfire.Core/Server/SharedWorkerContext.cs
+++ b/src/Hangfire.Core/Server/SharedWorkerContext.cs
@@ -16,6 +16,7 @@
 
 using System;
 using Hangfire.States;
+using Hangfire.UnitOfWork;
 
 namespace Hangfire.Server
 {
@@ -27,6 +28,7 @@ namespace Hangfire.Server
             JobStorage storage,
             IJobPerformanceProcess performanceProcess,
             JobActivator activator,
+            IUnitOfWorkManager unitOfWorkManager,
             IStateMachineFactory stateMachineFactory)
         {
             if (serverId == null) throw new ArgumentNullException("serverId");
@@ -34,6 +36,7 @@ namespace Hangfire.Server
             if (storage == null) throw new ArgumentNullException("storage");
             if (performanceProcess == null) throw new ArgumentNullException("performanceProcess");
             if (activator == null) throw new ArgumentNullException("activator");
+            if (unitOfWorkManager == null) throw new ArgumentNullException("unitOfWorkManager");
             if (stateMachineFactory == null) throw new ArgumentNullException("stateMachineFactory");
 
             ServerId = serverId;
@@ -41,11 +44,12 @@ namespace Hangfire.Server
             Storage = storage;
             PerformanceProcess = performanceProcess;
             Activator = activator;
+            UnitOfWorkManager = unitOfWorkManager;
             StateMachineFactory = stateMachineFactory;
         }
 
         internal SharedWorkerContext(SharedWorkerContext context)
-            : this(context.ServerId, context.Queues, context.Storage, context.PerformanceProcess, context.Activator, context.StateMachineFactory)
+            : this(context.ServerId, context.Queues, context.Storage, context.PerformanceProcess, context.Activator, context.UnitOfWorkManager, context.StateMachineFactory)
         {
         }
 
@@ -56,6 +60,7 @@ namespace Hangfire.Server
 
         internal IJobPerformanceProcess PerformanceProcess { get; private set; }
         internal JobActivator Activator { get; private set; }
+        internal IUnitOfWorkManager UnitOfWorkManager { get; private set; }
         internal IStateMachineFactory StateMachineFactory { get; private set; }
     }
 }

--- a/src/Hangfire.Core/StartupConfiguration.cs
+++ b/src/Hangfire.Core/StartupConfiguration.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Hangfire.Dashboard;
+using Hangfire.UnitOfWork;
 
 namespace Hangfire
 {
@@ -35,6 +36,7 @@ namespace Hangfire
         public string DashboardPath { get; private set; }
         public JobStorage Storage { get; private set; }
         public JobActivator Activator { get; private set; }
+        public IUnitOfWorkManager UnitOfWorkManager { get; private set; }
         public List<Func<BackgroundJobServer>> Servers { get; private set; }
         public IAuthorizationFilter[] AuthorizationFilters { get; private set; }
         public List<object> Filters { get; private set; } 
@@ -62,6 +64,11 @@ namespace Hangfire
         public void UseActivator(JobActivator activator)
         {
             Activator = activator;
+        }
+
+        public void UseUnitOfWorkManager(IUnitOfWorkManager unitOfWorkManager)
+        {
+            UnitOfWorkManager = unitOfWorkManager;
         }
 
         public void UseServer(Func<BackgroundJobServer> server)

--- a/src/Hangfire.Core/UnitOfWork/IUnitOfWorkManager.cs
+++ b/src/Hangfire.Core/UnitOfWork/IUnitOfWorkManager.cs
@@ -1,0 +1,36 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Hangfire.UnitOfWork
+{
+    public interface IUnitOfWorkManager
+    {
+        /// <summary>
+        /// Called before job is processed.
+        /// <returns>Unit of work context.</returns>
+        /// </summary>
+        object Begin();
+
+        /// <summary>
+        /// Called after job was processed, if an error has occurred the exception will be passed.
+        /// <paramref name="context">Unit of work context.</paramref>
+        /// <paramref name="ex">Exception if thrown, null otherwise.</paramref>
+        /// </summary>
+        void End(object context, Exception ex = null);
+    }
+}

--- a/src/Hangfire.Core/UnitOfWork/UnitOfWorkManager.cs
+++ b/src/Hangfire.Core/UnitOfWork/UnitOfWorkManager.cs
@@ -1,0 +1,53 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Hangfire.UnitOfWork
+{
+    public class UnitOfWorkManager : IUnitOfWorkManager
+    {
+        private static IUnitOfWorkManager _current = new UnitOfWorkManager();
+
+        /// <summary>
+        /// Gets or sets the current <see cref="IUnitOfWorkManager"/> instance 
+        /// that will be used to manage unit of work context during job processing.
+        /// </summary>
+        public static IUnitOfWorkManager Current
+        {
+            get { return _current; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                _current = value;
+            }
+        }
+
+        public object Begin()
+        {
+            return new object();
+        }
+
+        public void End(object context, Exception ex = null)
+        {
+            return;
+        }
+    }
+}

--- a/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobArgumentFacts.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using Hangfire.Common;
+using Hangfire.UnitOfWork;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -13,6 +13,7 @@ namespace Hangfire.Core.Tests.Common
 	public class JobArgumentFacts
 	{
 		private readonly Mock<JobActivator> _activator;
+	    private readonly Mock<IUnitOfWorkManager> _unitOfWorkManager;
 		private readonly Mock<IJobCancellationToken> _token;
 
 		public JobArgumentFacts()
@@ -20,6 +21,9 @@ namespace Hangfire.Core.Tests.Common
 			_activator = new Mock<JobActivator>();
 			_activator.Setup(x => x.ActivateJob(It.IsAny<Type>()))
 				      .Returns(() => new JobArgumentFacts());
+
+            _unitOfWorkManager = new Mock<IUnitOfWorkManager>();
+		    _unitOfWorkManager.Setup(x => x.Begin()).Returns(() => new object());
 
 			_token = new Mock<IJobCancellationToken>();
 		}
@@ -317,7 +321,7 @@ namespace Hangfire.Core.Tests.Common
 			foreach (var method in serializationMethods)
 			{
 				var job = new Job(type, methodInfo, new[] { method.Item2() });
-				job.Perform(_activator.Object, _token.Object);	
+				job.Perform(_activator.Object, _unitOfWorkManager.Object, _token.Object);	
 			}
 		}
 	}

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Storage\InvocationDataFacts.cs" />
     <Compile Include="Storage\MonitoringTypeFacts.cs" />
     <Compile Include="Storage\StorageConnectionExtensionsFacts.cs" />
+    <Compile Include="UnitOfWorkManagerFacts.cs" />
     <Compile Include="Utils\GlobalLockAttribute.cs" />
     <Compile Include="Utils\PossibleHangingFactAttribute.cs" />
     <Compile Include="Utils\SequenceAttribute.cs" />

--- a/tests/Hangfire.Core.Tests/Mocks/SharedWorkerContextMock.cs
+++ b/tests/Hangfire.Core.Tests/Mocks/SharedWorkerContextMock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Hangfire.Server;
 using Hangfire.States;
+using Hangfire.UnitOfWork;
 using Moq;
 
 namespace Hangfire.Core.Tests
@@ -16,6 +17,7 @@ namespace Hangfire.Core.Tests
             Storage = new Mock<JobStorage>();
             PerformanceProcess = new Mock<IJobPerformanceProcess>();
             Activator = new Mock<JobActivator>();
+            UnitOfWorkManager = new Mock<IUnitOfWorkManager>();
             StateMachineFactory = new Mock<IStateMachineFactory>();
 
             _context = new Lazy<SharedWorkerContext>(
@@ -25,6 +27,7 @@ namespace Hangfire.Core.Tests
                     Storage.Object,
                     PerformanceProcess.Object,
                     Activator.Object,
+                    UnitOfWorkManager.Object,
                     StateMachineFactory.Object));
         }
 
@@ -35,6 +38,7 @@ namespace Hangfire.Core.Tests
         public Mock<JobStorage> Storage { get; set; }
         public Mock<IJobPerformanceProcess> PerformanceProcess { get; set; } 
         public Mock<JobActivator> Activator { get; set; }
+        public Mock<IUnitOfWorkManager> UnitOfWorkManager { get; set; }
         public Mock<IStateMachineFactory> StateMachineFactory { get; set; } 
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/JobPerformanceProcessFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/JobPerformanceProcessFacts.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Hangfire.Common;
 using Hangfire.Server;
 using Hangfire.Storage;
+using Hangfire.UnitOfWork;
 using Moq;
 using Moq.Sequences;
 using Xunit;
@@ -60,7 +61,7 @@ namespace Hangfire.Core.Tests.Server
             process.Run(_context, _performer.Object);
 
             _performer.Verify(
-                x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IJobCancellationToken>()), 
+                x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsNotNull<IJobCancellationToken>()), 
                 Times.Once);
         }
 
@@ -72,7 +73,7 @@ namespace Hangfire.Core.Tests.Server
             var process = CreateProcess();
 
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsNotNull<IJobCancellationToken>()))
                 .Returns("Returned value");
 
             // Act
@@ -91,7 +92,7 @@ namespace Hangfire.Core.Tests.Server
             var process = CreateProcess();
 
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsNotNull<IJobCancellationToken>()))
                 .Returns("Returned value");
 
             // Act
@@ -106,7 +107,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<InvalidOperationException>();
 
             var process = CreateProcess();
@@ -123,7 +124,7 @@ namespace Hangfire.Core.Tests.Server
             var filter = CreateFilter<IServerExceptionFilter>();
 
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<InvalidOperationException>();
             
             var process = CreateProcess();
@@ -147,7 +148,7 @@ namespace Hangfire.Core.Tests.Server
             filter1.Setup(x => x.OnServerException(It.IsAny<ServerExceptionContext>())).InSequence();
 
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<InvalidOperationException>();
 
             var process = CreateProcess();
@@ -164,7 +165,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<InvalidOperationException>();
 
             var filter = CreateFilter<IServerExceptionFilter>();
@@ -186,7 +187,7 @@ namespace Hangfire.Core.Tests.Server
             filter.Setup(x => x.OnPerforming(It.IsNotNull<PerformingContext>()))
                 .InSequence();
 
-            _performer.Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+            _performer.Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .InSequence();
 
             filter.Setup(x => x.OnPerformed(It.IsNotNull<PerformedContext>()))
@@ -236,7 +237,7 @@ namespace Hangfire.Core.Tests.Server
 
             // Assert
             _performer.Verify(
-                x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IJobCancellationToken>()), 
+                x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()), 
                 Times.Never);
 
             filter.Verify(x => x.OnPerformed(It.IsAny<PerformedContext>()), Times.Never);
@@ -280,7 +281,7 @@ namespace Hangfire.Core.Tests.Server
             Assert.IsType<InvalidOperationException>(exception.InnerException);
 
             _performer.Verify(
-                x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IJobCancellationToken>()), 
+                x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()), 
                 Times.Never);
 
             filter.Verify(x => x.OnPerformed(It.IsAny<PerformedContext>()), Times.Never);
@@ -294,7 +295,7 @@ namespace Hangfire.Core.Tests.Server
 
             var exception = new InvalidOperationException();
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws(exception);
 
             var process = CreateProcess();
@@ -317,7 +318,7 @@ namespace Hangfire.Core.Tests.Server
 
             var exception = new InvalidOperationException();
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws(exception);
 
             var process = CreateProcess();
@@ -337,7 +338,7 @@ namespace Hangfire.Core.Tests.Server
 
             var exception = new InvalidOperationException();
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws(exception);
 
             filter.Setup(x => x.OnPerformed(It.Is<PerformedContext>(context => context.Exception == exception)))
@@ -357,7 +358,7 @@ namespace Hangfire.Core.Tests.Server
             var innerFilter = CreateFilter<IServerFilter>();
             
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<InvalidOperationException>();
 
             innerFilter.Setup(x => x.OnPerformed(It.IsAny<PerformedContext>()))
@@ -398,7 +399,7 @@ namespace Hangfire.Core.Tests.Server
                 .Throws<InvalidOperationException>();
 
             _performer
-                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsNotNull<JobActivator>(), It.IsNotNull<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<ArgumentNullException>();
 
             var process = CreateProcess();
@@ -415,7 +416,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             _performer
-                .Setup(x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IJobCancellationToken>()))
+                .Setup(x => x.Perform(It.IsAny<JobActivator>(), It.IsAny<IUnitOfWorkManager>(), It.IsAny<IJobCancellationToken>()))
                 .Throws<OperationCanceledException>();
 
             var filter = CreateFilter<IServerExceptionFilter>();

--- a/tests/Hangfire.Core.Tests/Server/SharedWorkerContextFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/SharedWorkerContextFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Hangfire.Server;
 using Hangfire.States;
+using Hangfire.UnitOfWork;
 using Moq;
 using Xunit;
 
@@ -13,6 +14,7 @@ namespace Hangfire.Core.Tests.Server
 
         private readonly Mock<IJobPerformanceProcess> _performanceProcess;
         private readonly Mock<JobActivator> _activator;
+        private readonly Mock<IUnitOfWorkManager> _unitOfWorkManager;
         private readonly Mock<IStateMachineFactory> _stateMachineFactory;
         private readonly Mock<JobStorage> _storage;
 
@@ -20,6 +22,7 @@ namespace Hangfire.Core.Tests.Server
         {
             _performanceProcess = new Mock<IJobPerformanceProcess>();
             _activator = new Mock<JobActivator>();
+            _unitOfWorkManager = new Mock<IUnitOfWorkManager>();
             _stateMachineFactory = new Mock<IStateMachineFactory>();
             _storage = new Mock<JobStorage>();
         }
@@ -29,7 +32,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    null, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, _stateMachineFactory.Object));
+                    null, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, _unitOfWorkManager.Object, _stateMachineFactory.Object));
 
             Assert.Equal("serverId", exception.ParamName);
         }
@@ -39,7 +42,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    ServerId, null, _storage.Object, _performanceProcess.Object, _activator.Object, _stateMachineFactory.Object));
+                    ServerId, null, _storage.Object, _performanceProcess.Object, _activator.Object, _unitOfWorkManager.Object, _stateMachineFactory.Object));
 
             Assert.Equal("queues", exception.ParamName);
         }
@@ -49,7 +52,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    ServerId, Queues, null, _performanceProcess.Object, _activator.Object, _stateMachineFactory.Object));
+                    ServerId, Queues, null, _performanceProcess.Object, _activator.Object, _unitOfWorkManager.Object, _stateMachineFactory.Object));
 
             Assert.Equal("storage", exception.ParamName);
         }
@@ -59,7 +62,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    ServerId, Queues, _storage.Object, null, _activator.Object, _stateMachineFactory.Object));
+                    ServerId, Queues, _storage.Object, null, _activator.Object, _unitOfWorkManager.Object, _stateMachineFactory.Object));
 
             Assert.Equal("performanceProcess", exception.ParamName);
         }
@@ -69,9 +72,19 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    ServerId, Queues, _storage.Object, _performanceProcess.Object, null, _stateMachineFactory.Object));
+                    ServerId, Queues, _storage.Object, _performanceProcess.Object, null, _unitOfWorkManager.Object, _stateMachineFactory.Object));
 
             Assert.Equal("activator", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenUnitOfWorkManagerIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new SharedWorkerContext(
+                    ServerId, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, null, _stateMachineFactory.Object));
+
+            Assert.Equal("unitOfWorkManager", exception.ParamName);
         }
 
         [Fact]
@@ -79,7 +92,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new SharedWorkerContext(
-                    ServerId, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, null));
+                    ServerId, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, _unitOfWorkManager.Object, null));
 
             Assert.Equal("stateMachineFactory", exception.ParamName);
         }
@@ -114,7 +127,7 @@ namespace Hangfire.Core.Tests.Server
         private SharedWorkerContext CreateContext()
         {
             return new SharedWorkerContext(
-                ServerId, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, _stateMachineFactory.Object);
+                ServerId, Queues, _storage.Object, _performanceProcess.Object, _activator.Object, _unitOfWorkManager.Object, _stateMachineFactory.Object);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/WorkerManagerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/WorkerManagerFacts.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using Hangfire.Server;
 using Hangfire.States;
+using Hangfire.UnitOfWork;
 using Moq;
 using Xunit;
 
@@ -24,6 +25,7 @@ namespace Hangfire.Core.Tests.Server
                 new Mock<JobStorage>().Object,
                 new Mock<IJobPerformanceProcess>().Object,
                 new Mock<JobActivator>().Object,
+                new Mock<IUnitOfWorkManager>().Object, 
                 new Mock<IStateMachineFactory>().Object);
 
             _workerSupervisors = new[]

--- a/tests/Hangfire.Core.Tests/UnitOfWorkManagerFacts.cs
+++ b/tests/Hangfire.Core.Tests/UnitOfWorkManagerFacts.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Hangfire.UnitOfWork;
+using Xunit;
+
+namespace Hangfire.Core.Tests
+{
+    public class UnitOfWorkManagerFacts
+    {
+        [Fact, GlobalLock]
+        public void SetCurrent_ThrowsAnException_WhenValueIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnitOfWorkManager.Current = null);
+        }
+
+        [Fact, GlobalLock]
+        public void GetCurrent_ReturnsPreviouslySetValue()
+        {
+            var unitOfWorkManager = new UnitOfWorkManager();
+            UnitOfWorkManager.Current = unitOfWorkManager;
+
+            Assert.Same(unitOfWorkManager, UnitOfWorkManager.Current);
+        }
+    }
+}


### PR DESCRIPTION
`UnitOfWorkManager` provides outer context for job execution which is useful for scopes management (database transactions, DI container scopes etc.) and for externalization of any other kind of repetitive code on begin or end of each executed task.

To use `UnitOfWorkManager` you have to implement interface `IUnitOfWorkManager` and provide your implementation to Hangfire configuration. This is very similar to `JobActivator` usage.

For example to create `WindorContainer` scope for each job execution context you can use blow implementation:
```csharp
class WindsorContainerScopeUnitOfWorkManager : IUnitOfWorkManager
{
  private readonly IWindsorContainer _container;

  public WindsorContainerScopeUnitOfWorkManager(IWindsorContainer container)
  {
     _container = container;
  }

  public object Begin()
  {
    return _container.BeginScope();
  }

  public void End(object context, Exception ex = null)
  {
    ((IDisposable) context).Dispose();
  }
}
```
And register it in Hangfire like below:
```csharp
app.UseHangfire(config =>
{
    config.UseActivator(new WindsorJobActivator(_container.Kernel));
    config.UseUnitOfWorkManager(new WindsorContainerScopeUnitOfWorkManager(_container));
});
```