### PR TITLE
Fix for #500, BackgroundJob.Delete may hang forever

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
-sudo: false
+sudo: required
 
 # Make sure build dependencies are installed.
 install:

--- a/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
+++ b/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
@@ -127,6 +127,12 @@ namespace Hangfire.States
             while (true)
             {
                 var jobData = context.Connection.GetJobData(context.BackgroundJobId);
+
+                if (jobData == null)
+                {
+                    return null;
+                }
+
                 if (jobData != null && !String.IsNullOrEmpty(jobData.State))
                 {
                     return jobData;

--- a/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
+++ b/src/Hangfire.Core/States/BackgroundJobStateChanger.cs
@@ -122,31 +122,13 @@ namespace Hangfire.States
 
         private static JobData GetJobData(StateChangeContext context)
         {
-            var firstAttempt = true;
-
-            while (true)
-            {
-                var jobData = context.Connection.GetJobData(context.BackgroundJobId);
-
-                if (jobData == null)
-                {
-                    return null;
-                }
-
-                if (jobData != null && !String.IsNullOrEmpty(jobData.State))
-                {
-                    return jobData;
-                }
-
-                if (context.CancellationToken.IsCancellationRequested ||
+            if (context.CancellationToken.IsCancellationRequested ||
                     context.CancellationToken == CancellationToken.None)
-                {
-                    return null;
-                }
-
-                Thread.Sleep(firstAttempt ? 0 : 100);
-                firstAttempt = false;
+            {
+                return null;
             }
+
+            return context.Connection.GetJobData(context.BackgroundJobId);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/States/BackgroundJobStateChangerFacts.cs
+++ b/tests/Hangfire.Core.Tests/States/BackgroundJobStateChangerFacts.cs
@@ -172,7 +172,6 @@ namespace Hangfire.Core.Tests.States
         {
             // Arrange
             var results = new Queue<JobData>();
-            results.Enqueue(null);
             results.Enqueue(new JobData { Job = _job, State = null });
             results.Enqueue(new JobData { Job = _job, State = OldStateName });
 

--- a/tests/Hangfire.Core.Tests/States/BackgroundJobStateChangerFacts.cs
+++ b/tests/Hangfire.Core.Tests/States/BackgroundJobStateChangerFacts.cs
@@ -172,7 +172,6 @@ namespace Hangfire.Core.Tests.States
         {
             // Arrange
             var results = new Queue<JobData>();
-            results.Enqueue(new JobData { Job = _job, State = null });
             results.Enqueue(new JobData { Job = _job, State = OldStateName });
 
             _connection.Setup(x => x.GetJobData(It.IsAny<string>()))


### PR DESCRIPTION
Added null handling to prevent an infinite loop if an attempt is made to delete a job
that doesn't exist