### PR TITLE
Drop constraints on Server.Id prior to altering it to avoid conflicts

### DIFF
--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -360,10 +360,19 @@ BEGIN
         [FetchedAt] ASC
     );
     PRINT 'Re-created index [IX_HangFire_JobQueue_QueueAndFetchedAt]';
+
+	ALTER TABLE [HangFire].[Server] DROP CONSTRAINT [PK_HangFire_Server]
+    PRINT 'Dropped constraint [PK_HangFire_Server] to modify the [HangFire].[Server].[Id] column';
 		
 	ALTER TABLE [HangFire].[Server] ALTER COLUMN [Id] NVARCHAR (100) NOT NULL;
 	PRINT 'Modified [HangFire].[Server].[Id] length to 100';
-		
+
+	ALTER TABLE [HangFire].[Server] ADD  CONSTRAINT [PK_HangFire_Server] PRIMARY KEY CLUSTERED
+	(
+		[Id] ASC
+	);
+	PRINT 'Re-created constraint [PK_HangFire_Server]';
+
 	SET @CURRENT_SCHEMA_VERSION = 5;
 END
 	

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -360,10 +360,19 @@ BEGIN
         [FetchedAt] ASC
     );
     PRINT 'Re-created index [IX_HangFire_JobQueue_QueueAndFetchedAt]';
-		
+
+	ALTER TABLE [$(HangFireSchema)].[Server] DROP CONSTRAINT [PK_HangFire_Server]
+    PRINT 'Dropped constraint [PK_HangFire_Server] to modify the [HangFire].[Server].[Id] column';
+
 	ALTER TABLE [$(HangFireSchema)].[Server] ALTER COLUMN [Id] NVARCHAR (100) NOT NULL;
 	PRINT 'Modified [$(HangFireSchema)].[Server].[Id] length to 100';
-		
+
+	ALTER TABLE [$(HangFireSchema)].[Server] ADD  CONSTRAINT [PK_HangFire_Server] PRIMARY KEY CLUSTERED
+	(
+		[Id] ASC
+	);
+	PRINT 'Re-created constraint [PK_HangFire_Server]';
+
 	SET @CURRENT_SCHEMA_VERSION = 5;
 END
 	


### PR DESCRIPTION
Currently running schema 3, and the alter statements for [Hangfire].[Server].[Id] in the schema 4 => 5 transition table fail because of a the clustered index that is referencing the [Id].

This is solved by dropping the constraint, doing the alter, and adding the constraint back. 

Surprisingly enough I could not replay this with a default run of the (Default)Install.sql script. I can only replicate this with a copy of our production database. Manually recreating the table (drop + create to from SSMS) did not recreate this issue either. 