### PR TITLE
Make SqlServerObjectsInstaller public

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -26,9 +26,9 @@ using Hangfire.Logging;
 namespace Hangfire.SqlServer
 {
     [ExcludeFromCodeCoverage]
-    internal static class SqlServerObjectsInstaller
+    public static class SqlServerObjectsInstaller
     {
-        private const int RequiredSchemaVersion = 5;
+        public static readonly int RequiredSchemaVersion = 5;
         private const int RetryAttempts = 3;
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(SqlServerStorage));


### PR DESCRIPTION
We have the need to run the update the HangFire during our database update / release process. The only current way is to create an instance of `SqlServerStorage` that does a bunch of other things or call the method via reflection.

This PR represent the simplest change to make it happen but i'm open to any other method as long as we can initialize the database separately from the Hangfire startup.