### PR TITLE
Adding support of ActivationFilters

### DIFF
--- a/src/Hangfire.Core/Common/JobFilterInfo.cs
+++ b/src/Hangfire.Core/Common/JobFilterInfo.cs
@@ -31,8 +31,9 @@ namespace Hangfire.Common
         private readonly List<IServerFilter> _serverFilters = new List<IServerFilter>();
         private readonly List<IElectStateFilter> _electStateFilters = new List<IElectStateFilter>();
         private readonly List<IApplyStateFilter> _applyStateFilters = new List<IApplyStateFilter>();
-        private readonly List<IClientExceptionFilter> _clientExceptionFilters = new List<IClientExceptionFilter>(); 
+        private readonly List<IClientExceptionFilter> _clientExceptionFilters = new List<IClientExceptionFilter>();
         private readonly List<IServerExceptionFilter> _serverExceptionFilters = new List<IServerExceptionFilter>();
+        private readonly List<IActivationFilter> _activationFilters = new List<IActivationFilter>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JobFilterInfo"/> class using the specified filters collection.
@@ -50,6 +51,8 @@ namespace Hangfire.Common
 
             _clientExceptionFilters.AddRange(list.OfType<IClientExceptionFilter>());
             _serverExceptionFilters.AddRange(list.OfType<IServerExceptionFilter>());
+
+            _activationFilters.AddRange(list.OfType<IActivationFilter>());
         }
 
         /// <summary>
@@ -122,6 +125,18 @@ namespace Hangfire.Common
         public IList<IServerExceptionFilter> ServerExceptionFilters
         {
             get { return _serverExceptionFilters; }
+        }
+
+        /// <summary>
+        /// Gets all activation filtres in the application
+        /// </summary>
+        /// 
+        /// <returns>
+        /// Activation filtres.
+        /// </returns>
+        public IList<IActivationFilter> ActivationFilters
+        {
+            get { return _activationFilters; }
         }
     }
 }

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -92,10 +92,14 @@
     </Compile>
     <Compile Include="JobActivatorScope.cs" />
     <Compile Include="Properties\NamespaceDoc.cs" />
+    <Compile Include="Server\ActivatedContext.cs" />
+    <Compile Include="Server\ActivatingContext.cs" />
+    <Compile Include="Server\ActivationContext.cs" />
     <Compile Include="Server\BackgroundProcessContext.cs" />
     <Compile Include="Obsolete\IServerProcess.cs" />
     <Compile Include="Server\BackgroundProcessingServerOptions.cs" />
     <Compile Include="Server\CoreBackgroundJobPerformer.cs" />
+    <Compile Include="Server\IActivationFilter.cs" />
     <Compile Include="Server\IBackgroundProcess.cs" />
     <Compile Include="Server\IBackgroundProcessWrapper.cs" />
     <Compile Include="Server\InfiniteLoopProcess.cs" />

