### PR TITLE
Updating StackTraceParser to prevent critical flaw

### DIFF
--- a/src/Hangfire.Core/packages.config
+++ b/src/Hangfire.Core/packages.config
@@ -8,5 +8,5 @@
   <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="StackTraceFormatter.Source" version="1.0.0" targetFramework="net45" />
-  <package id="StackTraceParser.Source" version="1.1.1" targetFramework="net45" />
+  <package id="StackTraceParser.Source" version="1.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The StackTraceParser had a critical flaw that caused the server to hang when specific error messages were returned (https://github.com/atifaziz/StackTraceParser/issues/4). This just replaces the parser with the updated version to avoid such problems.