### PR TITLE
SQL Server 2005

### DIFF
--- a/src/Hangfire.SqlServer/CountersAggregator.cs
+++ b/src/Hangfire.SqlServer/CountersAggregator.cs
@@ -76,8 +76,8 @@ namespace Hangfire.SqlServer
         private string GetAggregationQuery(SqlServerStorage storage)
         {
             var aggregationQuery = _sqlServerSettings != null &&
-                                   !string.IsNullOrEmpty(_sqlServerSettings.CountersAggregationQuery)
-                ? _sqlServerSettings.CountersAggregationQuery
+                                   !string.IsNullOrEmpty(_sqlServerSettings.CountersAggregationSql)
+                ? _sqlServerSettings.CountersAggregationSql
                 : @"
 DECLARE @RecordsToAggregate TABLE
 (

--- a/src/Hangfire.SqlServer/CountersAggregator.cs
+++ b/src/Hangfire.SqlServer/CountersAggregator.cs
@@ -88,11 +88,11 @@ OUTPUT DELETED.[Key], DELETED.[Value], DELETED.[ExpireAt] INTO @RecordsToAggrega
 
 SET NOCOUNT ON
 
-UPDATE [HangFire].[AggregatedCounter]
+UPDATE [{0}].[AggregatedCounter]
 SET 
 	[Value] = ac.[Value] + ra.[Value],
 	[ExpireAt] = (SELECT MAX([ExpireAt]) FROM (VALUES (ac.ExpireAt), (ra.[ExpireAt])) AS MaxExpireAt([ExpireAt]))
-FROM [HangFire].[AggregatedCounter] AS ac
+FROM [{0}].[AggregatedCounter] AS ac
 JOIN @RecordsToAggregate ra
 ON ac.[Key] = ra.[Key];
 
@@ -100,7 +100,7 @@ INSERT INTO [{0}].[AggregatedCounter]
 SELECT [Key], SUM([Value]) as [Value], MAX([ExpireAt]) AS [ExpireAt] 
 FROM @RecordsToAggregate 
 GROUP BY [Key]
-HAVING [Key] NOT IN (SELECT [Key] FROM [HangFire].[AggregatedCounter]);
+HAVING [Key] NOT IN (SELECT [Key] FROM [{0}].[AggregatedCounter]);
 
 COMMIT TRAN", storage.GetSchemaName());
         }

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -282,7 +282,7 @@ BEGIN
 		[Key] [nvarchar](100) NOT NULL,
 		[Field] [nvarchar](100) NOT NULL,
 		[Value] [nvarchar](max) NULL,
-		[ExpireAt] [datetime2](7) NULL,
+		[ExpireAt] [datetime] NULL,
 		
 		CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC)
 	);

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
@@ -72,7 +72,10 @@
     <Compile Include="IPersistentJobQueue.cs" />
     <Compile Include="IPersistentJobQueueMonitoringApi.cs" />
     <Compile Include="IPersistentJobQueueProvider.cs" />
+    <Compile Include="ISqlServerSettings.cs" />
     <Compile Include="PersistentJobQueueProviderCollection.cs" />
+    <Compile Include="SqlServer2005Settings.cs" />
+    <Compile Include="SqlServerDefaultSettings.cs" />
     <Compile Include="SqlServerJobQueue.cs" />
     <Compile Include="SqlServerFetchedJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -7,5 +7,6 @@
         string SetJobParameterSql { get; }
         string SetRangeInHashSql { get; }
         string AddToSetSql { get; }
+        string SetRangeInHashWriteOnlySql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -9,5 +9,6 @@
         string AddToSetSql { get; }
         string SetRangeInHashWriteOnlySql { get; }
         string AnnounceServerSql { get; }
+        string WithForceSeekSql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -8,5 +8,6 @@
         string SetRangeInHashSql { get; }
         string AddToSetSql { get; }
         string SetRangeInHashWriteOnlySql { get; }
