### PR TITLE
Prevent infinite loops when trying to change state of a job that doesn't exist

### DIFF
--- a/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
+++ b/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
@@ -132,7 +132,8 @@ namespace Hangfire.States
                     return jobData;
                 }
 
-                if (context.CancellationToken.IsCancellationRequested)
+                if (context.CancellationToken.IsCancellationRequested ||
+                    context.CancellationToken == CancellationToken.None)
                 {
                     return null;
                 }


### PR DESCRIPTION
Simple solution to break infinite loop and resolve #467.

This infinite loop happens when CancellationToken.None is used in one of the constructor overloads of 'StateChangeContext' class. 

Also maybe it is better to return null in 'GetJobData' method immediately after first try without any retries.