### PR TITLE
Fixed incompatibility issue with RabbitMQ.Client >=v3.4.0

### DIFF
--- a/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.csproj
+++ b/src/Hangfire.SqlServer.RabbitMq/Hangfire.SqlServer.RabbitMq.csproj
@@ -38,9 +38,9 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.4.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.3.0\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.4.0\lib\net35\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Hangfire.SqlServer.RabbitMq/RabbitMqFetchedJob.cs
+++ b/src/Hangfire.SqlServer.RabbitMq/RabbitMqFetchedJob.cs
@@ -36,7 +36,7 @@ namespace Hangfire.SqlServer.RabbitMQ
         {
             if (_completed) throw new InvalidOperationException("Job already completed");
             _channel.BasicNack(_message.DeliveryTag, false, true);
-            _channel.Close(global::RabbitMQ.Client.Framing.v0_9_1.Constants.ReplySuccess, "Requeue");
+            _channel.Close(global::RabbitMQ.Client.Framing.Constants.ReplySuccess, "Requeue");
 
             _completed = true;
         }

--- a/src/Hangfire.SqlServer.RabbitMq/packages.config
+++ b/src/Hangfire.SqlServer.RabbitMq/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RabbitMQ.Client" version="3.3.0" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.4.0" targetFramework="net45" />
 </packages>

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.csproj
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/Hangfire.SqlServer.RabbitMq.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,9 +36,9 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.3.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.4.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.3.0\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.4.0\lib\net35\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
+++ b/tests/Hangfire.SqlServer.RabbitMq.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="RabbitMQ.Client" version="3.3.0" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="3.4.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In RabbitMQ.Client v3.4.0 there was introduced some namespace changes making it incompatible with current code.
Simply updated package dependencies and code for it.