+        string AnnounceServerSql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -5,5 +5,6 @@
         string TransformScript(string script);
         string CountersAggregationSql { get; }
         string SetJobParameterSql { get; }
+        string SetRangeInHashSql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -3,5 +3,6 @@
     public interface ISqlServerSettings
     {
         string TransformScript(string script);
+        string CountersAggregationQuery { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -3,6 +3,7 @@
     public interface ISqlServerSettings
     {
         string TransformScript(string script);
-        string CountersAggregationQuery { get; }
+        string CountersAggregationSql { get; }
+        string SetJobParameterSql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Hangfire.SqlServer
+{
+    public interface ISqlServerSettings
+    {
+        string TransformScript(string script);
+    }
+}

--- a/src/Hangfire.SqlServer/ISqlServerSettings.cs
+++ b/src/Hangfire.SqlServer/ISqlServerSettings.cs
@@ -6,5 +6,6 @@
         string CountersAggregationSql { get; }
         string SetJobParameterSql { get; }
         string SetRangeInHashSql { get; }
+        string AddToSetSql { get; }
     }
 }

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -281,7 +281,7 @@ BEGIN
 		[Key] [nvarchar](100) NOT NULL,
 		[Field] [nvarchar](100) NOT NULL,
 		[Value] [nvarchar](max) NULL,
-		[ExpireAt] [datetime2](7) NULL,
+		[ExpireAt] [datetime] NULL,
 		
 		CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC)
 	);

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Hangfire.SqlServer
+{
+    public class SqlServer2005Settings : ISqlServerSettings
+    {
+        public string TransformScript(string script)
+        {
+            return Regex.Replace(script, @"\[datetime2\]\([0-9]\)", "[datetime]");
+        }
+    }
+}

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -43,14 +43,17 @@ COMMIT TRAN"; } }
 
         public string SetJobParameterSql
         {
-            get { return @";BEGIN TRANSACTION;" 
-                    + @"UPDATE [{0}].JobParameter "
-                    + @"SET [Value] = @value "
-                    + @"WHERE JobId = @jobId AND [Name] = @name; "
-                    + @"IF @@ROWCOUNT = 0 "
-                    + @"INSERT INTO [{0}].JobParameter (JobId, Name, Value) "
-                    + @"VALUES(@jobId, @name, @value); "
-                    + @"COMMIT TRANSACTION;"; }
+            get
+            {
+                return @";BEGIN TRANSACTION;"
+                  + @"UPDATE [{0}].JobParameter "
+                  + @"SET [Value] = @value "
+                  + @"WHERE JobId = @jobId AND [Name] = @name; "
+                  + @"IF @@ROWCOUNT = 0 "
+                  + @"INSERT INTO [{0}].JobParameter (JobId, Name, Value) "
+                  + @"VALUES(@jobId, @name, @value); "
+                  + @"COMMIT TRANSACTION;";
+            }
         }
 
         public string SetRangeInHashSql { get { return @"
@@ -73,6 +76,17 @@ WHERE [Key] = @key AND Value = @value;
 IF @@ROWCOUNT = 0
 INSERT INTO [{0}].[Set] ([Key], Score, Value)
 VALUES(@key, @score, @value);
+COMMIT TRANSACTION;"; } }
+
+        public string SetRangeInHashWriteOnlySql { get { return @"
+;BEGIN TRANSACTION;
+UPDATE [{0}].Hash
+SET [Value] = @value
+WHERE [Key] = @key AND Field = @field;
+
+IF @@ROWCOUNT = 0
+INSERT INTO [{0}].Hash ([Key], Field, Value)
+VALUES(@key, @field, @value);
 COMMIT TRANSACTION;"; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -40,5 +40,17 @@ GROUP BY [Key]
 HAVING [Key] NOT IN (SELECT [Key] FROM [{0}].[AggregatedCounter]);
 
 COMMIT TRAN"; } }
+
+        public string SetJobParameterSql
+        {
+            get { return @";BEGIN TRANSACTION;" 
+                    + @"UPDATE [{0}].JobParameter "
+                    + @"SET [Value] = @value "
+                    + @"WHERE JobId = @jobId AND [Name] = @name; "
+                    + @"IF @@ROWCOUNT = 0 "
+                    + @"INSERT INTO [{0}].JobParameter (JobId, Name, Value) "
+                    + @"VALUES(@jobId, @name, @value); "
+                    + @"COMMIT TRANSACTION;"; }
+        }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -99,5 +99,7 @@ IF @@ROWCOUNT = 0
 INSERT INTO [{0}].Server (Id, Data, LastHeartbeat)
 VALUES(@id, @data, @heartbeat);
 COMMIT TRANSACTION;"; } }
+
+        public string WithForceSeekSql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -8,5 +8,37 @@ namespace Hangfire.SqlServer
         {
             return Regex.Replace(script, @"\[datetime2\]\([0-9]\)", "[datetime]");
         }
+
+        public string CountersAggregationQuery { get { return @"
+DECLARE @RecordsToAggregate TABLE
+(
+	[Key] NVARCHAR(100) NOT NULL,
+	[Value] SMALLINT NOT NULL,
+	[ExpireAt] DATETIME NULL
+)
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+BEGIN TRAN
+
+DELETE TOP (@count) [{0}].[Counter] with (readpast)
+OUTPUT DELETED.[Key], DELETED.[Value], DELETED.[ExpireAt] INTO @RecordsToAggregate
+
+SET NOCOUNT ON
+
+UPDATE [{0}].[AggregatedCounter]
+SET 
+	[Value] = ac.[Value] + ra.[Value],
+	[ExpireAt] = (SELECT MAX([ExpireAt]) FROM (VALUES (ac.ExpireAt), (ra.[ExpireAt])) AS MaxExpireAt([ExpireAt]))
+FROM [{0}].[AggregatedCounter] AS ac
+JOIN @RecordsToAggregate ra
+ON ac.[Key] = ra.[Key];
+
+INSERT INTO [{0}].[AggregatedCounter]
+SELECT [Key], SUM([Value]) as [Value], MAX([ExpireAt]) AS [ExpireAt] 
+FROM @RecordsToAggregate 
+GROUP BY [Key]
+HAVING [Key] NOT IN (SELECT [Key] FROM [{0}].[AggregatedCounter]);
+
+COMMIT TRAN"; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -88,5 +88,16 @@ IF @@ROWCOUNT = 0
 INSERT INTO [{0}].Hash ([Key], Field, Value)
 VALUES(@key, @field, @value);
 COMMIT TRANSACTION;"; } }
+
+        public string AnnounceServerSql { get { return @"
+;BEGIN TRANSACTION;
+;UPDATE [{0}].Server
+SET Data = @data, LastHeartbeat = @heartbeat
+WHERE [Id] = @id;
+
+IF @@ROWCOUNT = 0
+INSERT INTO [{0}].Server (Id, Data, LastHeartbeat)
+VALUES(@id, @data, @heartbeat);
+COMMIT TRANSACTION;"; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -9,7 +9,7 @@ namespace Hangfire.SqlServer
             return Regex.Replace(script, @"\[datetime2\]\([0-9]\)", "[datetime]");
         }
 
-        public string CountersAggregationQuery { get { return @"
+        public string CountersAggregationSql { get { return @"
 DECLARE @RecordsToAggregate TABLE
 (
 	[Key] NVARCHAR(100) NOT NULL,
@@ -52,5 +52,16 @@ COMMIT TRAN"; } }
                     + @"VALUES(@jobId, @name, @value); "
                     + @"COMMIT TRANSACTION;"; }
         }
+
+        public string SetRangeInHashSql { get { return @"
+;BEGIN TRANSACTION;
+UPDATE [{0}].Hash
+SET [Value] = @value
+WHERE [Key] = @key AND Field = @field;
+
+IF @@ROWCOUNT = 0
+INSERT INTO [{0}].Hash ([Key], Field, Value)
+VALUES(@key, @field, @value);
+COMMIT TRANSACTION;"; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServer2005Settings.cs
+++ b/src/Hangfire.SqlServer/SqlServer2005Settings.cs
@@ -63,5 +63,16 @@ IF @@ROWCOUNT = 0
 INSERT INTO [{0}].Hash ([Key], Field, Value)
 VALUES(@key, @field, @value);
 COMMIT TRANSACTION;"; } }
+
+        public string AddToSetSql { get { return @"
+;BEGIN TRANSACTION;
+UPDATE [{0}].[Set]
+SET Score = @score
+WHERE [Key] = @key AND Value = @value;
+
+IF @@ROWCOUNT = 0
+INSERT INTO [{0}].[Set] ([Key], Score, Value)
+VALUES(@key, @score, @value);
+COMMIT TRANSACTION;"; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -279,7 +279,7 @@ VALUES(@key, @field, @value);", _storage.GetSchemaName());
             return _storage.UseConnection(connection =>
             {
                 var result = connection.Query<SqlHash>(
-                    string.Format("select Field, Value from [{0}].Hash with (forceseek) where [Key] = @key", _storage.GetSchemaName()),
+                    string.Format("select Field, Value from [{0}].Hash where [Key] = @key", _storage.GetSchemaName()),
                     new { key })
                     .ToDictionary(x => x.Field, x => x.Value);
 

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -202,12 +202,13 @@ where j.Id = @jobId", _storage.GetSchemaName());
             _storage.UseConnection(connection =>
             {
                 connection.Execute(
-                    string.Format(@";merge [{0}].JobParameter with (holdlock) as Target "
-                    + @"using (VALUES (@jobId, @name, @value)) as Source (JobId, Name, Value) "
-                    + @"on Target.JobId = Source.JobId AND Target.Name = Source.Name "
-                    + @"when matched then update set Value = Source.Value "
-                    +
-                    @"when not matched then insert (JobId, Name, Value) values (Source.JobId, Source.Name, Source.Value);", _storage.GetSchemaName()),
+                    string.Format(@";UPDATE [{0}].JobParameter "
+                    + @"SET [Value] = @value "
+                    + @"WHERE JobId = @jobId AND [Name] = @name; "
+                    + @"IF @@ROWCOUNT = 0 "
+                    + @"INSERT INTO [HangFire].JobParameter (JobId, Name, Value) "
+                    + @"VALUES(@jobId, @name, @value);",
+                    _storage.GetSchemaName()),
                     new { jobId = id, name, value });
             });
         }

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -287,8 +287,13 @@ when not matched then insert ([Key], Field, Value) values (Source.[Key], Source.
 
             return _storage.UseConnection(connection =>
             {
+                var forceSeek = _storage.SqlServerSettings != null
+                    ? _storage.SqlServerSettings.WithForceSeekSql
+                    : " with (forceseek) ";
                 var result = connection.Query<SqlHash>(
-                    string.Format("select Field, Value from [{0}].Hash where [Key] = @key", _storage.GetSchemaName()),
+                    string.Format("select Field, Value from [{0}].Hash {1} where [Key] = @key", 
+                    _storage.GetSchemaName(),
+                    forceSeek),
                     new { key })
                     .ToDictionary(x => x.Field, x => x.Value);
 

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -255,11 +255,13 @@ where j.Id = @jobId", _storage.GetSchemaName());
             if (keyValuePairs == null) throw new ArgumentNullException("keyValuePairs");
 
             string sql = string.Format(@"
-;merge [{0}].Hash with (holdlock) as Target
-using (VALUES (@key, @field, @value)) as Source ([Key], Field, Value)
-on Target.[Key] = Source.[Key] and Target.Field = Source.Field
-when matched then update set Value = Source.Value
-when not matched then insert ([Key], Field, Value) values (Source.[Key], Source.Field, Source.Value);", _storage.GetSchemaName());
+;UPDATE [{0}].Hash
+SET [Value] = @value
+WHERE [Key] = @key AND Field = @field;
+
+IF @@ROWCOUNT = 0
+INSERT INTO [HangFire].Hash ([Key], Field, Value)
+VALUES(@key, @field, @value);", _storage.GetSchemaName());
 
             _storage.UseTransaction(connection =>
             {

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -7,7 +7,8 @@
             return script;
         }
 
-        public string CountersAggregationQuery { get { return null; } }
+        public string CountersAggregationSql { get { return null; } }
         public string SetJobParameterSql { get { return null; } }
+        public string SetRangeInHashSql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -13,5 +13,6 @@
         public string AddToSetSql { get { return null; } }
         public string SetRangeInHashWriteOnlySql { get { return null; } }
         public string AnnounceServerSql { get { return null; } }
+        public string WithForceSeekSql { get { return " with (forceseek) "; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace Hangfire.SqlServer
+{
+    public class SqlServerDefaultSettings : ISqlServerSettings
+    {
+        public string TransformScript(string script)
+        {
+            return script;
+        }
+    }
+}

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -8,5 +8,6 @@
         }
 
         public string CountersAggregationQuery { get { return null; } }
+        public string SetJobParameterSql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -6,5 +6,7 @@
         {
             return script;
         }
+
+        public string CountersAggregationQuery { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -12,5 +12,6 @@
         public string SetRangeInHashSql { get { return null; } }
         public string AddToSetSql { get { return null; } }
         public string SetRangeInHashWriteOnlySql { get { return null; } }
+        public string AnnounceServerSql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -11,5 +11,6 @@
         public string SetJobParameterSql { get { return null; } }
         public string SetRangeInHashSql { get { return null; } }
         public string AddToSetSql { get { return null; } }
+        public string SetRangeInHashWriteOnlySql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
+++ b/src/Hangfire.SqlServer/SqlServerDefaultSettings.cs
@@ -10,5 +10,6 @@
         public string CountersAggregationSql { get { return null; } }
         public string SetJobParameterSql { get { return null; } }
         public string SetRangeInHashSql { get { return null; } }
+        public string AddToSetSql { get { return null; } }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -492,7 +492,7 @@ where j.Id in @jobIds", _storage.GetSchemaName());
             string jobsSql = string.Format(@"
 select * from (
   select j.*, s.Reason as StateReason, s.Data as StateData, row_number() over (order by j.Id desc) as row_num
-  from [{0}].Job j with (forceseek)
+  from [{0}].Job j 
   left join [{0}].State s on j.StateId = s.Id
   where j.StateName = @stateName
 ) as j where j.row_num between @start and @end

--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -33,12 +33,7 @@ namespace Hangfire.SqlServer
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(SqlServerStorage));
 
-        public static void Install(SqlConnection connection)
-        {
-            Install(connection, null);
-        }
-
-        public static void Install(SqlConnection connection, string schema)
+        public static void Install(SqlConnection connection, string schema, ISqlServerSettings sqlServerSettings)
         {
             if (connection == null) throw new ArgumentNullException("connection");
 
@@ -56,6 +51,8 @@ namespace Hangfire.SqlServer
             script = script.Replace("SET @TARGET_SCHEMA_VERSION = 5;", "SET @TARGET_SCHEMA_VERSION = " + RequiredSchemaVersion + ";");
 
             script = script.Replace("$(HangFireSchema)", !string.IsNullOrWhiteSpace(schema) ? schema : Constants.DefaultSchema);
+
+            script = sqlServerSettings.TransformScript(script);
 
             for (var i = 0; i < RetryAttempts; i++)
             {

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -131,7 +131,7 @@ namespace Hangfire.SqlServer
         public override IEnumerable<IServerComponent> GetComponents()
         {
             yield return new ExpirationManager(this, _options.JobExpirationCheckInterval);
-            yield return new CountersAggregator(this, _options.CountersAggregateInterval);
+            yield return new CountersAggregator(this, _options.CountersAggregateInterval, SqlServerSettings);
         }
 
         public override void WriteOptionsToLog(ILog logger)

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -62,6 +62,8 @@ namespace Hangfire.SqlServer
 
             _options = options;
 
+            SetSqlServerVersionSettings(options);
+
             if (IsConnectionString(nameOrConnectionString))
             {
                 _connectionString = nameOrConnectionString;
@@ -81,12 +83,22 @@ namespace Hangfire.SqlServer
             {
                 using (var connection = CreateAndOpenConnection())
                 {
-                    SqlServerObjectsInstaller.Install(connection, options.SchemaName);
+                    SqlServerObjectsInstaller.Install(connection, options.SchemaName, SqlServerSettings);
                 }
             }
 
             InitializeQueueProviders();
         }
+
+        private void SetSqlServerVersionSettings(SqlServerStorageOptions options)
+        {
+            SqlServerSettings = options.SqlServer2005Compatibility
+                ? (ISqlServerSettings)new SqlServer2005Settings()
+                : new SqlServerDefaultSettings();
+        }
+
+        internal ISqlServerSettings SqlServerSettings { get; private set; }
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlServerStorage"/> class with

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -35,6 +35,7 @@ namespace Hangfire.SqlServer
             DashboardJobListLimit = 50000;
             _schemaName = Constants.DefaultSchema;
             TransactionTimeout = TimeSpan.FromMinutes(1);
+            SqlServer2005Compatibility = false;
         }
 
         public IsolationLevel? TransactionIsolationLevel { get; set; }
@@ -84,5 +85,11 @@ namespace Hangfire.SqlServer
                 _schemaName = value;
             }
         }
+
+        /// <summary>
+        /// Whether to run SQL compatible with SQL Server 2005 (true), or 
+        /// SQL optimised for 2008 and newer (false). Default is false.
+        /// </summary>
+        public bool SqlServer2005Compatibility { get; set; }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -164,7 +164,7 @@ SET Score = @score
 WHERE [Key] = @key AND Value = @value;
 
 IF @@ROWCOUNT = 0
-INSERT INTO [HangFire].[Set] ([Key], Score, Value)
+INSERT INTO [{0}].[Set] ([Key], Score, Value)
 VALUES(@key, @score, @value);", _storage.GetSchemaName());
 
             AcquireSetLock();
@@ -225,7 +225,7 @@ SET [Value] = @value
 WHERE [Key] = @key AND Field = @field;
 
 IF @@ROWCOUNT = 0
-INSERT INTO [HangFire].Hash ([Key], Field, Value)
+INSERT INTO [{0}].Hash ([Key], Field, Value)
 VALUES(@key, @field, @value);", _storage.GetSchemaName());
 
             AcquireHashLock();

--- a/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.csproj
+++ b/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="CountersAggregatorFacts.cs" />
     <Compile Include="PersistentJobQueueProviderCollectionFacts.cs" />
+    <Compile Include="SqlServer2005Facts.cs" />
     <Compile Include="SqlServerConnectionFacts.cs" />
     <Compile Include="ExpirationManagerFacts.cs" />
     <Compile Include="SqlServerJobQueueFacts.cs" />

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -36,6 +36,18 @@ namespace Hangfire.SqlServer.Tests
             Assert.False(new SqlServer2005Settings().TransformScript(script).Contains("datetime2"));
         }
 
+        [Fact]
+        public void CountersAggregationQuery_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().CountersAggregationQuery.Contains("UPDATE"));
+        }
+
+        [Fact]
+        public void CountersAggregationQuery_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().CountersAggregationQuery));
+        }
+
         private static string GetStringResource(Assembly assembly, string resourceName)
         {
             using (var stream = assembly.GetManifestResourceStream(resourceName))

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -75,6 +75,19 @@ namespace Hangfire.SqlServer.Tests
             Assert.False(new SqlServer2005Settings().SetRangeInHashSql.Contains("merge"));
         }
 
+        [Fact]
+        public void AddToSetSql_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().AddToSetSql));
+        }
+
+        [Fact]
+        public void AddToSetSql_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().AddToSetSql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().AddToSetSql.Contains("merge"));
+        }
+
         private static string GetStringResource(Assembly assembly, string resourceName)
         {
             using (var stream = assembly.GetManifestResourceStream(resourceName))

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -101,6 +101,19 @@ namespace Hangfire.SqlServer.Tests
             Assert.False(new SqlServer2005Settings().SetRangeInHashWriteOnlySql.Contains("merge"));
         }
 
+        [Fact]
+        public void AnnounceServerSql_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().AnnounceServerSql));
+        }
+
+        [Fact]
+        public void AnnounceServerSql_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().AnnounceServerSql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().AnnounceServerSql.Contains("merge"));
+        }
+
         private static string GetStringResource(Assembly assembly, string resourceName)
         {
             using (var stream = assembly.GetManifestResourceStream(resourceName))

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -102,6 +102,19 @@ namespace Hangfire.SqlServer.Tests
         }
 
         [Fact]
+        public void WithForceSeekSql_BlankIn2005()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServer2005Settings().WithForceSeekSql));
+        }
+
+        [Fact]
+        public void WithForceSeekSql_PresentInDefault()
+        {
+            Assert.False(string.IsNullOrEmpty(new SqlServerDefaultSettings().WithForceSeekSql));
+            Assert.True(new SqlServerDefaultSettings().WithForceSeekSql.Contains("forceseek"));
+        }
+
+        [Fact]
         public void AnnounceServerSql_BlankInDefault()
         {
             Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().AnnounceServerSql));

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -88,6 +88,19 @@ namespace Hangfire.SqlServer.Tests
             Assert.False(new SqlServer2005Settings().AddToSetSql.Contains("merge"));
         }
 
