### PR TITLE
Created a status endpoint on the dashboard which returns active servers

### DIFF
--- a/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
@@ -46,7 +46,8 @@ namespace Hangfire.Dashboard
             Routes = new RouteCollection();
             Routes.AddRazorPage("/", x => new HomePage());
             Routes.Add("/stats", new JsonStats());
-            
+            Routes.Add("/status", new JsonStatus());
+
             #region Embedded static content
 
             Routes.Add("/js", new CombinedResourceDispatcher(

--- a/src/Hangfire.Core/Dashboard/JsonStatus.cs
+++ b/src/Hangfire.Core/Dashboard/JsonStatus.cs
@@ -1,0 +1,131 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+
+namespace Hangfire.Dashboard
+{
+    internal class JsonStatus : IRequestDispatcher
+    {
+        private static readonly TimeSpan ServerTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan ResultCacheTimeout = TimeSpan.FromMinutes(0.5);
+
+        private const string EmptyResult = "[]";
+
+        private static object ResultCacheLock = new object();
+        private static string ResultCache = null;
+        private static DateTime ResultCacheLastUpdate = DateTime.MinValue;
+
+        public async Task Dispatch(RequestDispatcherContext context)
+        {
+            DateTime now = DateTime.UtcNow;
+
+            string results = ResultCache;
+            if (string.IsNullOrWhiteSpace(results) || ResultCacheLastUpdate < now.Subtract(ResultCacheTimeout))
+            {
+                lock (ResultCacheLock)
+                {
+                    if (string.IsNullOrWhiteSpace(results) || ResultCacheLastUpdate < now.Subtract(ResultCacheTimeout))
+                    {
+                        results = ResultCache = GetSerialisedStatusResponse(context, now);
+                        ResultCacheLastUpdate = now;
+                    }
+                }
+            }
+
+            OwinContext owinContext = new OwinContext(context.OwinEnvironment);
+            owinContext.Response.ContentType = "application/json";
+            owinContext.Response.StatusCode = !string.IsNullOrWhiteSpace(results) && results != EmptyResult
+                ? 200
+                : 500;
+
+            await owinContext.Response.WriteAsync(results);
+
+            /*DateTime now = DateTime.UtcNow;
+
+            StubPage page = new StubPage();
+            page.Assign(context);
+
+            IMonitoringApi monitoringAPI = page.Storage.GetMonitoringApi();
+            List<ServerDto> servers = monitoringAPI
+                .Servers()
+                .Where(s => s.Heartbeat.HasValue && s.Heartbeat.Value >= now.Subtract(ServerTimeout))
+                .ToList();
+
+            JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new JsonConverter[]
+                {
+                    new StringEnumConverter
+                    {
+                        CamelCaseText = true
+                    }
+                }
+            };
+            string serialized = JsonConvert.SerializeObject(servers, jsonSerializerSettings);
+
+            OwinContext owinContext = new OwinContext(context.OwinEnvironment);
+            owinContext.Response.ContentType = "application/json";
+            owinContext.Response.StatusCode = servers.Any()
+                ? 200
+                : 500;
+
+            await owinContext.Response.WriteAsync(serialized);*/
+        }
+
+        private string GetSerialisedStatusResponse(RequestDispatcherContext context, DateTime now)
+        {
+            StubPage page = new StubPage();
+            page.Assign(context);
+
+            IMonitoringApi monitoringAPI = page.Storage.GetMonitoringApi();
+            List<ServerDto> servers = monitoringAPI
+                .Servers()
+                .Where(s => s.Heartbeat.HasValue && s.Heartbeat.Value >= now.Subtract(ServerTimeout))
+                .ToList();
+
+            JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new JsonConverter[]
+                {
+                    new StringEnumConverter
+                    {
+                        CamelCaseText = true
+                    }
+                }
+            };
+            return JsonConvert.SerializeObject(servers, jsonSerializerSettings);
+        }
+
+        private class StubPage : RazorPage
+        {
+            public override void Execute()
+            {
+            }
+        }
+    }
+}

--- a/src/Hangfire.Core/Dashboard/JsonStatus.cs
+++ b/src/Hangfire.Core/Dashboard/JsonStatus.cs
@@ -62,38 +62,6 @@ namespace Hangfire.Dashboard
                 : 500;
 
             await owinContext.Response.WriteAsync(results);
-
-            /*DateTime now = DateTime.UtcNow;
-
-            StubPage page = new StubPage();
-            page.Assign(context);
-
-            IMonitoringApi monitoringAPI = page.Storage.GetMonitoringApi();
-            List<ServerDto> servers = monitoringAPI
-                .Servers()
-                .Where(s => s.Heartbeat.HasValue && s.Heartbeat.Value >= now.Subtract(ServerTimeout))
-                .ToList();
-
-            JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Converters = new JsonConverter[]
-                {
-                    new StringEnumConverter
-                    {
-                        CamelCaseText = true
-                    }
-                }
-            };
-            string serialized = JsonConvert.SerializeObject(servers, jsonSerializerSettings);
-
-            OwinContext owinContext = new OwinContext(context.OwinEnvironment);
-            owinContext.Response.ContentType = "application/json";
-            owinContext.Response.StatusCode = servers.Any()
-                ? 200
-                : 500;
-
-            await owinContext.Response.WriteAsync(serialized);*/
         }
 
         private string GetSerialisedStatusResponse(RequestDispatcherContext context, DateTime now)

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="BackgroundJobServerOptions.cs" />
     <Compile Include="Client\IJobCreator.cs" />
     <Compile Include="Common\TypeExtensions.cs" />
+    <Compile Include="Dashboard\JsonStatus.cs" />
     <Compile Include="Dashboard\OwinRequestExtensions.cs" />
     <Compile Include="Dashboard\Pages\AwaitingJobsPage.generated.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Created a status endpoint on the dashboard (http://{server}/hangfire/status) which returns information about any servers which have been active in the last 5 minutes. The servers are explicitly filtered in case there is no background job server running to clean up expired servers.

Results are returned in JSON format and are cached in-memory for 30 seconds, reducing server load if the page is polled frequently. HTTP status 200 is returned if there is at least one active server, otherwise HTTP status 500 is returned.

Example output with one active server: (Status: 200)
```json
[
  {
    "name": "andrew-computer:140328:c4b87a3a-963d-4144-a983-87e5a4af3628",
    "workersCount": 40,
    "startedAt": "2015-08-19T22:48:25.7030065Z",
    "queues": [
      "critical",
      "default"
    ],
    "heartbeat": "2015-08-19T22:48:41.433"
  }
]
```

Example output with no active servers: (Status: 500)
```json
[]
```

Please see discussion topic:
http://discuss.hangfire.io/t/query-server-status-remotely/1242
