### PR TITLE
Add missing transaction to KeepAliveQuery.

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerFetchedJob.cs
+++ b/src/Hangfire.SqlServer/SqlServerFetchedJob.cs
@@ -96,7 +96,7 @@ namespace Hangfire.SqlServer
             {
                 try
                 {
-                    _connection?.Execute("SELECT 1;");
+                    _connection?.Execute("SELECT 1;", transaction: _transaction);
                 }
                 catch
                 {


### PR DESCRIPTION
It looks like the `transaction` argument is missing from the `Execute` call in the `KeepAliveQuery` method.