### PR TITLE
Fix Hangfire.SqlServer dependency version in MSMQ nuspec

### DIFF
--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -23,7 +23,7 @@
     </releaseNotes>
     <dependencies>
       <dependency id="Hangfire.Core" version="[0.0.0]" />
-      <dependency id="Hangfire.SqlServer" version="1.2.2" />
+      <dependency id="Hangfire.SqlServer" version="[0.0.0]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
`Hangfire.SqlServer.Msmq.nuspec` file points to `Hangfire.SqlServer` 1.2.2 dependency instead of a current one.