### PR TITLE
Use StackTraceFormatter for marking-up stack traces

### DIFF
--- a/src/Hangfire.Core/App_Packages/StackTraceFormatter/StackTraceFormatter.cs
+++ b/src/Hangfire.Core/App_Packages/StackTraceFormatter/StackTraceFormatter.cs
@@ -1,0 +1,155 @@
+#region Copyright (c) 2011 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+// ReSharper disable once CheckNamespace
+
+namespace Hangfire
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using MoreLinq;
+
+    partial class StackTraceHtmlFragments : IStackTraceFormatter<string>
+    {
+        public string BeforeType          { get; set; }
+        public string AfterType           { get; set; }
+        public string BeforeMethod        { get; set; }
+        public string AfterMethod         { get; set; }
+        public string BeforeParameterType { get; set; }
+        public string AfterParameterType  { get; set; }
+        public string BeforeParameterName { get; set; }
+        public string AfterParameterName  { get; set; }
+        public string BeforeFile          { get; set; }
+        public string AfterFile           { get; set; }
+        public string BeforeLine          { get; set; }
+        public string AfterLine           { get; set; }
+        public string BeforeFrame         { get; set; }
+        public string AfterFrame          { get; set; }
+        public string BeforeParameters    { get; set; }
+        public string AfterParameters     { get; set; }
+
+        string IStackTraceFormatter<string>.Text(string text)            { return  string.IsNullOrEmpty(text) ? string.Empty : WebUtility.HtmlEncode(text); }
+        string IStackTraceFormatter<string>.Type(string markup)          { return  BeforeType          + markup + AfterType; }
+        string IStackTraceFormatter<string>.Method(string markup)        { return  BeforeMethod        + markup + AfterMethod; }
+        string IStackTraceFormatter<string>.ParameterType(string markup) { return  BeforeParameterType + markup + AfterParameterType; }
+        string IStackTraceFormatter<string>.ParameterName(string markup) { return  BeforeParameterName + markup + AfterParameterName; }
+        string IStackTraceFormatter<string>.File(string markup)          { return  BeforeFile          + markup + AfterFile; }
+        string IStackTraceFormatter<string>.Line(string markup)          { return  BeforeLine          + markup + AfterLine; }
+        string IStackTraceFormatter<string>.BeforeFrame                  { get { return  BeforeFrame      ?? string.Empty; } }
+        string IStackTraceFormatter<string>.AfterFrame                   { get { return  AfterFrame       ?? string.Empty; } }
+        string IStackTraceFormatter<string>.BeforeParameters             { get { return  BeforeParameters ?? string.Empty; } }
+        string IStackTraceFormatter<string>.AfterParameters              { get { return  AfterParameters  ?? string.Empty; } }
+    }
+
+    partial interface IStackTraceFormatter<T>
+    {
+        T Text             (string text);
+        T Type             (T markup);
+        T Method           (T markup);
+        T ParameterType    (T markup);
+        T ParameterName    (T markup);
+        T File             (T markup);
+        T Line             (T markup);
+        T BeforeFrame      { get; }
+        T AfterFrame       { get; }
+        T BeforeParameters { get; }
+        T AfterParameters  { get; }
+    }
+
+    static partial class StackTraceFormatter
+    {
+        static readonly StackTraceHtmlFragments DefaultStackTraceHtmlFragments = new StackTraceHtmlFragments();
+
+        public static string FormatHtml(string text, IStackTraceFormatter<string> formatter)
+        {
+            return string.Concat(Format(text, formatter ?? DefaultStackTraceHtmlFragments));
+        }
+
+        public static IEnumerable<T> Format<T>(string text, IStackTraceFormatter<T> formatter)
+        {
+            Debug.Assert(text != null);
+
+            var frames = StackTraceParser.Parse
+                (
+                    text,
+                    (idx, len, txt) => new
+                    {
+                        Index   = idx,
+                        End     = idx + len,
+                        Text    = txt,
+                        Markup  = formatter.Text(txt),
+                    },
+                    (t, m) => new
+                    {
+                        Type   = new { t.Index, t.End, Markup = formatter.Type(t.Markup)   },
+                        Method = new { m.Index, m.End, Markup = formatter.Method(m.Markup) }
+                    },
+                    (t, n) => new
+                    {
+                        Type = new { t.Index, t.End, Markup = formatter.ParameterType(t.Markup) },
+                        Name = new { n.Index, n.End, Markup = formatter.ParameterName(n.Markup) }
+                    },
+                    (p, ps) => new { List = p, Parameters = ps.ToArray() },
+                    (f, l) => new
+                    {
+                        File = f.Text.Length > 0
+                             ? new { f.Index, f.End, Markup = formatter.File(f.Markup) }
+                             : null,
+                        Line = l.Text.Length > 0
+                             ? new { l.Index, l.End, Markup = formatter.Line(l.Markup) }
+                             : null,
+                    },
+                    (f, tm, p, fl) =>
+                        from tokens in new[]
+                        {
+                            new[]
+                            {
+                                new { f.Index, End = f.Index, Markup = formatter.BeforeFrame },
+                                tm.Type,
+                                tm.Method,
+                                new { p.List.Index, End = p.List.Index, Markup = formatter.BeforeParameters },
+                            },
+                            from pe in p.Parameters
+                            from e in new[] { pe.Type, pe.Name }
+                            select e,
+                            new[]
+                            {
+                                new { Index = p.List.End, p.List.End, Markup = formatter.AfterParameters },
+                                fl.File,
+                                fl.Line,
+                                new { Index = f.End, f.End, Markup = formatter.AfterFrame },
+                            },
+                        }
+                        from token in tokens
+                        where token != null
+                        select token
+                );
+
+            return
+                from token in Enumerable.Repeat(new { Index = 0, End = 0, Markup = default(T) }, 1)
+                                        .Concat(from tokens in frames from token in tokens select token)
+                                        .Pairwise((prev, curr) => new { Previous = prev, Current = curr })
+                from m in new[]
+                {
+                    formatter.Text(text.Substring(token.Previous.End, token.Current.Index - token.Previous.End)),
+                    token.Current.Markup,
+                }
+                select m;
+        }
+    }
+}

