### PR TITLE
Job serialization fix when using TypeNameHandling.All

### DIFF
--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -70,7 +70,7 @@ namespace Hangfire.Storage
             return new InvocationData(
                 job.Type.AssemblyQualifiedName,
                 job.Method.Name,
-                JobHelper.ToJson(job.Method.GetParameters().Select(x => x.ParameterType)),
+                JobHelper.ToJson(job.Method.GetParameters().Select(x => x.ParameterType).ToArray()),
                 JobHelper.ToJson(job.Arguments));
         }
 

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Runtime.Serialization.Formatters;
 using Hangfire.Common;
+using Hangfire.Storage;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Xunit;
@@ -166,6 +168,34 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
+        public void ForDeserializeCanUseCustomConfigurationOfJsonNetWithInvocationData()
+        {
+            try
+            {
+                JobHelper.SetSerializerSettings(new JsonSerializerSettings
+                {
+                    TypeNameHandling = TypeNameHandling.All,
+                    TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
+                });
+
+                var method = typeof (BackgroundJob).GetMethod("DoWork");
+                var args = new[] {"123", "Test"};
+                var job = new Job(typeof(BackgroundJob), method, args);
+
+                var invocationData = InvocationData.Serialize(job);
+                var deserializedJob = invocationData.Deserialize();
+
+                Assert.Equal(typeof(BackgroundJob), deserializedJob.Type);
+                Assert.Equal(method, deserializedJob.Method);
+                Assert.Equal(args, deserializedJob.Arguments);
+            }
+            finally
+            {
+                JobHelper.SetSerializerSettings(null);
+            }
+        }
+
+        [Fact]
         public void ForDeserializeWithGenericMethodCanUseCustomConfigurationOfJsonNet()
         {
             try
@@ -196,6 +226,13 @@ namespace Hangfire.Core.Tests.Common
             }
 
             public string PropertyA { get; private set; }
+        }
+
+        private class BackgroundJob
+        {
+            public void DoWork(string workId, string message)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
I am serializing message DTOs into my hangfire jobs, and needed to specify `TypeNameHandling = TypeNameHandling.All` on the JsonSerializerSettings. Unfortunately this breaks the Job serialization as it attempts to serialize the unevaluated linq select statement for the method parameter array:

```
Hangfire.Common.JobLoadException : Could not load the job. See inner exception for the details.
---- Newtonsoft.Json.JsonSerializationException : Type specified in JSON 'System.Linq.Enumerable+WhereSelectArrayIterator`2[[System.Reflection.ParameterInfo, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Type, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' is not compatible with 'System.Type[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. Path '$type', line 1, position 142.
Result StackTrace:	
at Hangfire.Storage.InvocationData.Deserialize() in c:\Code\Hangfire\src\Hangfire.Core\Storage\InvocationData.cs:line 64
   at Hangfire.Core.Tests.Common.JobHelperFacts.ForDeserializeCanUseCustomConfigurationOfJsonNetWithInvocationData() in c:\Code\Hangfire\tests\Hangfire.Core.Tests\Common\JobHelperFacts.cs:line 186
----- Inner Stack Trace -----
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.ReadSpecialProperties(JsonReader reader, Type& objectType, JsonContract& contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue, Object& newValue, String& id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at Hangfire.Common.JobHelper.FromJson[T](String value) in c:\Code\Hangfire\src\Hangfire.Core\Common\JobHelper.cs:line 42
   at Hangfire.Storage.InvocationData.Deserialize() in c:\Code\Hangfire\src\Hangfire.Core\Storage\InvocationData.cs:line 46
```