### PR TITLE
Add DisplayName property to Job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
-sudo: false
+sudo: required
 
 # Make sure build dependencies are installed.
 install:

--- a/Hangfire.sln
+++ b/Hangfire.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSample", "samples\ConsoleSample\ConsoleSample.csproj", "{C02BB718-2AE4-434C-8668-C894FF663FCE}"
 EndProject

--- a/Hangfire.sln
+++ b/Hangfire.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSample", "samples\ConsoleSample\ConsoleSample.csproj", "{C02BB718-2AE4-434C-8668-C894FF663FCE}"
 EndProject

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 License
 ========
 
-Copyright © 2013-2014 Sergey Odinokov.
+Copyright © 2013-2016 Sergey Odinokov.
 
 Hangfire is an Open Source project licensed under the terms of
 the LGPLv3 license.  Please see http://www.gnu.org/licenses/lgpl-3.0.html

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hangfire uses [psake](https://github.com/psake/psake) build automation tool. All
 License
 --------
 
-Copyright © 2013-2014 Sergey Odinokov.
+Copyright © 2013-2016 Sergey Odinokov.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Hangfire is available as a NuGet package. You can install it using the NuGet Pac
 PM> Install-Package Hangfire
 ```
 
-After installation, update your existing [OWIN Startup](http://www.asp.net/aspnet/overview/owin-and-katana/owin-startup-class-detection) file with the following lines of code. If you do not have this class in your project or don't know what is it, please read the [Quick start](http://docs.hangfire.io/en/latest/quickstart.html) guide to learn about how to install Hangfire.
+After installation, update your existing [OWIN Startup](http://www.asp.net/aspnet/overview/owin-and-katana/owin-startup-class-detection) file with the following lines of code. If you do not have this class in your project or don't know what is it, please read the [Quick start](http://docs.hangfire.io/en/latest/quick-start.html) guide to learn about how to install Hangfire.
 
 ```csharp
 public void Configuration(IAppBuilder app)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,9 +44,6 @@ nuget:
 #       build configuration       #
 #---------------------------------#
 
-install:
-  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
-
 # to run your custom scripts instead of automatic MSBuild
 build_script: build.bat pack
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,9 @@ nuget:
 #       build configuration       #
 #---------------------------------#
 
+install:
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+
 # to run your custom scripts instead of automatic MSBuild
 build_script: build.bat pack
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@
 # Don't edit manually! Use `build.bat version` command instead!
 version: 1.5.4-build-0{build}
 
+os: Visual Studio 2015
+
 #---------------------------------#
 #    environment configuration    #
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@
 # Don't edit manually! Use `build.bat version` command instead!
 version: 1.5.4-build-0{build}
 
-os: Visual Studio 2015
-
 #---------------------------------#
 #    environment configuration    #
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.5.3-build-0{build}
+version: 1.5.4-build-0{build}
 
 #---------------------------------#
 #    environment configuration    #

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,6 +14,12 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.5.4
+* Changed – C# 6.0 is now required to compile the solution.
+* Fixed – Recurring jobs failing after moving clock forward for daylight saving time.
+* Fixed – Infinite loops when trying to change state of a background job that doesn't exist (by @mkravchuk7).
+* Fixed – Update StackTraceParser and StackTraceFormatter to prevent critical flaw (by @atifaziz and @lukerogers).
+    
 1.5.2
 * Fixed – `JobLoadException` when using interface method as a background job, appeared in 1.5.1.
     

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>Core components for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2013-2015 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>MSMQ queues support for SQL Server job storage implementation for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2014-2015 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2014-2016 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer MSMQ</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>SQL Server 2008+ (including Express), SQL Server LocalDB and SQL Azure storage support for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2013-2015 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer SqlAzure LocalDB</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -18,6 +18,11 @@
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.5.4
+* Fixed – Recurring jobs failing after moving clock forward for daylight saving time.
+* Fixed – Infinite loops when trying to change state of a background job that doesn't exist (by @mkravchuk7).
+* Fixed – Update StackTraceParser to 1.1 to prevent critical flaw (by @atifaziz and @lukerogers).
+    
 1.5.3
 
 Hangfire.SqlServer

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -21,7 +21,7 @@
 1.5.4
 * Fixed – Recurring jobs failing after moving clock forward for daylight saving time.
 * Fixed – Infinite loops when trying to change state of a background job that doesn't exist (by @mkravchuk7).
-* Fixed – Update StackTraceParser to 1.1 to prevent critical flaw (by @atifaziz and @lukerogers).
+* Fixed – Update StackTraceParser and StackTraceFormatter to prevent critical flaw (by @atifaziz and @lukerogers).
     
 1.5.3
 

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -14,7 +14,7 @@
       Backed by Redis, SQL Server, SQL Azure or MSMQ. This is a .NET alternative to Sidekiq, Resque and Celery.
       http://hangfire.io/
     </description>
-    <copyright>Copyright © 2013-2015 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -19,6 +19,7 @@
     <releaseNotes>http://hangfire.io/blog/
     
 1.5.4
+* Changed – C# 6.0 is now required to compile the solution.
 * Fixed – Recurring jobs failing after moving clock forward for daylight saving time.
 * Fixed – Infinite loops when trying to change state of a background job that doesn't exist (by @mkravchuk7).
 * Fixed – Update StackTraceParser and StackTraceFormatter to prevent critical flaw (by @atifaziz and @lukerogers).

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -1,3 +1,4 @@
+Framework 4.5.1
 Properties {
     $solution = "Hangfire.sln"
     $opencover = "packages\OpenCover.*\opencover.console.exe"

--- a/src/Hangfire.Core/App_Packages/StackTraceFormatter/StackTraceFormatter.cs
+++ b/src/Hangfire.Core/App_Packages/StackTraceFormatter/StackTraceFormatter.cs
@@ -43,17 +43,17 @@ namespace Hangfire
         public string BeforeParameters    { get; set; }
         public string AfterParameters     { get; set; }
 
-        string IStackTraceFormatter<string>.Text(string text)            { return  string.IsNullOrEmpty(text) ? string.Empty : WebUtility.HtmlEncode(text); }
-        string IStackTraceFormatter<string>.Type(string markup)          { return  BeforeType          + markup + AfterType; }
-        string IStackTraceFormatter<string>.Method(string markup)        { return  BeforeMethod        + markup + AfterMethod; }
-        string IStackTraceFormatter<string>.ParameterType(string markup) { return  BeforeParameterType + markup + AfterParameterType; }
-        string IStackTraceFormatter<string>.ParameterName(string markup) { return  BeforeParameterName + markup + AfterParameterName; }
-        string IStackTraceFormatter<string>.File(string markup)          { return  BeforeFile          + markup + AfterFile; }
-        string IStackTraceFormatter<string>.Line(string markup)          { return  BeforeLine          + markup + AfterLine; }
-        string IStackTraceFormatter<string>.BeforeFrame                  { get { return  BeforeFrame      ?? string.Empty; } }
-        string IStackTraceFormatter<string>.AfterFrame                   { get { return  AfterFrame       ?? string.Empty; } }
-        string IStackTraceFormatter<string>.BeforeParameters             { get { return  BeforeParameters ?? string.Empty; } }
-        string IStackTraceFormatter<string>.AfterParameters              { get { return  AfterParameters  ?? string.Empty; } }
+        string IStackTraceFormatter<string>.Text(string text)            => string.IsNullOrEmpty(text) ? string.Empty : WebUtility.HtmlEncode(text);
+        string IStackTraceFormatter<string>.Type(string markup)          => BeforeType          + markup + AfterType;
+        string IStackTraceFormatter<string>.Method(string markup)        => BeforeMethod        + markup + AfterMethod;
+        string IStackTraceFormatter<string>.ParameterType(string markup) => BeforeParameterType + markup + AfterParameterType;
+        string IStackTraceFormatter<string>.ParameterName(string markup) => BeforeParameterName + markup + AfterParameterName;
+        string IStackTraceFormatter<string>.File(string markup)          => BeforeFile          + markup + AfterFile;
+        string IStackTraceFormatter<string>.Line(string markup)          => BeforeLine          + markup + AfterLine;
+        string IStackTraceFormatter<string>.BeforeFrame                  => BeforeFrame      ?? string.Empty;
+        string IStackTraceFormatter<string>.AfterFrame                   => AfterFrame       ?? string.Empty;
+        string IStackTraceFormatter<string>.BeforeParameters             => BeforeParameters ?? string.Empty;
+        string IStackTraceFormatter<string>.AfterParameters              => AfterParameters  ?? string.Empty;
     }
 
     partial interface IStackTraceFormatter<T>

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -175,7 +175,14 @@ namespace Hangfire.Common
         /// </summary>
         [NotNull]
         public IReadOnlyList<object> Args { get; private set; }
-        
+
+        /// <summary>
+        /// Gets or sets the DisplayName for this job, which allows overriding the default
+        /// on the dashboard (this takes precendence over any DisplayNameAttribute on the
+        /// method this job represents).
+        /// </summary>
+        public string DisplayName { get; set; }
+
         public override string ToString()
         {
             return String.Format("{0}.{1}", Type.ToGenericTypeString(), Method.Name);

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -103,6 +103,11 @@ namespace Hangfire.Dashboard
                 return "Can not find the target method.";
             }
 
+            if (!string.IsNullOrEmpty(job.DisplayName))
+            {
+                return job.DisplayName;
+            }
+
             var displayNameAttribute = Attribute.GetCustomAttribute(job.Method, typeof(DisplayNameAttribute), true) as DisplayNameAttribute;
 
             if (displayNameAttribute == null || displayNameAttribute.DisplayName == null)

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -27,7 +27,7 @@
     <DocumentationFile>bin\Debug\Hangfire.Core.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>1591</NoWarn>
-    <LangVersion>5</LangVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Hangfire.Core/Hangfire.Core.csproj.DotSettings
+++ b/src/Hangfire.Core/Hangfire.Core.csproj.DotSettings
@@ -1,5 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
+	
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Attributes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Client_005CClient/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Client_005CFilters/@EntryIndexedValue">False</s:Boolean>

--- a/src/Hangfire.Core/Server/IScheduleInstant.cs
+++ b/src/Hangfire.Core/Server/IScheduleInstant.cs
@@ -22,7 +22,7 @@ namespace Hangfire.Server
     internal interface IScheduleInstant
     {
         DateTime NowInstant { get; }
-        DateTime NextInstant { get; }
+        DateTime? NextInstant { get; }
         IEnumerable<DateTime> GetNextInstants(DateTime? lastInstant);
     }
 }

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -201,7 +201,7 @@ namespace Hangfire.Server
                     changedFields.Add("LastJobId", jobId ?? String.Empty);
                 }
 
