### PR TITLE
Fix for ToGenericTypeString method to support nested classes

### DIFF
--- a/src/Hangfire.Core/Common/TypeExtensions.cs
+++ b/src/Hangfire.Core/Common/TypeExtensions.cs
@@ -1,24 +1,58 @@
 ﻿using System;
 using System.Linq;
-using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Hangfire.Common
 {
     internal static class TypeExtensions
     {
-        public static string ToGenericTypeString(this Type t)
+        public static string ToGenericTypeString(this Type type)
         {
-            if (!t.GetTypeInfo().IsGenericType)
+            if (!type.IsGenericType)
             {
-                return t.Name;
+                return type.GetFullNameWithoutNamespace()
+                        .ReplacePlusWithDotInNestedTypeName();
             }
 
-            var genericTypeName = t.GetGenericTypeDefinition().Name;
-            genericTypeName = genericTypeName.Substring(0, genericTypeName.IndexOf('`'));
+            return type.GetGenericTypeDefinition()
+                    .GetFullNameWithoutNamespace()
+                    .ReplacePlusWithDotInNestedTypeName()
+                    .ReplaceGenericParametersInGenericTypeName(type);
+        }
 
-            var genericArgs = string.Join(",", t.GetGenericArguments().Select(ToGenericTypeString).ToArray());
+        private static string GetFullNameWithoutNamespace(this Type type)
+        {
+            if (type.IsGenericParameter)
+            {
+                return type.Name;
+            }
 
-            return genericTypeName + "<" + genericArgs + ">";
+            const int dotLength = 1;
+            return type.FullName.Substring(type.Namespace.Length + dotLength);
+        }
+
+        private static string ReplacePlusWithDotInNestedTypeName(this string typeName)
+        {
+            return typeName.Replace('+', '.');
+        }
+
+        private static string ReplaceGenericParametersInGenericTypeName(this string typeName, Type type)
+        {
+            var genericArguments = type.GetGenericArguments();
+
+            const string regexForGenericArguments = @"`[1-9]\d*";
+
+            var rgx = new Regex(regexForGenericArguments);
+
+            typeName = rgx.Replace(typeName, match =>
+            {
+                var currentGenericArgumentNumbers = int.Parse(match.Value.Substring(1));
+                var currentArguments = string.Join(",", genericArguments.Take(currentGenericArgumentNumbers).Select(ToGenericTypeString));
+                genericArguments = genericArguments.Skip(currentGenericArgumentNumbers).ToArray();
+                return string.Concat("<", currentArguments, ">");
+            });
+
+            return typeName;
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using Hangfire.Common;
+using Xunit;
+
+namespace Hangfire.Core.Tests.Common
+{
+	public class TypeExtensionsFacts
+	{
+        [Fact]
+        public void ToGenericTypeString_PrintsNonGenericNestedClassName_WithDot()
+        {
+            Assert.Equal(typeof(NonGenericClass).ToGenericTypeString(), "NonGenericClass");
+            Assert.Equal(typeof(NonGenericClass.NestedNonGenericClass).ToGenericTypeString(), "NonGenericClass.NestedNonGenericClass");
+            Assert.Equal(typeof(NonGenericClass.NestedNonGenericClass.DoubleNestedNonGenericClass).ToGenericTypeString(), "NonGenericClass.NestedNonGenericClass.DoubleNestedNonGenericClass");
+        }	    
+
+        [Fact]
+        public void ToGenericTypeString_PrintsOpenGenericNestedClassName_WithGenericParameters()
+	    {
+            Assert.Equal(typeof(NonGenericClass.NestedGenericClass<,>).ToGenericTypeString(), "NonGenericClass.NestedGenericClass<T1,T2>");
+	        Assert.Equal(typeof(GenericClass<>).ToGenericTypeString(), "GenericClass<T0>");
+            Assert.Equal(typeof(GenericClass<>.NestedNonGenericClass).ToGenericTypeString(), "GenericClass<T0>.NestedNonGenericClass");
+            Assert.Equal(typeof(GenericClass<>.NestedNonGenericClass.DoubleNestedGenericClass<,,>).ToGenericTypeString(), "GenericClass<T0>.NestedNonGenericClass.DoubleNestedGenericClass<T1,T2,T3>");
+        }	    
+        
+        [Fact]
+        public void ToGenericTypeString_PrintsClosedGenericNestedClassName_WithGivenTypes()
+	    {
+            Assert.Equal(typeof(NonGenericClass.NestedGenericClass<Assert, List<Assert>>).ToGenericTypeString(), "NonGenericClass.NestedGenericClass<Assert,List<Assert>>");
+            Assert.Equal(typeof(GenericClass<Assert>).ToGenericTypeString(), "GenericClass<Assert>");
+            Assert.Equal(typeof(GenericClass<List<Assert>>.NestedNonGenericClass).ToGenericTypeString(), "GenericClass<List<Assert>>.NestedNonGenericClass");
+            Assert.Equal(typeof(GenericClass<List<GenericClass<List<Assert>>.NestedNonGenericClass.DoubleNestedGenericClass<Assert, List<Assert>, Stack<Assert>>>>.NestedNonGenericClass.DoubleNestedGenericClass<Assert, List<Assert>, Stack<Assert>>).ToGenericTypeString(), "GenericClass<List<GenericClass<List<Assert>>.NestedNonGenericClass.DoubleNestedGenericClass<Assert,List<Assert>,Stack<Assert>>>>.NestedNonGenericClass.DoubleNestedGenericClass<Assert,List<Assert>,Stack<Assert>>");        
+	    }
+	}
+
+    public class GenericClass<T0>
+    {
+        public class NestedNonGenericClass
+        {
+            public class DoubleNestedGenericClass<T1, T2, T3>
+            {
+
+            }
+        }
+    }
+
+    public class NonGenericClass
+    {
+        public class NestedNonGenericClass
+        {
+            public class DoubleNestedNonGenericClass
+            {
+
+            }
+        }
+
+        public class NestedGenericClass<T1, T2>
+        {
+        }
+    }
+}

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Common\JobFilterProviderCollectionFacts.cs" />
     <Compile Include="Common\JobHelperFacts.cs" />
     <Compile Include="Common\JobLoadExceptionFacts.cs" />
+    <Compile Include="Common\TypeExtensionsFacts.cs" />	
     <Compile Include="CronFacts.cs" />
     <Compile Include="GlobalStateHandlersFacts.cs" />
     <Compile Include="JobActivatorFacts.cs" />


### PR DESCRIPTION
Current version of ToGenericTypeString method doesn't support nested classes. 
This is my fix for it. Commit also contains some tests to prove its correctness.