### PR TITLE
Fetch recurring jobs using search criteria

### DIFF
--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -394,6 +394,7 @@
     <Compile Include="Storage\IWriteOnlyTransaction.cs" />
     <Compile Include="Storage\IStorageConnection.cs" />
     <Compile Include="Storage\JobData.cs" />
+    <Compile Include="Storage\SearchCriteria.cs" />
     <Compile Include="Storage\RecurringJobDto.cs" />
     <Compile Include="Storage\StateData.cs" />
     <Compile Include="Storage\StorageConnectionExtensions.cs" />

--- a/src/Hangfire.Core/Storage/IStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/IStorageConnection.cs
@@ -55,8 +55,8 @@ namespace Hangfire.Storage
         [NotNull]
         HashSet<string> GetAllItemsFromSet([NotNull] string key);
 
-		[NotNull]
-		HashSet<string> GetAllItemsFromSet([NotNull] string key, [NotNull] string valueFragment);
+        [NotNull]
+        HashSet<string> GetAllItemsFromSet([NotNull] string key, [NotNull] string valueFragment);
 
         string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 

--- a/src/Hangfire.Core/Storage/IStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/IStorageConnection.cs
@@ -55,6 +55,9 @@ namespace Hangfire.Storage
         [NotNull]
         HashSet<string> GetAllItemsFromSet([NotNull] string key);
 
+		[NotNull]
+		HashSet<string> GetAllItemsFromSet([NotNull] string key, [NotNull] string valueFragment);
+
         string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 
         // Hash operations

--- a/src/Hangfire.Core/Storage/IStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/IStorageConnection.cs
@@ -56,7 +56,7 @@ namespace Hangfire.Storage
         HashSet<string> GetAllItemsFromSet([NotNull] string key);
 
         [NotNull]
-        HashSet<string> GetAllItemsFromSet([NotNull] string key, [NotNull] string valueFragment);
+        HashSet<string> GetAllItemsFromSet([NotNull] string key, [NotNull] SearchCriteria criteria);
 
         string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 

--- a/src/Hangfire.Core/Storage/JobStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/JobStorageConnection.cs
@@ -49,7 +49,7 @@ namespace Hangfire.Storage
 
         // Sets
         public abstract HashSet<string> GetAllItemsFromSet(string key);
-        public abstract HashSet<string> GetAllItemsFromSet(string key, string valueFragment);
+        public abstract HashSet<string> GetAllItemsFromSet(string key, SearchCriteria criteria);
         public abstract string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 
         public virtual long GetSetCount([NotNull] string key)

--- a/src/Hangfire.Core/Storage/JobStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/JobStorageConnection.cs
@@ -49,7 +49,7 @@ namespace Hangfire.Storage
 
         // Sets
         public abstract HashSet<string> GetAllItemsFromSet(string key);
-		public abstract HashSet<string> GetAllItemsFromSet(string key, string valueFragment);
+        public abstract HashSet<string> GetAllItemsFromSet(string key, string valueFragment);
         public abstract string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 
         public virtual long GetSetCount([NotNull] string key)

--- a/src/Hangfire.Core/Storage/JobStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/JobStorageConnection.cs
@@ -49,6 +49,7 @@ namespace Hangfire.Storage
 
         // Sets
         public abstract HashSet<string> GetAllItemsFromSet(string key);
+		public abstract HashSet<string> GetAllItemsFromSet(string key, string valueFragment);
         public abstract string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
 
         public virtual long GetSetCount([NotNull] string key)

--- a/src/Hangfire.Core/Storage/SearchCriteria.cs
+++ b/src/Hangfire.Core/Storage/SearchCriteria.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Storage
+{
+    public class SearchCriteria
+    {
+        public SearchMode SearchMode { get; set; }
+
+        public string Text { get; set; }
+    }
+
+    public enum SearchMode
+    {
+        Contains,
+        StartsWith,
+        EndsWith
+    }
+}

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -62,11 +62,11 @@ namespace Hangfire.Storage
             return GetRecurringJobDtos(connection, ids);
         }
 
-        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, string jobIdFragment)
+        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, SearchCriteria criteria)
         {
             if (connection == null) throw new ArgumentNullException("connection");
 
-            var ids = connection.GetAllItemsFromSet("recurring-jobs", jobIdFragment);
+            var ids = connection.GetAllItemsFromSet("recurring-jobs", criteria);
             return GetRecurringJobDtos(connection, ids);
         }
 

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -62,9 +62,10 @@ namespace Hangfire.Storage
             return GetRecurringJobDtos(connection, ids);
         }
 
-        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, SearchCriteria criteria)
+        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, [NotNull] SearchCriteria criteria)
         {
             if (connection == null) throw new ArgumentNullException("connection");
+            if (criteria == null) throw new ArgumentNullException("criteria");
 
             var ids = connection.GetAllItemsFromSet("recurring-jobs", criteria);
             return GetRecurringJobDtos(connection, ids);

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -62,13 +62,13 @@ namespace Hangfire.Storage
             return GetRecurringJobDtos(connection, ids);
         }
 
-		public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, string jobIdFragment)
-		{
-			if (connection == null) throw new ArgumentNullException("connection");
+        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, string jobIdFragment)
+        {
+            if (connection == null) throw new ArgumentNullException("connection");
 
-			var ids = connection.GetAllItemsFromSet("recurring-jobs", jobIdFragment);
-			return GetRecurringJobDtos(connection, ids);
-		}
+            var ids = connection.GetAllItemsFromSet("recurring-jobs", jobIdFragment);
+            return GetRecurringJobDtos(connection, ids);
+        }
 
         private static List<RecurringJobDto> GetRecurringJobDtos(IStorageConnection connection, IEnumerable<string> ids)
         {

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -62,6 +62,14 @@ namespace Hangfire.Storage
             return GetRecurringJobDtos(connection, ids);
         }
 