-                changedFields.Add("NextExecution", JobHelper.SerializeDateTime(instant.NextInstant));
+                changedFields.Add("NextExecution", instant.NextInstant.HasValue ? JobHelper.SerializeDateTime(instant.NextInstant.Value) : null);
 
                 connection.SetRangeInHash(
                     String.Format("recurring-job:{0}", recurringJobId),

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -29,17 +29,20 @@ namespace Hangfire.Storage
     public class InvocationData
     {
         public InvocationData(
-            string type, string method, string parameterTypes, string arguments)
+            string type, string method, string parameterTypes, string arguments, string displayName)
         {
             Type = type;
             Method = method;
             ParameterTypes = parameterTypes;
             Arguments = arguments;
+            DisplayName = displayName;
         }
+
 
         public string Type { get; private set; }
         public string Method { get; private set; }
         public string ParameterTypes { get; private set; }
+        public string DisplayName { get; private set; }
         public string Arguments { get; set; }
 
         public Job Deserialize()
@@ -62,7 +65,10 @@ namespace Hangfire.Storage
                 var serializedArguments = JobHelper.FromJson<string[]>(Arguments);
                 var arguments = DeserializeArguments(method, serializedArguments);
 
-                return new Job(type, method, arguments);
+                return new Job(type, method, arguments)
+                {
+                    DisplayName = DisplayName
+                };
             }
             catch (Exception ex)
             {
@@ -76,7 +82,8 @@ namespace Hangfire.Storage
                 job.Type.AssemblyQualifiedName,
                 job.Method.Name,
                 JobHelper.ToJson(job.Method.GetParameters().Select(x => x.ParameterType).ToArray()),
-                JobHelper.ToJson(SerializeArguments(job.Args)));
+                JobHelper.ToJson(SerializeArguments(job.Args)), 
+                job.DisplayName);
         }
 
         internal static string[] SerializeArguments(IReadOnlyCollection<object> arguments)

