### PR TITLE
Added Server/BackgroundProcessContextExtensions.cs to Hangfire.Core project

### DIFF
--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Properties\NamespaceDoc.cs" />
     <Compile Include="Server\BackgroundProcessContext.cs" />
     <Compile Include="Obsolete\IServerProcess.cs" />
+    <Compile Include="Server\BackgroundProcessContextExtensions.cs" />
     <Compile Include="Server\MethodInvokePerformanceProcess.cs" />
     <Compile Include="Server\IBackgroundProcess.cs" />
     <Compile Include="Server\InfiniteLoopProcess.cs" />


### PR DESCRIPTION
Added Server/BackgroundProcessContextExtensions.cs to Hangfire.Core project file.

Corrects an issue created by this commit, preventing the dev branch from building:
https://github.com/HangfireIO/Hangfire/commit/ac05704e3c0dc3d3659f2c53661f52257f467370