--- a/src/Hangfire.Core/Server/ActivatedContext.cs
+++ b/src/Hangfire.Core/Server/ActivatedContext.cs
@@ -1,0 +1,57 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Hangfire.Annotations;
+using Hangfire.Storage;
+
+namespace Hangfire.Server
+{
+    /// <summary>
+    /// Provides the context for the <see cref="IActivationFilter.OnActivated"/>
+    /// method of the <see cref="IActivationFilter"/> interface.
+    /// </summary>
+    public class ActivatedContext : ActivationContext
+    {
+        internal ActivatedContext(
+            [NotNull] ActivationContext context,
+            object instance,
+            Exception exception)
+            : this(context.Connection, context.BackgroundJob, instance, exception)
+        { }
+
+        private ActivatedContext(
+            [NotNull] IStorageConnection connection,
+            [NotNull] BackgroundJob backgroundJob,
+            object instance,
+            Exception exception)
+            : base(connection, backgroundJob)
+        {
+            Instance = instance;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Instance of the job
+        /// </summary>
+        public object Instance { get; }
+
+        /// <summary>
+        /// Exception that occured during creation of the job instance
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/src/Hangfire.Core/Server/ActivatingContext.cs
+++ b/src/Hangfire.Core/Server/ActivatingContext.cs
@@ -1,0 +1,38 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using Hangfire.Annotations;
+using Hangfire.Storage;
+
+namespace Hangfire.Server
+{
+    /// <summary>
+    /// Provides the context for the <see cref="IActivationFilter.OnActivating"/>
+    /// method of the <see cref="IActivationFilter"/> interface.
+    /// </summary>
+    public class ActivatingContext : ActivationContext
+    {
+        internal ActivatingContext([NotNull] ActivationContext context)
+            : this(context.Connection, context.BackgroundJob)
+        { }
+
+        private ActivatingContext(
+            [NotNull] IStorageConnection connection,
+            [NotNull] BackgroundJob backgroundJob)
+            : base(connection, backgroundJob)
+        { }
+    }
+}

--- a/src/Hangfire.Core/Server/ActivationContext.cs
+++ b/src/Hangfire.Core/Server/ActivationContext.cs
@@ -1,0 +1,40 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Hangfire.Annotations;
+using Hangfire.Storage;
+
+namespace Hangfire.Server
+{
+    public class ActivationContext
+    {
+        internal ActivationContext(
+            [NotNull] IStorageConnection connection,
+            [NotNull] BackgroundJob backgroundJob)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (backgroundJob == null) throw new ArgumentNullException(nameof(backgroundJob));
+
+            Connection = connection;
+            BackgroundJob = backgroundJob;
+        }
+
+        public IStorageConnection Connection { get; }
+
+        public BackgroundJob BackgroundJob { get; }
+    }
+}

--- a/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
@@ -40,12 +40,12 @@ namespace Hangfire.Server
         public BackgroundJobPerformer(
             [NotNull] IJobFilterProvider filterProvider,
             [NotNull] JobActivator activator)
-            : this(filterProvider, new CoreBackgroundJobPerformer(activator))
+            : this(filterProvider, new CoreBackgroundJobPerformer(activator, filterProvider))
         {
         }
 
         internal BackgroundJobPerformer(
-            [NotNull] IJobFilterProvider filterProvider, 
+            [NotNull] IJobFilterProvider filterProvider,
             [NotNull] IBackgroundJobPerformer innerPerformer)
         {
             if (filterProvider == null) throw new ArgumentNullException("filterProvider");
@@ -101,14 +101,14 @@ namespace Hangfire.Server
 
             var thunk = filters.Reverse().Aggregate(continuation,
                 (next, filter) => () => InvokePerformFilter(filter, preContext, next));
-            
+
             thunk();
 
             return result;
         }
 
         private static PerformedContext InvokePerformFilter(
-            IServerFilter filter, 
+            IServerFilter filter,
             PerformingContext preContext,
             Func<PerformedContext> continuation)
         {
@@ -126,7 +126,7 @@ namespace Hangfire.Server
                     "An exception occurred during execution of one of the filters",
                     filterException);
             }
-            
+
             if (preContext.Canceled)
             {
                 return new PerformedContext(

--- a/src/Hangfire.Core/Server/IActivationFilter.cs
+++ b/src/Hangfire.Core/Server/IActivationFilter.cs
@@ -1,0 +1,36 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+namespace Hangfire.Server
+{
+    /// <summary>
+    /// Provides methods which allow to interfere in job activation.
+    /// </summary>
+    public interface IActivationFilter
+    {
+        /// <summary>
+        /// Called before job instance is created.
+        /// </summary>
+        /// <param name="context">Context of the filter.</param>
+        void OnActivating(ActivatingContext context);
+
+        /// <summary>
+        /// Called after job instance is created.
+        /// </summary>
+        /// <param name="context">Context of the filter.</param>
+        void OnActivated(ActivatedContext context);
+    }
+}


### PR DESCRIPTION
**Problem:** in our system we want to perform intelligent dependency injection based on job parameters/job id. There's no way to do this because JobActivator accepts only job type as its argument.

How could we overcome this?

- **extend JobActivator interface.** Give it more information about activation context (for example, pass BackroundJob as a parameter). But changing a public interface will break existing code, we can't do it without bumping a major version, so we can't do it now.
- **we could postpone dependency injection until we have an instance of the object and property-inject then.** None of the existing filters gives us access to a job instance, especially before the job execution. The only place where we could add this is OnPerforming in IServerFilter, but it means that we need to create instance of the job even if we want to cancel it, and we don't want to do it. Also semantically it does not seem like a good place to perform dependency injection.

None of the above really works, so we need to find a third solution, which this pull request is about.

**The idea is to add a new type of server filter - ActivationFilter.**
ActivationFilter will know everything about the job (type, parameters, job id) and will contain two methods:
- OnActivating - will execute before creation of the job instance. Allows us to modify parameters or perform any custom actions.
- OnActivated - will execute after creation of the job instance. Provides us with the job instance itself _or_ with exception, which occurred during the activation process. Allows us to perform any intelligent DI or custom-log exception, if any.

I've also included IStorageConnection in the context. Data from storage could also be useful for some intelligent decisions. For example, we use GetAllEntriesFromHash and SetRangeInHash to store infrastructural information for each job.

This functionality can also provide more convenient way to inject job id into the job itself (https://discuss.hangfire.io/t/how-to-get-jobid-within-job/851).