--- a/src/Hangfire.Core/packages.config
+++ b/src/Hangfire.Core/packages.config
@@ -8,5 +8,5 @@
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="StackTraceFormatter.Source" version="1.0.0" targetFramework="net45" />
-  <package id="StackTraceParser.Source" version="1.1.1" targetFramework="net45" />
+  <package id="StackTraceParser.Source" version="1.2.0" targetFramework="net45" />
 </packages>

--- a/src/Hangfire.Core/packages.config
+++ b/src/Hangfire.Core/packages.config
@@ -7,6 +7,6 @@
   <package id="ncrontab" version="1.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="StackTraceFormatter.Source" version="1.0.0" targetFramework="net45" />
+  <package id="StackTraceFormatter.Source" version="1.1.0" targetFramework="net45" />
   <package id="StackTraceParser.Source" version="1.2.0" targetFramework="net45" />
 </packages>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.5.3")]
+[assembly: AssemblyVersion("1.5.4")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("Hangfire")]
 [assembly: AssemblyCompany("Sergey Odinokov")]
-[assembly: AssemblyCopyright("Copyright © 2013-2015 Sergey Odinokov")]
+[assembly: AssemblyCopyright("Copyright © 2013-2016 Sergey Odinokov")]
 [assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]

--- a/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
@@ -187,7 +187,7 @@ namespace Hangfire.Core.Tests.Server
         {
             // Arrange
             _recurringJob["Job"] =
-                JobHelper.ToJson(new InvocationData("SomeType", "SomeMethod", "Parameters", "arguments"));
+                JobHelper.ToJson(new InvocationData("SomeType", "SomeMethod", "Parameters", "arguments", null));
 
             var scheduler = CreateScheduler();
 

--- a/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
@@ -34,6 +34,7 @@ namespace Hangfire.Core.Tests.Server
             // Setting up the successful path
             _instant = new Mock<IScheduleInstant>();
             _instant.Setup(x => x.GetNextInstants(It.IsAny<DateTime?>())).Returns(new[] { _instant.Object.NowInstant });
+            _instant.Setup(x => x.NextInstant).Returns(_instant.Object.NowInstant);
 
             var timeZone1 = TimeZoneInfo.Local;
 
@@ -157,7 +158,7 @@ namespace Hangfire.Core.Tests.Server
                 String.Format("recurring-job:{0}", RecurringJobId),
                 It.Is<Dictionary<string, string>>(rj =>
                     rj.ContainsKey("NextExecution") && rj["NextExecution"]
-                        == JobHelper.SerializeDateTime(_instant.Object.NextInstant))));
+                        == JobHelper.SerializeDateTime(_instant.Object.NextInstant.Value))));
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/Server/ScheduleInstantFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ScheduleInstantFacts.cs
@@ -72,7 +72,7 @@ namespace Hangfire.Core.Tests.Server
         public void NextInstant_DoesntThrow_NearDaylightSavings()
         {
             // Arrange
-            _timeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            _timeZone = GetNewYorkTimeZone();
             _now = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2016, 3, 13, 1, 0, 0), _timeZone);
             _schedule = CrontabSchedule.Parse("0 * * * *");
             
