### PR TITLE
Fixing bug in history when duration > int.MaxValue

### DIFF
--- a/src/Hangfire.Core/Dashboard/JobHistoryRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobHistoryRenderer.cs
@@ -129,7 +129,7 @@ namespace Hangfire.Dashboard
 
             if (stateData.ContainsKey("Latency"))
             {
-                var latency = TimeSpan.FromMilliseconds(long.Parse(stateData["Latency"]));
+                var latency = TimeSpan.FromMilliseconds(ulong.Parse(stateData["Latency"]));
 
                 builder.AppendFormat("<dt>Latency:</dt><dd>{0}</dd>", html.ToHumanDuration(latency, false));
 
@@ -138,7 +138,7 @@ namespace Hangfire.Dashboard
 
             if (stateData.ContainsKey("PerformanceDuration"))
             {
-                var duration = TimeSpan.FromMilliseconds(int.Parse(stateData["PerformanceDuration"]));
+                var duration = TimeSpan.FromMilliseconds(ulong.Parse(stateData["PerformanceDuration"]));
                 builder.AppendFormat("<dt>Duration:</dt><dd>{0}</dd>", html.ToHumanDuration(duration, false));
 
                 itemsAdded = true;


### PR DESCRIPTION
Fixing bug in history when duration is longer than int.MaxValue ms.