### PR TITLE
Add spanish language for the Dashboard

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -66,7 +66,8 @@
 
             var hoverDetail = new Rickshaw.Graph.HoverDetail({
                 graph: this._graph,
-                yFormatter: function (y) { return Math.floor(y); }
+                yFormatter: function (y) { return Math.floor(y); },
+                xFormatter: function (x) { return moment(new Date(x * 1000)).format("LLLL"); }
             });
 
             this._graph.render();
@@ -126,7 +127,8 @@
             
             var hoverDetail = new Rickshaw.Graph.HoverDetail({
                 graph: this._graph,
-                yFormatter: function(y) { return Math.floor(y); }
+                yFormatter: function (y) { return Math.floor(y); },
+                xFormatter: function (x) { return moment(new Date(x * 1000)).format("LLLL"); }
             });
 
             this._graph.render();

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -37,7 +37,7 @@
     })();
 
     hangFire.RealtimeGraph = (function() {
-        function RealtimeGraph(element, succeeded, failed) {
+        function RealtimeGraph(element, succeeded, failed, succeededStr, failedStr) {
             this._succeeded = succeeded;
             this._failed = failed;
             
@@ -50,8 +50,8 @@
                 stroke: true,
 
                 series: new Rickshaw.Series.FixedDuration([
-                        { name: 'failed', color: '#d9534f' },
-                        { name: 'succeeded', color: '#5cb85c' }
+                        { name: failedStr, color: '#d9534f' },
+                        { name: succeededStr, color: '#5cb85c' }
                 ],
                     undefined,
                     { timeInterval: 2000, maxDataPoints: 100 }
@@ -97,7 +97,7 @@
     })();
 
     hangFire.HistoryGraph = (function() {
-        function HistoryGraph(element, succeeded, failed) {
+        function HistoryGraph(element, succeeded, failed, succeededStr, failedStr) {
             this._graph = new Rickshaw.Graph({
                 element: element,
                 width: $(element).innerWidth(),
@@ -109,11 +109,11 @@
                     {
                         color: '#d9534f',
                         data: failed,
-                        name: 'Failed'
+                        name: failedStr
                     }, {
                         color: '#6ACD65',
                         data: succeeded,
-                        name: 'Succeeded'
+                        name: succeededStr
                     }
                 ]
             });
@@ -232,8 +232,11 @@
             var succeeded = parseInt($(realtimeElement).data('succeeded'));
             var failed = parseInt($(realtimeElement).data('failed'));
 
+            var succeededStr = $(realtimeElement).data('succeeded-string');
+            var failedStr = $(realtimeElement).data('failed-string');
+
             if (realtimeElement) {
-                var realtimeGraph = new Hangfire.RealtimeGraph(realtimeElement, succeeded, failed);
+                var realtimeGraph = new Hangfire.RealtimeGraph(realtimeElement, succeeded, failed, succeededStr, failedStr);
 
                 this._poller.addListener(function (data) {
                     realtimeGraph.appendHistory(data);
@@ -263,7 +266,10 @@
                 var succeeded = createSeries($(historyElement).data("succeeded"));
                 var failed = createSeries($(historyElement).data("failed"));
 
-                return new Hangfire.HistoryGraph(historyElement, succeeded, failed);
+                var succeededStr = $(historyElement).data('succeeded-string');
+                var failedStr = $(historyElement).data('failed-string');
+
+                return new Hangfire.HistoryGraph(historyElement, succeeded, failed, succeededStr, failedStr);
             }
 
             return null;

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
@@ -692,11 +692,47 @@ namespace Hangfire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Awaiting.
+        /// </summary>
+        public static string Metrics_AwaitingCount {
+            get {
+                return ResourceManager.GetString("Metrics_AwaitingCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deleted Jobs.
         /// </summary>
         public static string Metrics_DeletedJobs {
             get {
                 return ResourceManager.GetString("Metrics_DeletedJobs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enqueued.
+        /// </summary>
+        public static string Metrics_EnqueuedCountOrNull {
+            get {
+                return ResourceManager.GetString("Metrics_EnqueuedCountOrNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enqueued / Queues.
+        /// </summary>
+        public static string Metrics_EnqueuedQueuesCount {
+            get {
+                return ResourceManager.GetString("Metrics_EnqueuedQueuesCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} failed job(s) found. Retry or delete them manually..
+        /// </summary>
+        public static string Metrics_FailedCountOrNull {
+            get {
+                return ResourceManager.GetString("Metrics_FailedCountOrNull", resourceCulture);
             }
         }
         

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
@@ -468,6 +468,24 @@ namespace Hangfire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed.
+        /// </summary>
+        public static string HomePage_GraphHover_Failed {
+            get {
+                return ResourceManager.GetString("HomePage_GraphHover_Failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Succeeded.
+        /// </summary>
+        public static string HomePage_GraphHover_Succeeded {
+            get {
+                return ResourceManager.GetString("HomePage_GraphHover_Succeeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to History graph.
         /// </summary>
         public static string HomePage_HistoryGraph {

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+	<!-- 
+		Microsoft ResX Schema
+
+		Version 1.3
+
+		The primary goals of this format is to allow a simple XML format 
+		that is mostly human readable. The generation and parsing of the 
+		various data types are done through the TypeConverter classes 
+		associated with the data types.
+
+		Example:
+
+		... ado.net/XML headers & schema ...
+		<resheader name="resmimetype">text/microsoft-resx</resheader>
+		<resheader name="version">1.3</resheader>
+		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+		<data name="Name1">this is my long string</data>
+		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+			[base64 mime encoded serialized .NET Framework object]
+		</data>
+		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+			[base64 mime encoded string representing a byte array form of the .NET Framework object]
+		</data>
+
+		There are any number of "resheader" rows that contain simple 
+		name/value pairs.
+
+		Each data row contains a name, and value. The row also contains a 
+		type or mimetype. Type corresponds to a .NET class that support 
+		text/value conversion through the TypeConverter architecture. 
+		Classes that don't support this are serialized and stored with the 
+		mimetype set.
+
+		The mimetype is used for serialized objects, and tells the 
+		ResXResourceReader how to depersist the object. This is currently not 
+		extensible. For a given mimetype the value must be set accordingly:
+
+		Note - application/x-microsoft.net.object.binary.base64 is the format 
+		that the ResXResourceWriter will generate, however the reader can 
+		read any of the formats listed below.
+
+		mimetype: application/x-microsoft.net.object.binary.base64
+		value   : The object must be serialized with 
+			: System.Serialization.Formatters.Binary.BinaryFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.soap.base64
+		value   : The object must be serialized with 
+			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+			: and then encoded with base64 encoding.
+
+		mimetype: application/x-microsoft.net.object.bytearray.base64
+		value   : The object must be serialized into a byte array 
+			: using a System.ComponentModel.TypeConverter
+			: and then encoded with base64 encoding.
+	-->
+	
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>1.3</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+</root>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -515,4 +515,10 @@
   <data name="Metrics_EnqueuedQueuesCount" xml:space="preserve">
     <value>En la cola / Colas</value>
   </data>
+  <data name="HomePage_GraphHover_Failed" xml:space="preserve">
+    <value>Con errores</value>
+  </data>
+  <data name="HomePage_GraphHover_Succeeded" xml:space="preserve">
+    <value>Completados</value>
+  </data>
 </root>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -506,6 +506,12 @@
   <data name="Common_Continuations" xml:space="preserve">
     <value>Continuaciones</value>
   </data>
+  <data name="Metrics_AwaitingCount" xml:space="preserve">
+    <value>En espera</value>
+  </data>
+  <data name="Metrics_EnqueuedCountOrNull" xml:space="preserve">
+    <value>En la cola</value>
+  </data>
   <data name="Metrics_EnqueuedQueuesCount" xml:space="preserve">
     <value>En la cola / Colas</value>
   </data>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -1,101 +1,510 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AwaitingJobsPage_ContinuationsWarning_Text" xml:space="preserve">
+    <value>Las continuaciones funcionan correctamente, pero tu sistema de almacenamiento de tareas actual no soporta algunas consultas necesarias para mostrar esta página. Actualiza tu sistema de almacenamiento o espera hasta que éste soporte esta funcionalidad</value>
+  </data>
+  <data name="AwaitingJobsPage_ContinuationsWarning_Title" xml:space="preserve">
+    <value>Las continuaciones funcionan, pero esta página no se puede mostrar.</value>
+  </data>
+  <data name="AwaitingJobsPage_NoJobs" xml:space="preserve">
+    <value>No se han encontrado tareas en espera</value>
+  </data>
+  <data name="AwaitingJobsPage_Table_Options" xml:space="preserve">
+    <value>Opciones</value>
+  </data>
+  <data name="AwaitingJobsPage_Table_Parent" xml:space="preserve">
+    <value>Padre</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="AwaitingJobsPage_Title" xml:space="preserve">
+    <value>Tareas en espera</value>
+  </data>
+  <data name="Common_Created" xml:space="preserve">
+    <value>Creado</value>
+  </data>
+  <data name="Common_Delete" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="Common_DeleteConfirm" xml:space="preserve">
+    <value>¿Estás seguro que quieres ELIMINAR TODAS las tareas seleccionadas?</value>
+  </data>
+  <data name="Common_Deleting" xml:space="preserve">
+    <value>Eliminando...</value>
+  </data>
+  <data name="Common_DeleteSelected" xml:space="preserve">
+    <value>Eliminar seleccionados</value>
+  </data>
+  <data name="Common_EnqueueButton_Text" xml:space="preserve">
+    <value>Poner tareas en la cola</value>
+  </data>
+  <data name="Common_Enqueueing" xml:space="preserve">
+    <value>Poniendo en la cola...</value>
+  </data>
+  <data name="Common_Fetched" xml:space="preserve">
+    <value>Obtenido</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="Common_Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="Common_Job" xml:space="preserve">
+    <value>Tarea</value>
+  </data>
+  <data name="Common_JobExpired" xml:space="preserve">
+    <value>Tarea expirada</value>
+  </data>
+  <data name="Common_JobStateChanged_Text" xml:space="preserve">
+    <value>El estado de la tarea ha cambiado misentras se obtenia información.</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="Common_LessDetails" xml:space="preserve">
+    <value>Menos detalles</value>
+  </data>
+  <data name="Common_MoreDetails" xml:space="preserve">
+    <value>Más detalles</value>
+  </data>
+  <data name="Common_NotAvailable" xml:space="preserve">
+    <value>N/D</value>
+  </data>
+  <data name="Common_PeriodDay" xml:space="preserve">
+    <value>Día</value>
+  </data>
+  <data name="Common_PeriodWeek" xml:space="preserve">
+    <value>Semana</value>
+  </data>
+  <data name="Common_Reason" xml:space="preserve">
+    <value>Razón</value>
+  </data>
+  <data name="Common_RequeueJobs" xml:space="preserve">
+    <value>Volver a poner a la cola las tareas</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="Common_Retry" xml:space="preserve">
+    <value>Reintentar</value>
+  </data>
+  <data name="Common_Server" xml:space="preserve">
+    <value>Servidor</value>
+  </data>
+  <data name="Common_State" xml:space="preserve">
+    <value>Estado</value>
+  </data>
+  <data name="Common_Unknown" xml:space="preserve">
+    <value>Desconocido</value>
+  </data>
+  <data name="DeletedJobsPage_NoJobs" xml:space="preserve">
+    <value>No se han encontrado tareas eliminadas.</value>
+  </data>
+  <data name="DeletedJobsPage_Table_Deleted" xml:space="preserve">
+    <value>Eliminado</value>
+  </data>
+  <data name="DeletedJobsPage_Title" xml:space="preserve">
+    <value>Tareas eliminadas</value>
+  </data>
+  <data name="EnqueuedJobsPage_NoJobs" xml:space="preserve">
+    <value>La cola esta vacía.</value>
+  </data>
+  <data name="EnqueuedJobsPage_Title" xml:space="preserve">
+    <value>Tareas en la cola</value>
+  </data>
+  <data name="FailedJobsPage_FailedJobsNotExpire_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;Las tareas fallidas no expiran&lt;/strong&gt; para permititrte volver a añadirlas a la cola sin ninguna presión. Puedes añadirlas de nuevo a la cola, eliminarlas manualmente o aplicar el atributo &lt;code&gt;AutomaticRetry(OnAttemptsExceeded = AttemptsExceededAction.Delete)&lt;/code&gt; para eliminarlas automáticamente.</value>
+  </data>
+  <data name="FailedJobsPage_NoJobs" xml:space="preserve">
+    <value>No hay tareas con errores.</value>
+  </data>
+  <data name="FailedJobsPage_Table_Failed" xml:space="preserve">
+    <value>Con errores</value>
+  </data>
+  <data name="FailedJobsPage_Title" xml:space="preserve">
+    <value>Tareas con errores</value>
+  </data>
+  <data name="FetchedJobsPage_NoJobs" xml:space="preserve">
+    <value>La cola está vacía</value>
+  </data>
+  <data name="FetchedJobsPage_Title" xml:space="preserve">
+    <value>Tareas obtenidas</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="HomePage_HistoryGraph" xml:space="preserve">
+    <value>Gráfico histórico</value>
+  </data>
+  <data name="HomePage_RealtimeGraph" xml:space="preserve">
+    <value>Gráfico en tiempo real</value>
+  </data>
+  <data name="HomePage_Title" xml:space="preserve">
+    <value>Panel</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="JobDetailsPage_Created" xml:space="preserve">
+    <value>Creado</value>
+  </data>
+  <data name="JobDetailsPage_DeleteConfirm" xml:space="preserve">
+    <value>¿Estás seguro que quieres eliminar esta tarea?</value>
+  </data>
+  <data name="JobDetailsPage_State" xml:space="preserve">
+    <value>Estado</value>
+  </data>
+  <data name="JobDetailsPage_JobAbortedNotActive_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;La tarea ha sido abortada&lt;/strong&gt; - ha sido procesada por el servidor &lt;code&gt;{0}&lt;/code&gt; que no está en la lista de &lt;a href=&quot;{1}&quot;&gt;servidores activos&lt;/a&gt; por ahora. Se recuperará automáticamente despues del periodo de invisibilidad, pero puedes volverla a poner en la cola o eliminarla manualmente.</value>
+  </data>
+  <data name="JobDetailsPage_JobAbortedWithHeartbeat_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;La tarea ha sido abortada&lt;/strong&gt; - ha sido procesada por el servidor &lt;code&gt;{0}&lt;/code&gt; que ha reportado un latido hace más de un minuto. Se recuperará automáticamente despues del periodo de invisibilidad, pero puedes volverla a poner en la cola o eliminarla manualmente.</value>
+  </data>
+  <data name="JobDetailsPage_JobExpired" xml:space="preserve">
+    <value>La tarea con id &apos;{0}&apos; ha expirado o no se ha encontrado en el servidor</value>
+  </data>
+  <data name="JobDetailsPage_JobFinished_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;La tarea ha finalizado&lt;/strong&gt;. Se va a eliminar automáticamente en &lt;em&gt;&lt;abbr data-moment=&quot;{0}&quot;&gt;{1}&lt;/abbr&gt;&lt;/em&gt;</value>
+  </data>
+  <data name="JobDetailsPage_JobId" xml:space="preserve">
+    <value>ID Tarea</value>
+  </data>
+  <data name="JobDetailsPage_Requeue" xml:space="preserve">
+    <value>Volver a poner en la cola</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="LayoutPage_Back" xml:space="preserve">
+    <value>Volver</value>
+  </data>
+  <data name="LayoutPage_Brand" xml:space="preserve">
+    <value>Panel Hangfire</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="LayoutPage_Footer_Generatedms" xml:space="preserve">
+    <value>Generado: {0}ms</value>
+  </data>
+  <data name="LayoutPage_Footer_Time" xml:space="preserve">
+    <value>Hora: {0} GMT</value>
+  </data>
+  <data name="Paginator_Next" xml:space="preserve">
+    <value>Siguiente</value>
+  </data>
+  <data name="Paginator_Prev" xml:space="preserve">
+    <value>Anterior</value>
+  </data>
+  <data name="Paginator_TotalItems" xml:space="preserve">
+    <value>Total elementos</value>
+  </data>
+  <data name="PerPageSelector_ItemsPerPage" xml:space="preserve">
+    <value>Elementos por página</value>
+  </data>
+  <data name="ProcessingJobsPage_Aborted" xml:space="preserve">
+    <value>Parece que la tarea ha sido cancelada</value>
+  </data>
+  <data name="ProcessingJobsPage_NoJobs" xml:space="preserve">
+    <value>No hay tareas en proceso.</value>
+  </data>
+  <data name="ProcessingJobsPage_Table_Started" xml:space="preserve">
+    <value>Iniciado</value>
+  </data>
+  <data name="ProcessingJobsPage_Title" xml:space="preserve">
+    <value>Tareas en proceso</value>
+  </data>
+  <data name="QueuesPage_NoJobs" xml:space="preserve">
+    <value>No hay tareas en la cola.</value>
+  </data>
+  <data name="QueuesPage_NoQueues" xml:space="preserve">
+    <value>No se han encontrado tareas en la cola. Prueba a poner alguna.</value>
+  </data>
+  <data name="QueuesPage_Table_Length" xml:space="preserve">
+    <value>Longitud</value>
+  </data>
+  <data name="QueuesPage_Table_NextsJobs" xml:space="preserve">
+    <value>Próximas tareas</value>
+  </data>
+  <data name="QueuesPage_Table_Queue" xml:space="preserve">
+    <value>Cola</value>
+  </data>
+  <data name="QueuesPage_Title" xml:space="preserve">
+    <value>Colas</value>
+  </data>
+  <data name="RecurringJobsPage_Canceled" xml:space="preserve">
+    <value>Cancelado</value>
+  </data>
+  <data name="RecurringJobsPage_NoJobs" xml:space="preserve">
+    <value>No se han encontrado tareas recurrentes</value>
+  </data>
+  <data name="RecurringJobsPage_Table_Cron" xml:space="preserve">
+    <value>Cron</value>
+  </data>
+  <data name="RecurringJobsPage_Table_LastExecution" xml:space="preserve">
+    <value>Última ejecución</value>
+  </data>
+  <data name="RecurringJobsPage_Table_NextExecution" xml:space="preserve">
+    <value>Próxima ejecución</value>
+  </data>
+  <data name="RecurringJobsPage_Table_TimeZone" xml:space="preserve">
+    <value>Zona horaria</value>
+  </data>
+  <data name="RecurringJobsPage_Title" xml:space="preserve">
+    <value>Tareas recurrentes</value>
+  </data>
+  <data name="RecurringJobsPage_Triggering" xml:space="preserve">
+    <value>Lanzando...</value>
+  </data>
+  <data name="RecurringJobsPage_TriggerNow" xml:space="preserve">
+    <value>Lanzar ahora</value>
+  </data>
+  <data name="RetriesPage_NoJobs" xml:space="preserve">
+    <value>Todo va bien - no hay ningún reintento.</value>
+  </data>
+  <data name="RetriesPage_Title" xml:space="preserve">
+    <value>Reintentos</value>
+  </data>
+  <data name="RetriesPage_Warning_Html" xml:space="preserve">
+    <value>&lt;h4&gt;Los reintentos están funcionando, pero esta página no se puede mostrar&lt;/h4&gt;
+        &lt;p&gt;
+            No te preocupes, los reintentos fucionan como deberian, pero tu sistema de almacenamiento de tareas actual no soporta algunas consultas necesarias para mostrar esta página. Actualiza tu sistema de almacenamiento o espera hasta que éste soporte esta funcionalidad
+        &lt;/p&gt;
+        &lt;p&gt;
+           Visita la página &lt;a href=&quot;{0}&quot;&gt;Tareas programadas&lt;/a&gt; para ver todas las tareas programadas, incluidos los reintentos.
+        &lt;/p&gt; </value>
+  </data>
+  <data name="ScheduledJobsPage_EnqueueNow" xml:space="preserve">
+    <value>Poner en la cola ahora</value>
+  </data>
+  <data name="ScheduledJobsPage_NoJobs" xml:space="preserve">
+    <value>No hay tareas programadas.</value>
+  </data>
+  <data name="ScheduledJobsPage_Table_Enqueue" xml:space="preserve">
+    <value>Poner en la cola</value>
+  </data>
+  <data name="ScheduledJobsPage_Table_Scheduled" xml:space="preserve">
+    <value>Programadas</value>
+  </data>
+  <data name="ScheduledJobsPage_Title" xml:space="preserve">
+    <value>Tareas programadas</value>
+  </data>
+  <data name="ServersPage_NoServers" xml:space="preserve">
+    <value>No hay ningún servidor activo. Las tareas en segundo plano no serán procesadas.</value>
+  </data>
+  <data name="ServersPage_Table_Heartbeat" xml:space="preserve">
+    <value>Latido</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="ServersPage_Table_Name" xml:space="preserve">
+    <value>Nombre</value>
+  </data>
+  <data name="ServersPage_Table_Queues" xml:space="preserve">
+    <value>Colas</value>
+  </data>
+  <data name="ServersPage_Table_Started" xml:space="preserve">
+    <value>Iniciada</value>
+  </data>
+  <data name="ServersPage_Table_Workers" xml:space="preserve">
+    <value>Trabajadores</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="ServersPage_Title" xml:space="preserve">
+    <value>Servidores</value>
+  </data>
+  <data name="SucceededJobsPage_NoJobs" xml:space="preserve">
+    <value>No se han encontrado tareas completadas</value>
+  </data>
+  <data name="SucceededJobsPage_Table_Succeeded" xml:space="preserve">
+    <value>Completadas</value>
+  </data>
+  <data name="SucceededJobsPage_Table_TotalDuration" xml:space="preserve">
+    <value>Duración total</value>
+  </data>
+  <data name="SucceededJobsPage_Title" xml:space="preserve">
+    <value>Tareas completadas</value>
+  </data>
+  <data name="JobsSidebarMenu_Awaiting" xml:space="preserve">
+    <value>En espera</value>
+  </data>
+  <data name="JobsSidebarMenu_Deleted" xml:space="preserve">
+    <value>Eliminado</value>
+  </data>
+  <data name="JobsSidebarMenu_Failed" xml:space="preserve">
+    <value>Con errores</value>
+  </data>
+  <data name="JobsSidebarMenu_Processing" xml:space="preserve">
+    <value>Procesando</value>
+  </data>
+  <data name="JobsSidebarMenu_Scheduled" xml:space="preserve">
+    <value>Programadas</value>
+  </data>
+  <data name="JobsSidebarMenu_Succeeded" xml:space="preserve">
+    <value>Completadas</value>
+  </data>
+  <data name="NavigationMenu_Jobs" xml:space="preserve">
+    <value>Tareas</value>
+  </data>
+  <data name="NavigationMenu_RecurringJobs" xml:space="preserve">
+    <value>Tareas recurrentes</value>
+  </data>
+  <data name="NavigationMenu_Retries" xml:space="preserve">
+    <value>Reintentos</value>
+  </data>
+  <data name="NavigationMenu_Servers" xml:space="preserve">
+    <value>Servidores</value>
+  </data>
+  <data name="Common_CannotFindTargetMethod" xml:space="preserve">
+    <value>No se puede encontrar el método destino</value>
+    <comment>Fuzzy</comment>
+  </data>
+  <data name="Common_Enqueued" xml:space="preserve">
+    <value>En la cola</value>
+  </data>
+  <data name="Common_NoState" xml:space="preserve">
+    <value>Sin estado</value>
+  </data>
+  <data name="JobsSidebarMenu_Enqueued" xml:space="preserve">
+    <value>En la cola</value>
+  </data>
+  <data name="Metrics_ActiveConnections" xml:space="preserve">
+    <value>Conexiones activas</value>
+  </data>
+  <data name="Metrics_DeletedJobs" xml:space="preserve">
+    <value>Tareas eliminadas</value>
+  </data>
+  <data name="Metrics_FailedJobs" xml:space="preserve">
+    <value>Tareas fallidas</value>
+  </data>
+  <data name="Metrics_ProcessingJobs" xml:space="preserve">
+    <value>Tareas en proceso</value>
+  </data>
+  <data name="Metrics_RecurringJobs" xml:space="preserve">
+    <value>Tareas recurrentes</value>
+  </data>
+  <data name="Metrics_Retries" xml:space="preserve">
+    <value>Reintentos</value>
+  </data>
+  <data name="Metrics_ScheduledJobs" xml:space="preserve">
+    <value>Tareas programadas</value>
+  </data>
+  <data name="Metrics_Servers" xml:space="preserve">
+    <value>Servidores</value>
+  </data>
+  <data name="Metrics_SucceededJobs" xml:space="preserve">
+    <value>Tareas completadas</value>
+  </data>
+  <data name="Metrics_TotalConnections" xml:space="preserve">
+    <value>Conexiones totales</value>
+  </data>
+  <data name="Common_Condition" xml:space="preserve">
+    <value>Condición</value>
+  </data>
+  <data name="Common_Continuations" xml:space="preserve">
+    <value>Continuaciones</value>
+  </data>
 
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
 </root>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -262,16 +262,16 @@
     <value>Estado</value>
   </data>
   <data name="JobDetailsPage_JobAbortedNotActive_Warning_Html" xml:space="preserve">
-    <value>&lt;strong&gt;La tarea ha sido abortada&lt;/strong&gt; - ha sido procesada por el servidor &lt;code&gt;{0}&lt;/code&gt; que no está en la lista de &lt;a href=&quot;{1}&quot;&gt;servidores activos&lt;/a&gt; por ahora. Se recuperará automáticamente despues del periodo de invisibilidad, pero puedes volverla a poner en la cola o eliminarla manualmente.</value>
+    <value>&lt;strong&gt;La tarea ha sido abortada&lt;/strong&gt; - ha sido procesada por el servidor &lt;code&gt;{0}&lt;/code&gt; que no está en la lista de &lt;a href="{1}"&gt;servidores activos&lt;/a&gt; por ahora. Se recuperará automáticamente despues del periodo de invisibilidad, pero puedes volverla a poner en la cola o eliminarla manualmente.</value>
   </data>
   <data name="JobDetailsPage_JobAbortedWithHeartbeat_Warning_Html" xml:space="preserve">
     <value>&lt;strong&gt;La tarea ha sido abortada&lt;/strong&gt; - ha sido procesada por el servidor &lt;code&gt;{0}&lt;/code&gt; que ha reportado un latido hace más de un minuto. Se recuperará automáticamente despues del periodo de invisibilidad, pero puedes volverla a poner en la cola o eliminarla manualmente.</value>
   </data>
   <data name="JobDetailsPage_JobExpired" xml:space="preserve">
-    <value>La tarea con id &apos;{0}&apos; ha expirado o no se ha encontrado en el servidor</value>
+    <value>La tarea con id '{0}' ha expirado o no se ha encontrado en el servidor</value>
   </data>
   <data name="JobDetailsPage_JobFinished_Warning_Html" xml:space="preserve">
-    <value>&lt;strong&gt;La tarea ha finalizado&lt;/strong&gt;. Se va a eliminar automáticamente en &lt;em&gt;&lt;abbr data-moment=&quot;{0}&quot;&gt;{1}&lt;/abbr&gt;&lt;/em&gt;</value>
+    <value>&lt;strong&gt;La tarea ha finalizado&lt;/strong&gt;. Se va a eliminar automáticamente en &lt;em&gt;&lt;abbr data-moment="{0}"&gt;{1}&lt;/abbr&gt;&lt;/em&gt;</value>
   </data>
   <data name="JobDetailsPage_JobId" xml:space="preserve">
     <value>ID Tarea</value>
@@ -374,7 +374,7 @@
             No te preocupes, los reintentos fucionan como deberian, pero tu sistema de almacenamiento de tareas actual no soporta algunas consultas necesarias para mostrar esta página. Actualiza tu sistema de almacenamiento o espera hasta que éste soporte esta funcionalidad
         &lt;/p&gt;
         &lt;p&gt;
-           Visita la página &lt;a href=&quot;{0}&quot;&gt;Tareas programadas&lt;/a&gt; para ver todas las tareas programadas, incluidos los reintentos.
+           Visita la página &lt;a href="{0}"&gt;Tareas programadas&lt;/a&gt; para ver todas las tareas programadas, incluidos los reintentos.
         &lt;/p&gt; </value>
   </data>
   <data name="ScheduledJobsPage_EnqueueNow" xml:space="preserve">
@@ -506,5 +506,7 @@
   <data name="Common_Continuations" xml:space="preserve">
     <value>Continuaciones</value>
   </data>
-
+  <data name="Metrics_EnqueuedQueuesCount" xml:space="preserve">
+    <value>En la cola / Colas</value>
+  </data>
 </root>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
@@ -508,4 +508,16 @@
   <data name="Common_Continuations" xml:space="preserve">
     <value>Continuations</value>
   </data>
+  <data name="Metrics_AwaitingCount" xml:space="preserve">
+    <value>Awaiting</value>
+  </data>
+  <data name="Metrics_EnqueuedCountOrNull" xml:space="preserve">
+    <value>Enqueued</value>
+  </data>
+  <data name="Metrics_EnqueuedQueuesCount" xml:space="preserve">
+    <value>Enqueued / Queues</value>
+  </data>
+  <data name="Metrics_FailedCountOrNull" xml:space="preserve">
+    <value>{0} failed job(s) found. Retry or delete them manually.</value>
+  </data>
 </root>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
@@ -520,4 +520,10 @@
   <data name="Metrics_FailedCountOrNull" xml:space="preserve">
     <value>{0} failed job(s) found. Retry or delete them manually.</value>
   </data>
+  <data name="HomePage_GraphHover_Failed" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="HomePage_GraphHover_Succeeded" xml:space="preserve">
+    <value>Succeeded</value>
+  </data>
 </root>

--- a/src/Hangfire.Core/Dashboard/DashboardMetric.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardMetric.cs
@@ -15,6 +15,7 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using Hangfire.Dashboard.Resources;
 
 namespace Hangfire.Dashboard
 {
@@ -25,16 +26,17 @@ namespace Hangfire.Dashboard
         {
         }
 
-        public DashboardMetric(string name, string title, Func<RazorPage, Metric> func)
+        public DashboardMetric(string name, string titleResourceKey, Func<RazorPage, Metric> func)
         {
             Name = name;
-            Title = title;
+            TitleResourceKey = titleResourceKey;
             Func = func;
         }
 
         public string Name { get; }
         public Func<RazorPage, Metric> Func { get; }
 
-        public string Title { get; set; }
+        public string Title { get { return Strings.ResourceManager.GetString(TitleResourceKey) ?? TitleResourceKey; } }
+        public string TitleResourceKey { get; set; }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardMetric.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardMetric.cs
@@ -15,28 +15,26 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using Hangfire.Dashboard.Resources;
 
 namespace Hangfire.Dashboard
 {
     public class DashboardMetric
     {
-        public DashboardMetric(string name, Func<RazorPage, Metric> func)
+        public DashboardMetric(string name, Func<RazorPage, Metric> func) 
             : this(name, name, func)
         {
         }
 
-        public DashboardMetric(string name, string titleResourceKey, Func<RazorPage, Metric> func)
+        public DashboardMetric(string name, string title, Func<RazorPage, Metric> func)
         {
             Name = name;
-            TitleResourceKey = titleResourceKey;
+            Title = title;
             Func = func;
         }
 
         public string Name { get; }
         public Func<RazorPage, Metric> Func { get; }
 
-        public string Title { get { return Strings.ResourceManager.GetString(TitleResourceKey) ?? TitleResourceKey; } }
-        public string TitleResourceKey { get; set; }
+        public string Title { get; set; }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardMetrics.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardMetrics.cs
@@ -63,7 +63,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric ServerCount = new DashboardMetric(
             "servers:count", 
-            Strings.Metrics_Servers,
+            "Metrics_Servers",
             page => new Metric(page.Statistics.Servers.ToString("N0"))
             {
                 Style = page.Statistics.Servers == 0 ? MetricStyle.Warning : MetricStyle.Default,
@@ -75,12 +75,12 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric RecurringJobCount = new DashboardMetric(
             "recurring:count",
-            Strings.Metrics_RecurringJobs,
+            "Metrics_RecurringJobs",
             page => new Metric(page.Statistics.Recurring.ToString("N0")));
 
         public static readonly DashboardMetric RetriesCount = new DashboardMetric(
             "retries:count",
-             Strings.Metrics_Retries,
+             "Metrics_Retries",
             page =>
             {
                 long retryCount;
@@ -103,6 +103,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric EnqueuedCountOrNull = new DashboardMetric(
             "enqueued:count-or-null",
+            "Metrics_EnqueuedCountOrNull",
             page => page.Statistics.Enqueued > 0 || page.Statistics.Failed == 0
                 ? new Metric(page.Statistics.Enqueued.ToString("N0"))
                 {
@@ -113,18 +114,19 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric FailedCountOrNull = new DashboardMetric(
             "failed:count-or-null",
+            "Metrics_FailedJobs",
             page => page.Statistics.Failed > 0
                 ? new Metric(page.Statistics.Failed.ToString("N0"))
                 {
                     Style = MetricStyle.Danger,
                     Highlighted = true,
-                    Title =
-                        $"{page.Statistics.Failed} failed job(s) found. Retry or delete them manually."
+                    Title = string.Format(Strings.Metrics_FailedCountOrNull, page.Statistics.Failed)
                 }
                 : null);
 
         public static readonly DashboardMetric EnqueuedAndQueueCount = new DashboardMetric(
             "enqueued-queues:count",
+            "Metrics_EnqueuedQueuesCount",
             page => new Metric($"{page.Statistics.Enqueued:N0} / {page.Statistics.Queues:N0}")
             {
                 Style = page.Statistics.Enqueued > 0 ? MetricStyle.Info : MetricStyle.Default,
@@ -133,7 +135,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric ScheduledCount = new DashboardMetric(
             "scheduled:count",
-            Strings.Metrics_ScheduledJobs,
+            "Metrics_ScheduledJobs",
             page => new Metric(page.Statistics.Scheduled.ToString("N0"))
             {
                 Style = page.Statistics.Scheduled > 0 ? MetricStyle.Info : MetricStyle.Default
@@ -141,7 +143,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric ProcessingCount = new DashboardMetric(
             "processing:count",
-            Strings.Metrics_ProcessingJobs,
+            "Metrics_ProcessingJobs",
             page => new Metric(page.Statistics.Processing.ToString("N0"))
             {
                 Style = page.Statistics.Processing > 0 ? MetricStyle.Warning : MetricStyle.Default
@@ -149,7 +151,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric SucceededCount = new DashboardMetric(
             "succeeded:count",
-            Strings.Metrics_SucceededJobs,
+            "Metrics_SucceededJobs",
             page => new Metric(page.Statistics.Succeeded.ToString("N0"))
             {
                 IntValue = page.Statistics.Succeeded
@@ -157,7 +159,7 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric FailedCount = new DashboardMetric(
             "failed:count",
-            Strings.Metrics_FailedJobs,
+            "Metrics_FailedJobs",
             page => new Metric(page.Statistics.Failed.ToString("N0"))
             {
                 IntValue = page.Statistics.Failed,
@@ -167,11 +169,12 @@ namespace Hangfire.Dashboard
 
         public static readonly DashboardMetric DeletedCount = new DashboardMetric(
             "deleted:count",
-             Strings.Metrics_DeletedJobs,
+             "Metrics_DeletedJobs",
             page => new Metric(page.Statistics.Deleted.ToString("N0")));
 
         public static readonly DashboardMetric AwaitingCount = new DashboardMetric(
             "awaiting:count",
+            "Metrics_AwaitingCount",
             page =>
             {
                 long awaitingCount = -1;

--- a/src/Hangfire.Core/Dashboard/Pages/HomePage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/HomePage.cshtml
@@ -41,7 +41,9 @@
             </div>
         }
         <h3>@Strings.HomePage_RealtimeGraph</h3>
-        <div id="realtimeGraph" data-succeeded="@Statistics.Succeeded" data-failed="@Statistics.Failed"></div>
+        <div id="realtimeGraph" data-succeeded="@Statistics.Succeeded" data-failed="@Statistics.Failed"
+             data-succeeded-string="@Strings.HomePage_GraphHover_Succeeded"
+             data-failed-string="@Strings.HomePage_GraphHover_Failed"></div>
         <div style="display: none;">
             <span data-metric="succeeded:count"></span>
             <span data-metric="failed:count"></span>
@@ -59,7 +61,9 @@
         {
             <div id="historyGraph"
                  data-succeeded="@JsonConvert.SerializeObject(succeeded)"
-                 data-failed="@JsonConvert.SerializeObject(failed)">
+                 data-failed="@JsonConvert.SerializeObject(failed)"
+                 data-succeeded-string="@Strings.HomePage_GraphHover_Succeeded"
+                 data-failed-string="@Strings.HomePage_GraphHover_Failed">
             </div>
         }
     </div>

--- a/src/Hangfire.Core/Dashboard/Pages/HomePage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/HomePage.generated.cs
@@ -187,6 +187,26 @@ WriteLiteral("\" data-failed=\"");
             
             #line default
             #line hidden
+WriteLiteral("\"\r\n             data-succeeded-string=\"");
+
+
+            
+            #line 45 "..\..\Dashboard\Pages\HomePage.cshtml"
+                               Write(Strings.HomePage_GraphHover_Succeeded);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n             data-failed-string=\"");
+
+
+            
+            #line 46 "..\..\Dashboard\Pages\HomePage.cshtml"
+                            Write(Strings.HomePage_GraphHover_Failed);
+
+            
+            #line default
+            #line hidden
 WriteLiteral(@"""></div>
         <div style=""display: none;"">
             <span data-metric=""succeeded:count""></span>
@@ -199,7 +219,7 @@ WriteLiteral(@"""></div>
 
 
             
-            #line 52 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 54 "..\..\Dashboard\Pages\HomePage.cshtml"
                                                                 Write("day".Equals(period, StringComparison.OrdinalIgnoreCase) ? "active" : null);
 
             
@@ -209,7 +229,7 @@ WriteLiteral("\">");
 
 
             
-            #line 52 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 54 "..\..\Dashboard\Pages\HomePage.cshtml"
                                                                                                                                               Write(Strings.Common_PeriodDay);
 
             
@@ -219,7 +239,7 @@ WriteLiteral("</a>\r\n                <a href=\"?period=week\" class=\"btn btn-s
 
 
             
-            #line 53 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 55 "..\..\Dashboard\Pages\HomePage.cshtml"
                                                                  Write("week".Equals(period, StringComparison.OrdinalIgnoreCase) ? "active" : null);
 
             
@@ -229,7 +249,7 @@ WriteLiteral("\">");
 
 
             
-            #line 53 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 55 "..\..\Dashboard\Pages\HomePage.cshtml"
                                                                                                                                                 Write(Strings.Common_PeriodWeek);
 
             
@@ -239,7 +259,7 @@ WriteLiteral("</a>\r\n            </div>\r\n            ");
 
 
             
-            #line 55 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 57 "..\..\Dashboard\Pages\HomePage.cshtml"
        Write(Strings.HomePage_HistoryGraph);
 
             
@@ -249,7 +269,7 @@ WriteLiteral("\r\n        </h3>\r\n\r\n");
 
 
             
-            #line 58 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 60 "..\..\Dashboard\Pages\HomePage.cshtml"
          if (succeeded != null && failed != null)
         {
 
@@ -260,7 +280,7 @@ WriteLiteral("            <div id=\"historyGraph\"\r\n                 data-succ
 
 
             
-            #line 61 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 63 "..\..\Dashboard\Pages\HomePage.cshtml"
                             Write(JsonConvert.SerializeObject(succeeded));
 
             
@@ -270,8 +290,28 @@ WriteLiteral("\"\r\n                 data-failed=\"");
 
 
             
-            #line 62 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 64 "..\..\Dashboard\Pages\HomePage.cshtml"
                          Write(JsonConvert.SerializeObject(failed));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                 data-succeeded-string=\"");
+
+
+            
+            #line 65 "..\..\Dashboard\Pages\HomePage.cshtml"
+                                   Write(Strings.HomePage_GraphHover_Succeeded);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                 data-failed-string=\"");
+
+
+            
+            #line 66 "..\..\Dashboard\Pages\HomePage.cshtml"
+                                Write(Strings.HomePage_GraphHover_Failed);
 
             
             #line default
@@ -280,7 +320,7 @@ WriteLiteral("\">\r\n            </div>\r\n");
 
 
             
-            #line 64 "..\..\Dashboard\Pages\HomePage.cshtml"
+            #line 68 "..\..\Dashboard\Pages\HomePage.cshtml"
         }
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/_BlockMetric.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/_BlockMetric.cshtml
@@ -1,5 +1,6 @@
 ﻿@* Generator: Template TypeVisibility: Internal GeneratePrettyNames: True TrimLeadingUnderscores : true *@
 @using Hangfire.Dashboard
+@using Hangfire.Dashboard.Resources
 @inherits RazorPage
 @{
     var metric = DashboardMetric.Func(this);
@@ -11,6 +12,6 @@
         @(metric?.Value)
     </div>
     <div class="metric-description">
-        @DashboardMetric.Title
+        @(Strings.ResourceManager.GetString(DashboardMetric.Title) ?? DashboardMetric.Title)
     </div>
 </div>

--- a/src/Hangfire.Core/Dashboard/Pages/_BlockMetric.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/_BlockMetric.generated.cs
@@ -22,6 +22,12 @@ namespace Hangfire.Dashboard.Pages
     #line default
     #line hidden
     
+    #line 3 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+    using Hangfire.Dashboard.Resources;
+    
+    #line default
+    #line hidden
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("RazorGenerator", "2.0.0.0")]
     internal partial class BlockMetric : RazorPage
     {
@@ -36,8 +42,9 @@ WriteLiteral("\r\n");
 
 
 
+
             
-            #line 4 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+            #line 5 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
   
     var metric = DashboardMetric.Func(this);
     var className = metric == null ? "metric-null" : metric.Style.ToClassName();
@@ -51,7 +58,7 @@ WriteLiteral("<div class=\"metric ");
 
 
             
-            #line 9 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+            #line 10 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
               Write(className);
 
             
@@ -61,7 +68,7 @@ WriteLiteral(" ");
 
 
             
-            #line 9 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+            #line 10 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
                          Write(highlighted);
 
             
@@ -71,7 +78,7 @@ WriteLiteral("\">\r\n    <div class=\"metric-body\" data-metric=\"");
 
 
             
-            #line 10 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+            #line 11 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
                                      Write(DashboardMetric.Name);
 
             
@@ -81,7 +88,7 @@ WriteLiteral("\">\r\n        ");
 
 
             
-            #line 11 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+            #line 12 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
     Write(metric?.Value);
 
             
@@ -91,8 +98,8 @@ WriteLiteral("\r\n    </div>\r\n    <div class=\"metric-description\">\r\n      
 
 
             
-            #line 14 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
-   Write(DashboardMetric.Title);
+            #line 15 "..\..\Dashboard\Pages\_BlockMetric.cshtml"
+    Write(Strings.ResourceManager.GetString(DashboardMetric.Title) ?? DashboardMetric.Title);
 
             
             #line default

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -423,6 +423,7 @@
     <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.woff" />
     <EmbeddedResource Include="Dashboard\Content\fonts\glyphicons-halflings-regular.woff2" />
     <Compile Include="BackgroundJob.Instance.cs" />
+    <EmbeddedResource Include="Dashboard\Content\resx\Strings.es.resx" />
     <EmbeddedResource Include="Dashboard\Content\resx\Strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -269,7 +269,7 @@ namespace Hangfire.SqlServer
 
         public static readonly DashboardMetric ActiveConnections = new DashboardMetric(
             "connections:active",
-            Strings.Metrics_ActiveConnections,
+            "Metrics_ActiveConnections",
             page =>
             {
                 var sqlStorage = page.Storage as SqlServerStorage;
@@ -291,7 +291,7 @@ where dbid = db_id(@name) and status != 'background' and status != 'sleeping'";
 
         public static readonly DashboardMetric TotalConnections = new DashboardMetric(
             "connections:total",
-            Strings.Metrics_TotalConnections,
+            "Metrics_TotalConnections",
             page =>
             {
                 var sqlStorage = page.Storage as SqlServerStorage;


### PR DESCRIPTION
Adding Spanish :es: translation for Hangfire. Any correction for the strings translated will be great.

After translating I saw that all the Metrics titles always showed in english. It was because they were static, so the title was always on the default culture before setting any other culture. 
I modified them to use a TitleResourceKey and load the title from resources when asked. 