### PR TITLE
Add context for JobActivator.BeginScope

### DIFF
--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -82,6 +82,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
+    <Compile Include="JobActivatorContext.cs" />
     <Compile Include="Obsolete\Job.Obsolete.cs" />
     <Compile Include="Common\TypeExtensions.cs" />
     <Compile Include="Dashboard\OwinRequestExtensions.cs" />

--- a/src/Hangfire.Core/JobActivator.cs
+++ b/src/Hangfire.Core/JobActivator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Hangfire.Annotations;
+using Hangfire.Server;
 
 namespace Hangfire
 {
@@ -42,14 +43,21 @@ namespace Hangfire
             }
         }
 
+        
         public virtual object ActivateJob(Type jobType)
         {
             return Activator.CreateInstance(jobType);
         }
 
+        [Obsolete("Please implement/use the BeginScope(JobActivatorContext) method instead. Will be removed in 2.0.0.")]
         public virtual JobActivatorScope BeginScope()
         {
             return new SimpleJobActivatorScope(this);
+        }
+
+        public virtual JobActivatorScope BeginScope(JobActivatorContext context)
+        {
+            return BeginScope();
         }
 
         class SimpleJobActivatorScope : JobActivatorScope

--- a/src/Hangfire.Core/JobActivatorContext.cs
+++ b/src/Hangfire.Core/JobActivatorContext.cs
@@ -1,0 +1,75 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Hangfire.Annotations;
+using Hangfire.Common;
+using Hangfire.Server;
+using Hangfire.Storage;
+
+namespace Hangfire
+{
+    public class JobActivatorContext
+    {
+        internal JobActivatorContext(
+            [NotNull] IStorageConnection connection,
+            [NotNull] BackgroundJob backgroundJob,
+            [NotNull] IJobCancellationToken cancellationToken)
+        {
+            if (connection == null) throw new ArgumentNullException("connection");
+            if (backgroundJob == null) throw new ArgumentNullException("backgroundJob");
+            if (cancellationToken == null) throw new ArgumentNullException("cancellationToken");
+
+            Connection = connection;
+            BackgroundJob = backgroundJob;
+            CancellationToken = cancellationToken;
+        }
+
+        [NotNull]
+        public BackgroundJob BackgroundJob { get; private set; }
+
+        [NotNull]
+        public IJobCancellationToken CancellationToken { get; private set; }
+
+        [NotNull]
+        public IStorageConnection Connection { get; private set; }
+
+        public void SetJobParameter(string name, object value)
+        {
+            if (String.IsNullOrEmpty(name)) throw new ArgumentNullException("name");
+
+            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.ToJson(value));
+        }
+
+        public T GetJobParameter<T>(string name)
+        {
+            if (String.IsNullOrEmpty(name)) throw new ArgumentNullException("name");
+
+            try
+            {
+                return JobHelper.FromJson<T>(Connection.GetJobParameter(BackgroundJob.Id, name));
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(String.Format(
+                    "Could not get a value of the job parameter `{0}`. See inner exception for details.",
+                    name), ex);
+            }
+        }
+    }
+}