+        [Fact]
+        public void SetRangeInHashWriteOnlySql_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().SetRangeInHashWriteOnlySql));
+        }
+
+        [Fact]
+        public void SetRangeInHashWriteOnlySql_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().SetRangeInHashWriteOnlySql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().SetRangeInHashWriteOnlySql.Contains("merge"));
+        }
+
         private static string GetStringResource(Assembly assembly, string resourceName)
         {
             using (var stream = assembly.GetManifestResourceStream(resourceName))

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -39,14 +39,14 @@ namespace Hangfire.SqlServer.Tests
         [Fact]
         public void CountersAggregationQuery_BlankInDefault()
         {
-            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().CountersAggregationQuery));
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().CountersAggregationSql));
         }
 
         [Fact]
         public void CountersAggregationQuery_PresentIn2005()
         {
-            Assert.True(new SqlServer2005Settings().CountersAggregationQuery.Contains("UPDATE"));
-            Assert.False(new SqlServer2005Settings().CountersAggregationQuery.Contains("merge"));
+            Assert.True(new SqlServer2005Settings().CountersAggregationSql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().CountersAggregationSql.Contains("merge"));
         }
 
         [Fact]
@@ -60,6 +60,19 @@ namespace Hangfire.SqlServer.Tests
         {
             Assert.True(new SqlServer2005Settings().SetJobParameterSql.Contains("UPDATE"));
             Assert.False(new SqlServer2005Settings().SetJobParameterSql.Contains("merge"));
+        }
+
+        [Fact]
+        public void SetRangeInHash_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().SetRangeInHashSql));
+        }
+
+        [Fact]
+        public void SetRangeInHash_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().SetRangeInHashSql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().SetRangeInHashSql.Contains("merge"));
         }
 
         private static string GetStringResource(Assembly assembly, string resourceName)

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace Hangfire.SqlServer.Tests
+{
+    public class SqlServer2005Facts
+    {
+        [Fact]
+        public void Ctor_CreatesDefaultSettings()
+        {
+            var options = new SqlServerStorageOptions();
+            var storage = new SqlServerStorage(ConnectionUtils.GetConnectionString(), options);
+            Assert.Equal(typeof(SqlServerDefaultSettings), storage.SqlServerSettings.GetType());
+        }
+
+        [Fact]
+        public void Ctor_CreatesSqlServer2005Settings()
+        {
+            var options = new SqlServerStorageOptions
+            {
+                SqlServer2005Compatibility = true
+            };
+            var storage = new SqlServerStorage(ConnectionUtils.GetConnectionString(), options);
+            Assert.Equal(typeof(SqlServer2005Settings), storage.SqlServerSettings.GetType());
+        }
+
+        [Fact]
+        public void TransformScript_RemovesDateTime2()
+        {
+            var script = GetStringResource(
+                typeof(SqlServerObjectsInstaller).Assembly,
+                "Hangfire.SqlServer.Install.sql");
+
+            Assert.False(new SqlServer2005Settings().TransformScript(script).Contains("datetime2"));
+        }
+
+        private static string GetStringResource(Assembly assembly, string resourceName)
+        {
+            using (var stream = assembly.GetManifestResourceStream(resourceName))
+            {
+                if (stream == null)
+                {
+                    throw new InvalidOperationException(String.Format(
+                        "Requested resource `{0}` was not found in the assembly `{1}`.",
+                        resourceName,
+                        assembly));
+                }
+
+                using (var reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+    }
+}

--- a/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServer2005Facts.cs
@@ -37,15 +37,29 @@ namespace Hangfire.SqlServer.Tests
         }
 
         [Fact]
-        public void CountersAggregationQuery_PresentIn2005()
-        {
-            Assert.True(new SqlServer2005Settings().CountersAggregationQuery.Contains("UPDATE"));
-        }
-
-        [Fact]
         public void CountersAggregationQuery_BlankInDefault()
         {
             Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().CountersAggregationQuery));
+        }
+
+        [Fact]
+        public void CountersAggregationQuery_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().CountersAggregationQuery.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().CountersAggregationQuery.Contains("merge"));
+        }
+
+        [Fact]
+        public void SetJobParameterSql_BlankInDefault()
+        {
+            Assert.True(string.IsNullOrEmpty(new SqlServerDefaultSettings().SetJobParameterSql));
+        }
+
+        [Fact]
+        public void SetJobParameterSql_PresentIn2005()
+        {
+            Assert.True(new SqlServer2005Settings().SetJobParameterSql.Contains("UPDATE"));
+            Assert.False(new SqlServer2005Settings().SetJobParameterSql.Contains("merge"));
         }
 
         private static string GetStringResource(Assembly assembly, string resourceName)

