### PR TITLE
Fixed an issue where if the DisableConcurrentExecutionAttribute was used then it was impossible to specify a timeout greater than 30 seconds.

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -59,7 +59,9 @@ namespace Hangfire.SqlServer
             connection.Execute(
                 @"sp_getapplock", 
                 parameters, 
-                commandType: CommandType.StoredProcedure);
+                null,
+                timeout.Seconds,
+                CommandType.StoredProcedure);
 
             var lockResult = parameters.Get<int>("@Result");
 

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -77,7 +77,7 @@ namespace Hangfire.SqlServer
             {
                 throw CreateLockException(ex.Number);
             }
-            
+
         }
 
         private SqlServerDistributedLockException CreateLockException(int lockResult)
@@ -113,7 +113,7 @@ namespace Hangfire.SqlServer
             {
                 throw new SqlServerDistributedLockException(
                     String.Format(
-                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.", 
+                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.",
                         _resource,
                         releaseResult));
             }


### PR DESCRIPTION
Fixed an issue where the correct timeout value was being passed to the sp_getapplock stored procedure but the SqlCommand was having the default timeout of 30 seconds applied in all cases.

This meant it was impossible for any job which would take more than 30 seconds to complete if it used the DisableConcurrentExecutionAttribute attribute. 