--- a/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
@@ -42,7 +42,8 @@ namespace Hangfire.Server
 
         public object Perform(PerformContext context)
         {
-            using (var scope = _activator.BeginScope())
+            using (var scope = _activator.BeginScope(
+                new JobActivatorContext(context.Connection, context.BackgroundJob, context.CancellationToken)))
             {
                 object instance = null;
 

--- a/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
@@ -35,7 +35,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_CanInvokeStaticMethods()
+        public void Perform_CanInvokeStaticMethods()
         {
             _methodInvoked = false;
             _context.BackgroundJob.Job = Job.FromExpression(() => StaticMethod());
@@ -47,7 +47,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_CanInvokeInstanceMethods()
+        public void Perform_CanInvokeInstanceMethods()
         {
             _methodInvoked = false;
             _context.BackgroundJob.Job = Job.FromExpression<CoreBackgroundJobPerformerFacts>(x => x.InstanceMethod());
@@ -59,7 +59,18 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_DisposesDisposableInstance_AfterPerformance()
+        public void Perform_ActivatesJob_WithinAScope()
+        {
+            var performer = CreatePerformer();
+            _context.BackgroundJob.Job = Job.FromExpression<CoreBackgroundJobPerformerFacts>(x => x.InstanceMethod());
+
+            performer.Perform(_context.Object);
+
+            _activator.Verify(x => x.BeginScope(It.IsNotNull<JobActivatorContext>()), Times.Once);
+        }
+
+        [Fact, StaticLock]
+        public void Perform_DisposesDisposableInstance_AfterPerformance()
         {
             _disposed = false;
             _context.BackgroundJob.Job = Job.FromExpression<Disposable>(x => x.Method());
@@ -71,7 +82,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_PassesArguments_ToACallingMethod()
+        public void Perform_PassesArguments_ToACallingMethod()
         {
             // Arrange
             _methodInvoked = false;
@@ -86,7 +97,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_PassesCorrectDateTime_IfItWasSerialized_UsingTypeConverter()
+        public void Perform_PassesCorrectDateTime_IfItWasSerialized_UsingTypeConverter()
         {
             // Arrange
             _methodInvoked = false;
@@ -107,7 +118,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_PassesCorrectDateTime_IfItWasSerialized_UsingOldFormat()
+        public void Perform_PassesCorrectDateTime_IfItWasSerialized_UsingOldFormat()
         {
             // Arrange
             _methodInvoked = false;
@@ -127,7 +138,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_PassesCorrectDateTimeArguments()
+        public void Perform_PassesCorrectDateTimeArguments()
         {
             // Arrange
             _methodInvoked = false;
@@ -142,7 +153,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_WorksCorrectly_WithNullValues()
+        public void Perform_WorksCorrectly_WithNullValues()
         {
             // Arrange
             _methodInvoked = false;
@@ -157,7 +168,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ThrowsException_WhenActivatorThrowsAnException()
+        public void Perform_ThrowsException_WhenActivatorThrowsAnException()
         {
             // Arrange
             var exception = new InvalidOperationException();
@@ -172,7 +183,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ThrowsPerformanceException_WhenActivatorReturnsNull()
+        public void Perform_ThrowsPerformanceException_WhenActivatorReturnsNull()
         {
             _activator.Setup(x => x.ActivateJob(It.IsNotNull<Type>())).Returns(null);
             _context.BackgroundJob.Job = Job.FromExpression(() => InstanceMethod());
@@ -183,7 +194,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ThrowsPerformanceException_OnArgumentsDeserializationFailure()
+        public void Perform_ThrowsPerformanceException_OnArgumentsDeserializationFailure()
         {
             var type = typeof(JobFacts);
             var method = type.GetMethod("MethodWithDateTimeArgument");
@@ -197,7 +208,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact, StaticLock]
-        public void Run_ThrowsPerformanceException_OnDisposalFailure()
+        public void Perform_ThrowsPerformanceException_OnDisposalFailure()
         {
             _methodInvoked = false;
             _context.BackgroundJob.Job = Job.FromExpression<BrokenDispose>(x => x.Method());
@@ -210,7 +221,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ThrowsPerformanceException_WithUnwrappedInnerException()
+        public void Perform_ThrowsPerformanceException_WithUnwrappedInnerException()
         {
             _context.BackgroundJob.Job = Job.FromExpression(() => ExceptionMethod());
             var performer = CreatePerformer();
@@ -223,7 +234,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ThrowsPerformanceException_WhenMethodThrownTaskCanceledException()
+        public void Perform_ThrowsPerformanceException_WhenMethodThrownTaskCanceledException()
         {
             _context.BackgroundJob.Job = Job.FromExpression(() => TaskCanceledExceptionMethod());
             var performer = CreatePerformer();
@@ -235,7 +246,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_PassesCancellationToken_IfThereIsIJobCancellationTokenParameter()
+        public void Perform_PassesCancellationToken_IfThereIsIJobCancellationTokenParameter()
         {
             // Arrange
             _context.BackgroundJob.Job = Job.FromExpression(() => CancelableJob(JobCancellationToken.Null));
@@ -248,7 +259,7 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Run_ReturnsValue_WhenCallingFunctionReturningValue()
+        public void Perform_ReturnsValue_WhenCallingFunctionReturningValue()
         {
             _context.BackgroundJob.Job = Job.FromExpression<JobFacts.Instance>(x => x.FunctionReturningValue());
             var performer = CreatePerformer();


### PR DESCRIPTION
This allows to inject specific services in IoC containers based on background job metadata.