+		public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, string jobIdFragment)
+		{
+			if (connection == null) throw new ArgumentNullException("connection");
+
+			var ids = connection.GetAllItemsFromSet("recurring-jobs", jobIdFragment);
+			return GetRecurringJobDtos(connection, ids);
+		}
+
         private static List<RecurringJobDto> GetRecurringJobDtos(IStorageConnection connection, IEnumerable<string> ids)
         {
             var result = new List<RecurringJobDto>();

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -253,14 +253,30 @@ where j.Id = @jobId";
             return new HashSet<string>(result);
         }
 
-        public override HashSet<string> GetAllItemsFromSet(string key, string valueFragment)
+        public override HashSet<string> GetAllItemsFromSet(string key, SearchCriteria criteria)
         {
 	        if (key == null) throw new ArgumentNullException("key");
+            if (criteria == null) throw new ArgumentNullException("criteria");
 
-	        string valueContains = string.Format("%{0}%", valueFragment);
+            string valuePattern = null;
+            switch (criteria.SearchMode)
+            {
+                case SearchMode.Contains:
+                    valuePattern = string.Format("%{0}%", criteria.Text);
+                    break;
+                case SearchMode.StartsWith:
+                    valuePattern = string.Format("{0}%", criteria.Text);
+                    break;
+                case SearchMode.EndsWith:
+                    valuePattern = string.Format("%{0}", criteria.Text);
+                    break;
+                default: 
+                    throw new ArgumentNullException(string.Format("Unsupported search mode: {0}.", criteria.SearchMode));
+            }
+
 	        var result = _connection.Query<string>(
-		        @"select Value from HangFire.[Set] where [Key] = @key and Value like @valueContains",
-		        new { key, valueContains });
+                @"select Value from HangFire.[Set] where [Key] = @key and Value like @valuePattern",
+                new { key, valuePattern });
 
 	        return new HashSet<string>(result);
         }

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -255,7 +255,7 @@ where j.Id = @jobId";
 
         public override HashSet<string> GetAllItemsFromSet(string key, SearchCriteria criteria)
         {
-	        if (key == null) throw new ArgumentNullException("key");
+            if (key == null) throw new ArgumentNullException("key");
             if (criteria == null) throw new ArgumentNullException("criteria");
 
             string valuePattern = null;
@@ -274,11 +274,11 @@ where j.Id = @jobId";
                     throw new ArgumentNullException(string.Format("Unsupported search mode: {0}.", criteria.SearchMode));
             }
 
-	        var result = _connection.Query<string>(
+            var result = _connection.Query<string>(
                 @"select Value from HangFire.[Set] where [Key] = @key and Value like @valuePattern",
                 new { key, valuePattern });
 
-	        return new HashSet<string>(result);
+            return new HashSet<string>(result);
         }
 
         public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -253,17 +253,17 @@ where j.Id = @jobId";
             return new HashSet<string>(result);
         }
 
-		public override HashSet<string> GetAllItemsFromSet(string key, string valueFragment)
-		{
-			if (key == null) throw new ArgumentNullException("key");
+        public override HashSet<string> GetAllItemsFromSet(string key, string valueFragment)
+        {
+	        if (key == null) throw new ArgumentNullException("key");
 
-			string valueContains = string.Format("%{0}%", valueFragment);
-			var result = _connection.Query<string>(
-				@"select Value from HangFire.[Set] where [Key] = @key and Value like @valueContains",
-				new { key, valueContains });
+	        string valueContains = string.Format("%{0}%", valueFragment);
+	        var result = _connection.Query<string>(
+		        @"select Value from HangFire.[Set] where [Key] = @key and Value like @valueContains",
+		        new { key, valueContains });
 
-			return new HashSet<string>(result);
-		}
+	        return new HashSet<string>(result);
+        }
 
         public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
         {

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -253,6 +253,18 @@ where j.Id = @jobId";
             return new HashSet<string>(result);
         }
 
+		public override HashSet<string> GetAllItemsFromSet(string key, string valueFragment)
+		{
+			if (key == null) throw new ArgumentNullException("key");
+
+			string valueContains = string.Format("%{0}%", valueFragment);
+			var result = _connection.Query<string>(
+				@"select Value from HangFire.[Set] where [Key] = @key and Value like @valueContains",
+				new { key, valueContains });
+
+			return new HashSet<string>(result);
+		}
+
         public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
         {
             if (key == null) throw new ArgumentNullException("key");

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -25,6 +25,7 @@ using Hangfire.Common;
 using Hangfire.Server;
 using Hangfire.SqlServer.Entities;
 using Hangfire.Storage;
+using System.ComponentModel;
 
 namespace Hangfire.SqlServer
 {
@@ -270,8 +271,8 @@ where j.Id = @jobId";
                 case SearchMode.EndsWith:
                     valuePattern = string.Format("%{0}", criteria.Text);
                     break;
-                default: 
-                    throw new ArgumentNullException(string.Format("Unsupported search mode: {0}.", criteria.SearchMode));
+                default:
+                    throw new InvalidEnumArgumentException(string.Format("Unsupported search mode: {0}.", criteria.SearchMode));
             }
 
             var result = _connection.Query<string>(


### PR DESCRIPTION
With this change, users would be allowed to query Recurring Jobs by search criteria, where search criteria can be: RecurringJobID contains/starts with/ends with.

The purpose of the change: provided that we have millions of rows in HangFire.Set table, calling JobStorage.Current.GetConnection().GetRecurringJobs() and filtering results with Linq would not be performance efficient. Filtering at SQL level (this PR) is faster.
