### PR TITLE
SqlServerDistributedLockTimeout - logical error in value check

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -47,7 +47,7 @@ namespace Hangfire.SqlServer
         {
             if (storage == null) throw new ArgumentNullException("storage");
             if (String.IsNullOrEmpty(resource)) throw new ArgumentNullException("resource");
-            if (timeout.TotalSeconds > Int32.MaxValue) throw new ArgumentException("The timeout specified is greater than Int32.MaxValue when expressed as seconds.", "timeout");
+            if (timeout.TotalSeconds >= Int32.MaxValue) throw new ArgumentException("The timeout specified is greater than Int32.MaxValue when expressed as seconds.", "timeout");
 
             _storage = storage;
             _resource = resource;

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -27,7 +27,7 @@ namespace Hangfire.SqlServer
     {
         private const string LockMode = "Exclusive";
         private const string LockOwner = "Session";
-        private const int CommandTimeoutAddition = 1;
+        private const int CommandTimeoutAdditionSeconds = 1;
 
         private static readonly IDictionary<int, string> LockErrorMessages
             = new Dictionary<int, string>
@@ -48,7 +48,7 @@ namespace Hangfire.SqlServer
         {
             if (storage == null) throw new ArgumentNullException("storage");
             if (String.IsNullOrEmpty(resource)) throw new ArgumentNullException("resource");
-            if ((timeout.TotalSeconds + CommandTimeoutAddition) > Int32.MaxValue) throw new ArgumentException(string.Format("The timeout specified is too large. Please supply a timeout equal to or less than {0} seconds", Int32.MaxValue - CommandTimeoutAddition), "timeout");
+            if ((timeout.TotalSeconds + CommandTimeoutAdditionSeconds) > Int32.MaxValue) throw new ArgumentException(string.Format("The timeout specified is too large. Please supply a timeout equal to or less than {0} seconds", Int32.MaxValue - CommandTimeoutAdditionSeconds), "timeout");
 
             _storage = storage;
             _resource = resource;
@@ -84,7 +84,7 @@ namespace Hangfire.SqlServer
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
             // Ensuring the timeout for the command is longer than the timeout specified for the stored procedure.
-            var commandTimeout = (int)(timeout.TotalSeconds + CommandTimeoutAddition);
+            var commandTimeout = (int)(timeout.TotalSeconds + CommandTimeoutAdditionSeconds);
 
             connection.Execute(
                 @"sp_getapplock",

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -27,6 +27,7 @@ namespace Hangfire.SqlServer
     {
         private const string LockMode = "Exclusive";
         private const string LockOwner = "Session";
+        private const int CommandTimeoutAddition = 1;
 
         private static readonly IDictionary<int, string> LockErrorMessages
             = new Dictionary<int, string>
@@ -47,7 +48,7 @@ namespace Hangfire.SqlServer
         {
             if (storage == null) throw new ArgumentNullException("storage");
             if (String.IsNullOrEmpty(resource)) throw new ArgumentNullException("resource");
-            if (timeout.TotalSeconds >= Int32.MaxValue) throw new ArgumentException("The timeout specified is greater than Int32.MaxValue when expressed as seconds.", "timeout");
+            if ((timeout.TotalSeconds + CommandTimeoutAddition) > Int32.MaxValue) throw new ArgumentException(string.Format("The timeout specified is too large. Please supply a timeout equal to or less than {0} seconds", Int32.MaxValue - CommandTimeoutAddition), "timeout");
 
             _storage = storage;
             _resource = resource;
@@ -82,8 +83,8 @@ namespace Hangfire.SqlServer
             parameters.Add("@LockTimeout", timeout.TotalMilliseconds);
             parameters.Add("@Result", dbType: DbType.Int32, direction: ParameterDirection.ReturnValue);
 
-            // Ensuring the timeout for the command is 1 second longer than the timeout specified for the stored procedure.
-            var commandTimeout = (int)(timeout.TotalSeconds + 1);
+            // Ensuring the timeout for the command is longer than the timeout specified for the stored procedure.
+            var commandTimeout = (int)(timeout.TotalSeconds + CommandTimeoutAddition);
 
             connection.Execute(
                 @"sp_getapplock",

--- a/tests/Hangfire.SqlServer.Tests/SqlServerDistributedLockFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerDistributedLockFacts.cs
@@ -21,6 +21,19 @@ namespace Hangfire.SqlServer.Tests
             Assert.Equal("storage", exception.ParamName);
         }
 
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenTimeoutTooLarge()
+        {
+            UseConnection(connection =>
+            {
+                var storage = CreateStorage(connection);
+                var tooLargeTimeout = TimeSpan.FromSeconds(Int32.MaxValue);
+                var exception = Assert.Throws<ArgumentException>(() => new SqlServerDistributedLock(storage, "hello", tooLargeTimeout));
+
+                Assert.Equal("timeout", exception.ParamName);
+            });
+        }
+
         [Fact, CleanDatabase]
         public void Ctor_ThrowsAnException_WhenResourceIsNullOrEmpty()
         {


### PR DESCRIPTION
Previously the check was made for only `value > Int32.Max` but then 1 was added later. Now checking to see if `value >= Int32.Max`. 

Test also added for this.