--- a/src/Hangfire.Core/App_Packages/StackTraceParser/StackTraceParser.cs
+++ b/src/Hangfire.Core/App_Packages/StackTraceParser/StackTraceParser.cs
@@ -1,0 +1,121 @@
+#region Copyright (c) 2011 Atif Aziz. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+// ReSharper disable once CheckNamespace
+
+namespace Hangfire
+{
+    #region Imports
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
+    #endregion
+
+    // ReSharper disable once PartialTypeWithSinglePart
+
+    partial class StackTraceParser
+    {
+        const string Space = @"[\x20\t]";
+
+        static readonly Regex Regex = new Regex(@"
+            ^
+            " + Space + @"*
+            \w+ " + Space + @"+
+            (?<frame>
+                (?<type> .+ ) \.
+                (?<method> .+? ) " + Space + @"*
+                (?<params>  \( ( " + Space + @"* \)
+                               |        (?<pt> .+?) " + Space + @"+ (?<pn> .+?)
+                                 (, " + Space + @"* (?<pt> .+?) " + Space + @"+ (?<pn> .+?) )* \) ) )
+                ( " + Space + @"+
+                    ( # Microsoft .NET stack traces
+                    \w+ " + Space + @"+
+                    (?<file> [a-z] \: .+? )
+                    \: \w+ " + Space + @"+
+                    (?<line> [0-9]+ ) \p{P}?
+                    | # Mono stack traces
+                    \[0x[0-9a-f]+\] " + Space + @"+ \w+ " + Space + @"+
+                    <(?<file> [^>]+ )>
+                    :(?<line> [0-9]+ )
+                    )
+                )?
+            )
+            \s*
+            $",
+            RegexOptions.IgnoreCase
+            | RegexOptions.Multiline
+            | RegexOptions.ExplicitCapture
+            | RegexOptions.CultureInvariant
+            | RegexOptions.IgnorePatternWhitespace
+            | RegexOptions.Compiled);
+
+        public static IEnumerable<T> Parse<T>(
+            string text,
+            Func<string, string, string, string, IEnumerable<KeyValuePair<string, string>>, string, string, T> selector)
+        {
+            if (selector == null) throw new ArgumentNullException("selector");
+
+            return Parse(text, (idx, len, txt) => txt,
+                               (t, m) => new { Type = t, Method = m },
+                               (pt, pn) => new KeyValuePair<string, string>(pt, pn),
+                               // ReSharper disable once PossibleMultipleEnumeration
+                               (pl, ps) => new { List = pl, Items = ps },
+                               (fn, ln) => new { File = fn, Line = ln },
+                               (f, tm, p, fl) => selector(f, tm.Type, tm.Method, p.List, p.Items, fl.File, fl.Line));
+        }
+
+        public static IEnumerable<TFrame> Parse<TToken, TMethod, TParameters, TParameter, TSourceLocation, TFrame>(
+            string text,
+            Func<int, int, string, TToken> tokenSelector,
+            Func<TToken, TToken, TMethod> methodSelector,
+            Func<TToken, TToken, TParameter> parameterSelector,
+            Func<TToken, IEnumerable<TParameter>, TParameters> parametersSelector,
+            Func<TToken, TToken, TSourceLocation> sourceLocationSelector,
+            Func<TToken, TMethod, TParameters, TSourceLocation, TFrame> selector)
+        {
+            if (tokenSelector == null) throw new ArgumentNullException("tokenSelector");
+            if (methodSelector == null) throw new ArgumentNullException("methodSelector");
+            if (parameterSelector == null) throw new ArgumentNullException("parameterSelector");
+            if (parametersSelector == null) throw new ArgumentNullException("parametersSelector");
+            if (sourceLocationSelector == null) throw new ArgumentNullException("sourceLocationSelector");
+            if (selector == null) throw new ArgumentNullException("selector");
+
+            return from Match m in Regex.Matches(text)
+                   select m.Groups into groups
+                   let pt = groups["pt"].Captures
+                   let pn = groups["pn"].Captures
+                   select selector(Token(groups["frame"], tokenSelector),
+                                   methodSelector(
+                                       Token(groups["type"], tokenSelector),
+                                       Token(groups["method"], tokenSelector)),
+                                   parametersSelector(
+                                       Token(groups["params"], tokenSelector),
+                                       from i in Enumerable.Range(0, pt.Count)
+                                       select parameterSelector(Token(pt[i], tokenSelector),
+                                                                Token(pn[i], tokenSelector))),
+                                   sourceLocationSelector(Token(groups["file"], tokenSelector),
+                                                          Token(groups["line"], tokenSelector)));
+        }
+
+        static T Token<T>(Capture capture, Func<int, int, string, T> tokenSelector)
+        {
+            return tokenSelector(capture.Index, capture.Length, capture.Value);
+        }
+    }
+}

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -16,12 +16,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Text.RegularExpressions;
 using Hangfire.Common;
 using System.ComponentModel;
 using Hangfire.Annotations;
