### PR TITLE
Allow jobs to log directly to the hangfire dashboard

### DIFF
--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -82,6 +82,8 @@
     <Compile Include="BackgroundJobServer.cs" />
     <Compile Include="BackgroundJobServerOptions.cs" />
     <Compile Include="Client\CoreBackgroundJobFactory.cs" />
+    <Compile Include="IJobContext.cs" />
+    <Compile Include="JobContext.cs" />
     <Compile Include="Obsolete\Job.Obsolete.cs" />
     <Compile Include="Common\TypeExtensions.cs" />
     <Compile Include="Dashboard\OwinRequestExtensions.cs" />

--- a/src/Hangfire.Core/IJobContext.cs
+++ b/src/Hangfire.Core/IJobContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Hangfire
+{
+    public interface IJobContext
+    {   
+        string JobId { get; }
+    }
+}

--- a/src/Hangfire.Core/JobContext.cs
+++ b/src/Hangfire.Core/JobContext.cs
@@ -1,0 +1,25 @@
+﻿using Hangfire.Storage;
+
+namespace Hangfire
+{
+    public class JobContext : IJobContext
+    {
+        private readonly string jobId;
+        private readonly string serverId;
+
+        public JobContext(string jobId, IStorageConnection connection)
+        {
+            this.jobId = jobId;            
+        }       
+
+        public string JobId
+        {
+            get { return jobId; }
+        }
+
+        public static IJobContext Null
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
@@ -29,7 +29,8 @@ namespace Hangfire.Server
             = new Dictionary<Type, Func<PerformContext, object>>
             {
                 { typeof (IJobCancellationToken), x => x.CancellationToken },
-                { typeof (CancellationToken), x => x.CancellationToken.ShutdownToken }
+                { typeof (CancellationToken), x => x.CancellationToken.ShutdownToken },
+                { typeof (IJobContext), x => new JobContext(x.BackgroundJob.Id, x.Connection) },   
             };
 
         private readonly JobActivator _activator;


### PR DESCRIPTION
I have augmented parameter substitution in order to allow access to the job id in background jobs. This allows us to do the following:

  BackgroundJob.Enqueue<IRenewalJob>(x => x.Execute(JobContext.Null));

Hangfire will now substitute this with an instance of JobContext, allowing access to the jobId for logging purposes. A simple logger that makes use of this can be found at: 
https://github.com/samshiles/hangfire.job.logging 