@@ -89,7 +89,7 @@ namespace Hangfire.Core.Tests.Server
         public void GetNextInstants_DoesntThrow_NearDaylightSavings()
         {
             // Arrange
-            _timeZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+            _timeZone = GetNewYorkTimeZone();
             _now = TimeZoneInfo.ConvertTimeToUtc(new DateTime(2016, 3, 13, 3, 0, 0), _timeZone);
             _schedule = CrontabSchedule.Parse("0 * * * *");
 
@@ -161,6 +161,14 @@ namespace Hangfire.Core.Tests.Server
         private ScheduleInstant CreateInstant(DateTime? localTime = null)
         {
             return new ScheduleInstant(localTime ?? _now, _timeZone, _schedule);
+        }
+
+        private static TimeZoneInfo GetNewYorkTimeZone()
+        {
+            var isRunningMono = Type.GetType("Mono.Runtime") != null;
+            var timeZoneId = isRunningMono ? "America/New_York" : "Eastern Standard Time";
+
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -16,19 +16,21 @@ namespace Hangfire.Core.Tests.Storage
                 type.AssemblyQualifiedName,
                 methodInfo.Name,
                 JobHelper.ToJson(new [] { typeof(string) }),
-                JobHelper.ToJson(new [] { JobHelper.ToJson("Hello") }));
+                JobHelper.ToJson(new [] { JobHelper.ToJson("Hello") }),
+                "Display name");
 
             var job = serializedData.Deserialize();
 
             Assert.Equal(type, job.Type);
             Assert.Equal(methodInfo, job.Method);
             Assert.Equal("Hello", job.Args[0]);
