### PR TITLE
Add support for async Task methods

### DIFF
--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -21,6 +21,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using Hangfire.Annotations;
+using System.Runtime.CompilerServices;
 
 namespace Hangfire.Common
 {
@@ -329,6 +330,11 @@ namespace Hangfire.Common
                 throw new ArgumentException(
                     String.Format("The type `{0}` must be derived from the `{1}` type.", method.DeclaringType, type),
                     typeParameterName);
+            }
+
+            if (method.ReturnType == typeof(void) && method.GetCustomAttribute<AsyncStateMachineAttribute>() != null)
+            {
+                throw new NotSupportedException("Async void methods are not supported. Use async Task instead.");
             }
 
             var parameters = method.GetParameters();

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -331,11 +331,6 @@ namespace Hangfire.Common
                     typeParameterName);
             }
 
-            if (typeof(Task).IsAssignableFrom(method.ReturnType))
-            {
-                throw new NotSupportedException("Async methods are not supported. Please make them synchronous before using them in background.");
-            }
-
             var parameters = method.GetParameters();
 
             if (parameters.Length != argumentCount)

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -100,15 +100,6 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
-        public void Ctor_ThrowsAnException_WhenMethodReturns_Task()
-        {
-            var method = _type.GetMethod("AsyncMethod");
-
-            Assert.Throws<NotSupportedException>(
-                () => new Job(_type, method, new string[0]));
-        }
-
-        [Fact]
         public void FromStaticExpression_ShouldThrowException_WhenNullExpressionProvided()
         {
             var exception = Assert.Throws<ArgumentNullException>(
@@ -588,6 +579,18 @@ namespace Hangfire.Core.Tests.Common
             public string FunctionReturningValue()
             {
                 return "Return value";
+            }
+
+            public async Task FunctionReturningTask()
+            {
+                await Task.Yield();
+            }
+
+            public async Task<string> FunctionReturningTaskResultingInString()
+            {
+                await Task.Yield();
+
+                return FunctionReturningValue();
             }
         }
 

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -159,6 +159,15 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
+        public void Ctor_ThrowsAnException_WhenMethodIsAsyncVoid()
+        {
+            var method = typeof(JobFacts).GetMethod(nameof(AsyncVoidMethod));
+
+            Assert.Throws<NotSupportedException>(
+                () => new Job(typeof(JobFacts), method, new string[0]));
+        }
+
+        [Fact]
         public void FromInstanceExpression_ShouldThrowException_WhenNullExpressionIsProvided()
         {
             var exception = Assert.Throws<ArgumentNullException>(
@@ -560,6 +569,10 @@ namespace Hangfire.Core.Tests.Common
         {
             var source = new TaskCompletionSource<bool>();
             return source.Task;
+        }
+
+        public async void AsyncVoidMethod()
+        {
         }
 
         [TestType]


### PR DESCRIPTION
Fixes #150

I also added a test that confirms that a method can accept a standard .NET `CancellationToken` and addressed two of the items mentioned on the previous PR (disallowing `async void` methods and unwrapping `AggregateException`s when possible.)