@@ -238,159 +235,21 @@ namespace Hangfire.Dashboard
             return new NonEscapedString(label);
         }
 
+        static readonly StackTraceHtmlFragments StackTraceHtmlFragments = new StackTraceHtmlFragments
+        {
+            BeforeFrame         = "<span class='st-frame'>"                            , AfterFrame         = "</span>",
+            BeforeType          = "<span class='st-type'>"                             , AfterType          = "</span>",
+            BeforeMethod        = "<span class='st-method'>"                           , AfterMethod        = "</span>",
+            BeforeParameters    = "<span class='st-param'>"                            , AfterParameters    = "</span>",
+            BeforeParameterType = "<span class='st-param'><span class='st-param-type'>", AfterParameterType = "</span>",
+            BeforeParameterName = "<span class='st-param-name'>"                       , AfterParameterName = "</span></span>",
+            BeforeFile          = "<span class='st-file'>"                             , AfterFile          = "</span>",
+            BeforeLine          = "<span class='st-line'>"                             , AfterLine          = "</span>",
+        };
+
         public NonEscapedString StackTrace(string stackTrace)
         {
-            using (var writer = new StringWriter())
-            {
-                MarkupStackTrace(stackTrace, writer);
-                return new NonEscapedString(writer.ToString());
-            }
-        }
-
-        // This stack trace highlighting code was derived from the project ELMAH (Error 
-        // Logging Modules and Handlers for ASP.NET, https://code.google.com/p/elmah/),
-        // licensed under the Apache License 2.0.
-        // Copyright (c) 2004-9 Atif Aziz (http://www.raboof.com). All rights reserved.
-        private static readonly Regex ReStackTrace = new Regex(@"
-                ^
-                \s*
-                \w+ \s+ 
-                (?<type> .+ ) \.
-                (?<method> .+? ) 
-                (?<params> \( (?<params> .*? ) \) )
-                ( \s+ 
-                \w+ \s+ 
-                  (?<file> [a-z] \: .+? ) 
-                  \: \w+ \s+ 
-                  (?<line> [0-9]+ ) \p{P}? )?
-                \s*
-                $",
-            RegexOptions.IgnoreCase
-            | RegexOptions.Multiline
-            | RegexOptions.ExplicitCapture
-            | RegexOptions.CultureInvariant
-            | RegexOptions.IgnorePatternWhitespace
-            | RegexOptions.Compiled);
-
-        private static void MarkupStackTrace(string text, TextWriter writer)
-        {
-            Debug.Assert(text != null);
-            Debug.Assert(writer != null);
-
-            int anchor = 0;
-
-            foreach (Match match in ReStackTrace.Matches(text))
-            {
-                HtmlEncode(text.Substring(anchor, match.Index - anchor), writer);
-                MarkupStackFrame(text, match, writer);
-                anchor = match.Index + match.Length;
-            }
-
-            HtmlEncode(text.Substring(anchor), writer);
-        }
-
-        private static void MarkupStackFrame(string text, Match match, TextWriter writer)
-        {
-            Debug.Assert(text != null);
-            Debug.Assert(match != null);
-            Debug.Assert(writer != null);
-
-            int anchor = match.Index;
-            GroupCollection groups = match.Groups;
-
-            //
-            // Type + Method
-            //
-
-            Group type = groups["type"];
-            HtmlEncode(text.Substring(anchor, type.Index - anchor), writer);
-            anchor = type.Index;
-            writer.Write("<span class='st-frame'>");
-            anchor = StackFrameSpan(text, anchor, "st-type", type, writer);
-            anchor = StackFrameSpan(text, anchor, "st-method", groups["method"], writer);
-
-            //
-            // Parameters
-            //
-
-            Group parameters = groups["params"];
-            HtmlEncode(text.Substring(anchor, parameters.Index - anchor), writer);
-            writer.Write("<span class='st-params'>(");
-            int position = 0;
-            foreach (string parameter in parameters.Captures[0].Value.Split(','))
-            {
-                int spaceIndex = parameter.LastIndexOf(' ');
-                if (spaceIndex <= 0)
-                {
-                    Span(writer, "st-param", parameter.Trim());
-                }
-                else
-                {
-                    if (position++ > 0)
-                        writer.Write(", ");
-                    string argType = parameter.Substring(0, spaceIndex).Trim();
-                    Span(writer, "st-param-type", argType);
-                    writer.Write(' ');
-                    string argName = parameter.Substring(spaceIndex + 1).Trim();
-                    Span(writer, "st-param-name", argName);
-                }
-            }
-            writer.Write(")</span>");
-            anchor = parameters.Index + parameters.Length;
-
-            //
-            // File + Line
-            //
-
-            anchor = StackFrameSpan(text, anchor, "st-file", groups["file"], writer);
-            anchor = StackFrameSpan(text, anchor, "st-line", groups["line"], writer);
-
-            writer.Write("</span>");
-
-            //
-            // Epilogue
-            //
-
-            int end = match.Index + match.Length;
-            HtmlEncode(text.Substring(anchor, end - anchor), writer);
-        }
-
-        private static int StackFrameSpan(string text, int anchor, string klass, Group group, TextWriter writer)
-        {
-            Debug.Assert(text != null);
-            Debug.Assert(group != null);
-            Debug.Assert(writer != null);
-
-            return group.Success
-                 ? StackFrameSpan(text, anchor, klass, group.Value, group.Index, group.Length, writer)
-                 : anchor;
-        }
-
-        private static int StackFrameSpan(string text, int anchor, string klass, string value, int index, int length, TextWriter writer)
-        {
-            Debug.Assert(text != null);
-            Debug.Assert(writer != null);
-
-            HtmlEncode(text.Substring(anchor, index - anchor), writer);
-            Span(writer, klass, value);
-            return index + length;
-        }
-
-        private static void Span(TextWriter writer, string klass, string value)
-        {
-            Debug.Assert(writer != null);
-
-            writer.Write("<span class='");
-            writer.Write(klass);
-            writer.Write("'>");
-            HtmlEncode(value, writer);
-            writer.Write("</span>");
-        }
-
-        private static void HtmlEncode(string text, TextWriter writer)
-        {
-            Debug.Assert(writer != null);
-            WebUtility.HtmlEncode(text, writer);
+            return new NonEscapedString(StackTraceFormatter.FormatHtml(stackTrace, StackTraceHtmlFragments));
         }
 
         public string HtmlEncode(string text)

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -75,6 +75,8 @@
     <Compile Include="AppBuilderExtensions.cs" />
     <Compile Include="App_Packages\LibLog.1.4\LibLog.cs" />
     <Compile Include="AttemptsExceededAction.cs" />