--- a/tests/Hangfire.SqlServer.Tests/StorageOptionsFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/StorageOptionsFacts.cs
@@ -14,6 +14,7 @@ namespace Hangfire.SqlServer.Tests
             Assert.True(options.InvisibilityTimeout > TimeSpan.Zero);
             Assert.True(options.JobExpirationCheckInterval > TimeSpan.Zero);
             Assert.True(options.PrepareSchemaIfNecessary);
+            Assert.False(options.SqlServer2005Compatibility);
         }
 
         [Fact]

--- a/tests/Hangfire.SqlServer.Tests/Utils/CleanDatabaseAttribute.cs
+++ b/tests/Hangfire.SqlServer.Tests/Utils/CleanDatabaseAttribute.cs
@@ -72,7 +72,7 @@ namespace Hangfire.SqlServer.Tests
             using (var connection = new SqlConnection(
                 ConnectionUtils.GetConnectionString()))
             {
-                SqlServerObjectsInstaller.Install(connection);
+                SqlServerObjectsInstaller.Install(connection, null, new SqlServerDefaultSettings());
             }
         }
     }


### PR DESCRIPTION
Tentative changes to allow Hangfire to work with SQL Server 2005.
- Changed `datetime2` column to `datetime`
- Changed SQL `merge` commands to separate `insert` and `update` commands
- Removed the `forceseek` table hints

Whilst the SQL unit tests pass, and my installation works with a simple background job, I am wary of any side effects that this PR may cause.
