### PR TITLE
Changing ScheduleInstant to use UTC to get next run date

### DIFF
--- a/src/Hangfire.Core/Server/ScheduleInstant.cs
+++ b/src/Hangfire.Core/Server/ScheduleInstant.cs
@@ -43,17 +43,7 @@ namespace Hangfire.Server
 
             NowInstant = nowInstant.AddSeconds(-nowInstant.Second);
 
-            var nextOccurrences = _schedule.GetNextOccurrences(
-                TimeZoneInfo.ConvertTime(NowInstant, TimeZoneInfo.Utc, _timeZone),
-                DateTime.MaxValue);
-
-            foreach (var nextOccurrence in nextOccurrences)
-            {
-                if (_timeZone.IsInvalidTime(nextOccurrence)) continue;
-
-                NextInstant = TimeZoneInfo.ConvertTime(nextOccurrence, _timeZone, TimeZoneInfo.Utc);
-                break;
-            }
+            NextInstant = _schedule.GetNextOccurrence(NowInstant, DateTime.MaxValue);
         }
 
         public DateTime NowInstant { get; private set; }

--- a/tests/Hangfire.Core.Tests/Server/ScheduleInstantFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ScheduleInstantFacts.cs
@@ -86,6 +86,23 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
+        public void NextInstant_DoesntThrow_NearEndOfDaylightSavings()
+        {
+            // Arrange
+            _timeZone = GetNewYorkTimeZone();
+            _now = new DateTime(2016, 11, 6, 5, 59, 0, DateTimeKind.Utc);
+            _schedule = CrontabSchedule.Parse("* * * * *");
+            
+            var instant = CreateInstant(_now);
+
+            // Act
+            var value = instant.NextInstant;
+
+            // Assert
+            Assert.Equal(new DateTime(2016, 11, 6, 6, 0, 0), value);
+        }
+
+        [Fact]
         public void GetNextInstants_DoesntThrow_NearDaylightSavings()
         {
             // Arrange


### PR DESCRIPTION
Found an issue when the clocks go back jobs don't run for an hour. Reference: https://github.com/HangfireIO/Hangfire/issues/567

ScheduleInstant uses NCrontab to get the next occurrence in the schedule. This doesn't support time zones so needs to be passed UTC.