+    <Compile Include="App_Packages\StackTraceFormatter\StackTraceFormatter.cs" />
+    <Compile Include="App_Packages\StackTraceParser\StackTraceParser.cs" />
     <Compile Include="AutomaticRetryAttribute.cs" />
     <Compile Include="BackgroundJobServer.cs" />
     <Compile Include="BackgroundJobServerOptions.cs" />
@@ -96,6 +98,7 @@
     <Compile Include="Server\InfiniteLoopProcess.cs" />
     <Compile Include="Server\BackgroundProcessExtensions.cs" />
     <Compile Include="Server\BackgroundServer.cs" />
+    <Compile Include="MoreLinq\MoreEnumerable.Pairwise.cs" />
     <Compile Include="States\AwaitingState.cs" />
     <Compile Include="ContinuationsSupportAttribute.cs" />
     <Compile Include="JobContinuationOptions.cs" />

--- a/src/Hangfire.Core/MoreLinq/MoreEnumerable.Pairwise.cs
+++ b/src/Hangfire.Core/MoreLinq/MoreEnumerable.Pairwise.cs
@@ -1,0 +1,77 @@
+#region License and Terms
+// MoreLINQ - Extensions to LINQ to Objects
+// Copyright (c) 2008 Jonathan Skeet. All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+namespace MoreLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
+    static partial class MoreEnumerable
+    {
+        /// <summary>
+        /// Returns a sequence resulting from applying a function to each 
+        /// element in the source sequence and its 
+        /// predecessor, with the exception of the first element which is 
+        /// only returned as the predecessor of the second element.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TResult">The type of the element of the returned sequence.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="resultSelector">A transform function to apply to 
+        /// each pair of sequence.</param>
+        /// <returns>
+        /// Returns the resulting sequence.
+        /// </returns>
+        /// <remarks>
+        /// This operator uses deferred execution and streams its results.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// int[] numbers = { 123, 456, 789 };
+        /// IEnumerable&lt;int&gt; result = numbers.Pairwise(5, (a, b) => a + b);
+        /// </code>
+        /// The <c>result</c> variable, when iterated over, will yield 
+        /// 579 and 1245, in turn.
+        /// </example>
+        public static IEnumerable<TResult> Pairwise<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TSource, TResult> resultSelector)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (resultSelector == null) throw new ArgumentNullException("resultSelector");
+            return PairwiseImpl(source, resultSelector);
+        }
+
+        private static IEnumerable<TResult> PairwiseImpl<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TSource, TResult> resultSelector)
+        {
+            Debug.Assert(source != null);
+            Debug.Assert(resultSelector != null);
+
+            using (var e = source.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                    yield break;
+
+                var previous = e.Current;
+                while (e.MoveNext())
+                {
+                    yield return resultSelector(previous, e.Current);
+                    previous = e.Current;
+                }
+            }
+        }
+    }
+}

--- a/src/Hangfire.Core/packages.config
+++ b/src/Hangfire.Core/packages.config
@@ -3,7 +3,10 @@
   <package id="CronExpressionDescriptor" version="1.13.0" targetFramework="net45" />
   <package id="LibLog" version="1.5.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="MoreLinq.Source.MoreEnumerable.Pairwise" version="1.0.1" targetFramework="net45" />
   <package id="ncrontab" version="1.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="StackTraceFormatter.Source" version="1.0.0" targetFramework="net45" />
+  <package id="StackTraceParser.Source" version="1.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Instead of including stack trace highlighting code from ELMAH, use the more up-to-date and stand-alone version via the StackTraceFormatter package. Addresses issue #418 and also makes sync'ing easier going forward.