### PR TITLE
Arguments Render now supports TimeSpan and DateTime

### DIFF
--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -332,6 +332,18 @@ namespace Hangfire.Dashboard
                     };
                 }
 
+                if (type == typeof(TimeSpan) || type == typeof(DateTime))
+                {
+                    return new ArgumentRenderer
+                    {
+                        _enclosingString = String.Empty,
+                        _valueRenderer = value => String.Format(
+                            "{0}.Parse({1})",
+                            WrapType(type.Name),
+                            WrapString(string.Format("\"{0}\"", value)))
+                    };
+                }
+
                 return new ArgumentRenderer
                 {
                     _deserializationType = type,


### PR DESCRIPTION
When rendering the Job Details page:
TimeSpan parameters are now rendered as TimeSpan.Parse("12:13:14")
rather than FromJson<TimeSpan>("\"12:13:14\"")
DateTime parameters are now rendered as
DateTime.Parse("2012-11-10T00:00:00.0000000") rather than
Deserialize<DateTime>("2012-11-10T00:00:00.0000000")

Please see issue #353 (ArgumentRenderer - Support for TimeSpan and DateTime)

![image](https://cloud.githubusercontent.com/assets/1834655/7442772/748e0018-f117-11e4-8512-24409923fe66.png)