+            Assert.Equal("Display name", job.DisplayName);
         }
 
         [Fact]
         public void Deserialize_WrapsAnException_WithTheJobLoadException()
         {
-            var serializedData = new InvocationData(null, null, null, null);
+            var serializedData = new InvocationData(null, null, null, null, null);
 
             Assert.Throws<JobLoadException>(
                 () => serializedData.Deserialize());
@@ -40,6 +42,7 @@ namespace Hangfire.Core.Tests.Storage
             var serializedData = new InvocationData(
                 "NonExistingType",
                 "Perform",
+                "",
                 "",
                 "");
 
@@ -54,6 +57,7 @@ namespace Hangfire.Core.Tests.Storage
                 typeof(InvocationDataFacts).AssemblyQualifiedName,
                 "NonExistingMethod",
                 JobHelper.ToJson(new [] { typeof(string) }),
+                "",
                 "");
 
             Assert.Throws<JobLoadException>(
@@ -103,7 +107,8 @@ namespace Hangfire.Core.Tests.Storage
                 typeof(IParent).AssemblyQualifiedName,
                 "Method",
                 JobHelper.ToJson(new string[0]),
-                JobHelper.ToJson(new string[0]));
+                JobHelper.ToJson(new string[0]),
+                null);
 
             var job = serializedData.Deserialize();
 
@@ -117,7 +122,8 @@ namespace Hangfire.Core.Tests.Storage
                 typeof(IChild).AssemblyQualifiedName,
                 "Method",
                 JobHelper.ToJson(new string[0]),
-                JobHelper.ToJson(new string[0]));
+                JobHelper.ToJson(new string[0]),
+                null);
 
             var job = serializedData.Deserialize();
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -314,7 +314,7 @@ select scope_identity() as Id";
                     arrangeSql,
                     new
                     {
-                        invocationData = JobHelper.ToJson(new InvocationData(null, null, null, null)),
+                        invocationData = JobHelper.ToJson(new InvocationData(null, null, null, null, null)),
                         stateName = "Succeeded",
                         arguments = "['Arguments']"
                     }).Single();


### PR DESCRIPTION
Allows overriding the name of a job directly, in addition to the currently supported DisplayNameAttribute on the executed method.

With a custom creation of a job that uses a single generic method all of the jobs have the same name. This allows us to override that for each job instance that is created, instead of each job 'type'