### PR TITLE
Add feature to ensure ordered job dequeing in SQL server

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -54,7 +54,7 @@ namespace Hangfire.SqlServer
 delete top (1) from [{0}].JobQueue with (readpast, updlock, rowlock)
 output DELETED.Id, DELETED.JobId, DELETED.Queue
 where (FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))
-and Queue in @queues", _storage.GetSchemaName());
+and Queue in @queues {1}", _storage.GetSchemaName(), _options.EnsureJobOrder?" order by Id ASC":"");
 
             do
             {

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -37,6 +37,14 @@ namespace Hangfire.SqlServer
             TransactionTimeout = TimeSpan.FromMinutes(1);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether job dequeing is ensured ordered (FIFO) 
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> Ensure job order; otherwise, <c>false</c>.
+        /// </value>
+        public bool EnsureJobOrder { get; set; }
+
         public IsolationLevel? TransactionIsolationLevel { get; set; }
 
         public TimeSpan QueuePollInterval


### PR DESCRIPTION
It should fix  #398 by ensuring the dequeing order, but I'm not sure if jobs could be added to Job and JobQueque tables in different order, if there is no lock on enqueing