### PR TITLE
Disable concurrent execution command timeout

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -57,7 +57,7 @@ namespace Hangfire.SqlServer
             parameters.Add("@LockTimeout", timeout.TotalMilliseconds);
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
-            // Ensuring the timeout for the connection is 1 second longer than the timeout specified for the stored procedure.
+            // Ensuring the timeout for the command is 1 second longer than the timeout specified for the stored procedure.
             var connectionTimeout = timeout.Seconds + 1;
 
             connection.Execute(

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -44,6 +44,7 @@ namespace Hangfire.SqlServer
         {
             if (String.IsNullOrEmpty(resource)) throw new ArgumentNullException("resource");
             if (connection == null) throw new ArgumentNullException("connection");
+            if (timeout.TotalSeconds > Int32.MaxValue) throw new ArgumentException("The timeout specified is greater than Int32.MaxValue when expressed as seconds.", "timeout");
 
             _resource = resource;
             _connection = connection;
@@ -57,7 +58,7 @@ namespace Hangfire.SqlServer
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
             // Ensuring the timeout for the command is 1 second longer than the timeout specified for the stored procedure.
-            int commandTimeout = (int) ((timeout.TotalSeconds + 1) > Int32.MaxValue ? Int32.MaxValue : (timeout.TotalSeconds + 1));
+            var commandTimeout = (int)(timeout.TotalSeconds + 1);
 
             connection.Execute(
                 @"sp_getapplock",

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -57,7 +57,7 @@ namespace Hangfire.SqlServer
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
             // Ensuring the timeout for the command is 1 second longer than the timeout specified for the stored procedure.
-            var commandTimeout = timeout.Seconds + 1;
+            int commandTimeout = (int) ((timeout.TotalSeconds + 1) > Int32.MaxValue ? Int32.MaxValue : (timeout.TotalSeconds + 1));
 
             connection.Execute(
                 @"sp_getapplock",

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -58,12 +58,12 @@ namespace Hangfire.SqlServer
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
             // Ensuring the timeout for the command is 1 second longer than the timeout specified for the stored procedure.
-            var connectionTimeout = timeout.Seconds + 1;
+            var commandTimeout = timeout.Seconds + 1;
 
             connection.Execute(
                 @"sp_getapplock",
                 parameters,
-                commandTimeout: connectionTimeout,
+                commandTimeout: commandTimeout,
                 commandType: CommandType.StoredProcedure);
 
             var lockResult = parameters.Get<int>("@Result");

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -61,20 +61,20 @@ namespace Hangfire.SqlServer
             var connectionTimeout = timeout.Seconds + 1;
 
             connection.Execute(
-            @"sp_getapplock",
-            parameters,
-            commandTimeout: connectionTimeout,
-            commandType: CommandType.StoredProcedure);
+                @"sp_getapplock",
+                parameters,
+                commandTimeout: connectionTimeout,
+                commandType: CommandType.StoredProcedure);
 
             var lockResult = parameters.Get<int>("@Result");
 
             if (lockResult < 0)
             {
                 throw new SqlServerDistributedLockException(
-                String.Format(
+                    String.Format(
                     "Could not place a lock on the resource '{0}': {1}.",
                     _resource,
-                    LockErrorMessages.ContainsKey(lockResult)
+                    LockErrorMessages.ContainsKey(lockResult) 
                         ? LockErrorMessages[lockResult]
                         : String.Format("Server returned the '{0}' error.", lockResult)));
             }
@@ -102,7 +102,7 @@ namespace Hangfire.SqlServer
             {
                 throw new SqlServerDistributedLockException(
                     String.Format(
-                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.",
+                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.", 
                         _resource,
                         releaseResult));
             }

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -59,7 +59,9 @@ namespace Hangfire.SqlServer
             connection.Execute(
                 @"sp_getapplock", 
                 parameters, 
-                commandType: CommandType.StoredProcedure);
+                null,
+                timeout.Seconds,
+                CommandType.StoredProcedure);
 
             var lockResult = parameters.Get<int>("@Result");
 

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -77,7 +77,7 @@ namespace Hangfire.SqlServer
             {
                 throw CreateLockException(ex.Number);
             }
-            
+
         }
 
         private SqlServerDistributedLockException CreateLockException(int lockResult)
@@ -113,7 +113,7 @@ namespace Hangfire.SqlServer
             {
                 throw new SqlServerDistributedLockException(
                     String.Format(
-                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.", 
+                        "Could not release a lock on the resource '{0}': Server returned the '{1}' error.",
                         _resource,
                         releaseResult));
             }

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using Dapper;
 
 namespace Hangfire.SqlServer


### PR DESCRIPTION
Resolved an issue where the timeout for the Stored Procedure sp_getapplock could be longer than the default timeout on the Command object. This could result in the command timing out, not the SP call, and so an unexpected exception being thrown. 

The command object now has its timeout set to be 1 second longer than the SP timeout.