### PR TITLE
Notification System with Email Module

### DIFF
--- a/Hangfire.sln
+++ b/Hangfire.sln
@@ -62,6 +62,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.AspNetCore.NetStan
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.AspNetCore", "src\Hangfire.AspNetCore\Hangfire.AspNetCore.csproj", "{73AFEBE0-9B11-44F6-A69C-8A51538CF18E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.EmailNotification", "src\Hangfire.EmailNotification\Hangfire.EmailNotification.csproj", "{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -116,6 +118,10 @@ Global
 		{73AFEBE0-9B11-44F6-A69C-8A51538CF18E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{73AFEBE0-9B11-44F6-A69C-8A51538CF18E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{73AFEBE0-9B11-44F6-A69C-8A51538CF18E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -195,7 +195,7 @@ namespace Hangfire
                 var name = _options.ServerName;
                 var msg = $"The server with machine name: \"{ name }\" has had a peak of failed jobs.";
 
-                NotificationStore.Current.NotifyAll(EventTypes.Events.FailedJobPeak, "Failed job peak", msg);
+                NotificationStore.Current.NotifyAll(EventTypes.FailedJobPeak, "Failed job peak", msg);
             }
         }
     }

--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -24,9 +24,11 @@ namespace Hangfire
 {
     public class BackgroundJobServerOptions
     {
+        public static readonly TimeSpan DefaultJobCheckInterval = TimeSpan.FromMinutes(5);
+        public static readonly int DefaultJobCheckThreshold = 100;
+
         // https://github.com/HangfireIO/Hangfire/issues/246
         private const int MaxDefaultWorkerCount = 40;
-
         private int _workerCount;
         private string[] _queues;
 
@@ -39,7 +41,9 @@ namespace Hangfire
             HeartbeatInterval = ServerHeartbeat.DefaultHeartbeatInterval;
             ServerTimeout = ServerWatchdog.DefaultServerTimeout;
             ServerCheckInterval = ServerWatchdog.DefaultCheckInterval;
-            
+            JobCheckInterval = DefaultJobCheckInterval;
+            JobCheckThreshold = DefaultJobCheckThreshold;
+
             FilterProvider = null;
             Activator = null;
         }
@@ -74,6 +78,8 @@ namespace Hangfire
         public TimeSpan HeartbeatInterval { get; set; }
         public TimeSpan ServerTimeout { get; set; }
         public TimeSpan ServerCheckInterval { get; set; }
+        public TimeSpan JobCheckInterval { get; set; }
+        public int JobCheckThreshold { get; set; }
 
         [Obsolete("Please use `ServerTimeout` or `ServerCheckInterval` options instead. Will be removed in 2.0.0.")]
         public ServerWatchdogOptions ServerWatchdogOptions { get; set; }

--- a/src/Hangfire.Core/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Core/GlobalConfigurationExtensions.cs
@@ -21,6 +21,7 @@ using Hangfire.Dashboard;
 using Hangfire.Dashboard.Pages;
 using Hangfire.Logging;
 using Hangfire.Logging.LogProviders;
+using Hangfire.Notification;
 
 namespace Hangfire
 {
@@ -36,6 +37,17 @@ namespace Hangfire
             if (storage == null) throw new ArgumentNullException(nameof(storage));
 
             return configuration.Use(storage, x => JobStorage.Current = x);
+        }
+
+        public static IGlobalConfiguration<TStorage> UseNotificationStorage<TStorage>(
+            [NotNull] this IGlobalConfiguration configuration,
+            [NotNull] TStorage notificationStorage)
+            where TStorage : NotificationStore
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            if (notificationStorage == null) throw new ArgumentNullException(nameof(notificationStorage));
+
+            return configuration.Use(notificationStorage, x => NotificationStore.Current = x);
         }
 
         public static IGlobalConfiguration<TActivator> UseActivator<TActivator>(

--- a/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
@@ -296,6 +296,7 @@
     <Compile Include="IGlobalConfiguration.cs" />
     <Compile Include="IJobCancellationToken.cs" />
     <Compile Include="IRecurringJobManager.cs" />
+    <Compile Include="IWorkerObserver.cs" />
     <Compile Include="JobActivator.cs" />
     <Compile Include="JobActivatorContext.cs" />
     <Compile Include="JobActivatorScope.cs" />
@@ -304,6 +305,9 @@
     <Compile Include="JobStorage.cs" />
     <Compile Include="LatencyTimeoutAttribute.cs" />
     <Compile Include="MoreLinq\MoreEnumerable.Pairwise.cs" />
+    <Compile Include="Notification\EventTypes.cs" />
+    <Compile Include="Notification\INotifier.cs" />
+    <Compile Include="Notification\NotificationStore.cs" />
     <Compile Include="Obsolete\CreateJobFailedException.cs" />
     <Compile Include="Obsolete\IServerComponent.cs" />
     <Compile Include="Obsolete\IServerProcess.cs" />
@@ -334,6 +338,7 @@
     <Compile Include="Server\IServerExceptionFilter.cs" />
     <Compile Include="Server\IServerFilter.cs" />
     <Compile Include="Server\IThrottler.cs" />
+    <Compile Include="Server\IWorkerObservable.cs" />
     <Compile Include="Server\JobAbortedException.cs" />
     <Compile Include="Server\JobPerformanceException.cs" />
     <Compile Include="Server\PerformContext.cs" />

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -92,6 +92,10 @@
     <Compile Include="Dashboard\Owin\OwinDashboardContextExtensions.cs" />
     <Compile Include="Dashboard\Owin\OwinDashboardRequest.cs" />
     <Compile Include="Dashboard\Owin\OwinDashboardResponse.cs" />
+    <Compile Include="Notification\EventTypes.cs" />
+    <Compile Include="Notification\INotifier.cs" />
+    <Compile Include="IWorkerObserver.cs" />
+    <Compile Include="Notification\NotificationStore.cs" />
     <Compile Include="Obsolete\RequestDispatcherWrapper.cs" />
     <Compile Include="JobActivatorContext.cs" />
     <Compile Include="IRecurringJobManager.cs" />
@@ -114,6 +118,7 @@
     <Compile Include="Server\IBackgroundProcess.cs" />
     <Compile Include="Server\IBackgroundProcessWrapper.cs" />
     <Compile Include="Server\InfiniteLoopProcess.cs" />
+    <Compile Include="Server\IWorkerObservable.cs" />
     <Compile Include="Server\ServerProcessExtensions.cs" />
     <Compile Include="Server\BackgroundProcessingServer.cs" />
     <Compile Include="MoreLinq\MoreEnumerable.Pairwise.cs" />

--- a/src/Hangfire.Core/IWorkerObserver.cs
+++ b/src/Hangfire.Core/IWorkerObserver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire
+{
+    public interface IWorkerObserver
+    {
+        void Update();
+    }
+}

--- a/src/Hangfire.Core/Notification/EventTypes.cs
+++ b/src/Hangfire.Core/Notification/EventTypes.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Notification
+{
+    public class EventTypes
+    {
+        public enum Events
+        {
+            FailedJobPeak,
+            ServerTimeout
+        }
+    }
+}

--- a/src/Hangfire.Core/Notification/EventTypes.cs
+++ b/src/Hangfire.Core/Notification/EventTypes.cs
@@ -6,12 +6,9 @@ using System.Threading.Tasks;
 
 namespace Hangfire.Notification
 {
-    public class EventTypes
+    public enum EventTypes
     {
-        public enum Events
-        {
-            FailedJobPeak,
-            ServerTimeout
-        }
+        FailedJobPeak,
+        ServerTimeout
     }
 }

--- a/src/Hangfire.Core/Notification/INotifier.cs
+++ b/src/Hangfire.Core/Notification/INotifier.cs
@@ -8,7 +8,7 @@ namespace Hangfire.Notification
 {
     public interface INotifier
     {
-        void Notify(EventTypes.Events eventType, string subject, string message);
-        void Subscribe(EventTypes.Events eventType, List<string> toEmails);
+        void Notify(EventTypes eventType, string subject, string message);
+        void Subscribe(EventTypes eventType, List<string> toEmails);
     }
 }

--- a/src/Hangfire.Core/Notification/INotifier.cs
+++ b/src/Hangfire.Core/Notification/INotifier.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Notification
+{
+    public interface INotifier
+    {
+        void Notify(EventTypes.Events eventType, string subject, string message);
+        void Subscribe(EventTypes.Events eventType, List<string> toEmails);
+    }
+}

--- a/src/Hangfire.Core/Notification/NotificationStore.cs
+++ b/src/Hangfire.Core/Notification/NotificationStore.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Hangfire.Notification
 {
@@ -41,7 +38,7 @@ namespace Hangfire.Notification
             _notifiers = notifiers;
         }
 
-        public void NotifyAll(EventTypes.Events eventType, string subject, string message)
+        public void NotifyAll(EventTypes eventType, string subject, string message)
         {
             foreach (var notifer in _notifiers)
             {

--- a/src/Hangfire.Core/Notification/NotificationStore.cs
+++ b/src/Hangfire.Core/Notification/NotificationStore.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Notification
+{
+    public class NotificationStore
+    {
+        private static readonly object LockObject = new object();
+        private static NotificationStore _current;
+
+        private readonly List<INotifier> _notifiers;
+        
+        public static NotificationStore Current
+        {
+            get
+            {
+                lock (LockObject)
+                {
+                    if (_current == null)
+                    {
+                        throw new InvalidOperationException("JobStorage.Current property value has not been initialized. You must set it before using Hangfire Client or Server API.");
+                    }
+
+                    return _current;
+                }
+            }
+            set
+            {
+                lock (LockObject)
+                {
+                    _current = value;
+                }
+            }
+        }
+
+        public NotificationStore(List<INotifier> notifiers)
+        {
+            _notifiers = notifiers;
+        }
+
+        public void NotifyAll(EventTypes.Events eventType, string subject, string message)
+        {
+            foreach (var notifer in _notifiers)
+            {
+                notifer.Notify(eventType, subject, message);
+            }
+        }
+    }
+}

--- a/src/Hangfire.Core/Server/IWorkerObservable.cs
+++ b/src/Hangfire.Core/Server/IWorkerObservable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Server
+{
+    interface IWorkerObservable
+    {
+        void Subscribe(IWorkerObserver observer);
+    }
+}

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -56,7 +56,7 @@ namespace Hangfire.Server
                     }
                     msg += "\n \n have timed out.";
 
-                    NotificationStore.Current.NotifyAll(EventTypes.Events.ServerTimeout, "Server timeout", msg);
+                    NotificationStore.Current.NotifyAll(EventTypes.ServerTimeout, "Server timeout", msg);
 
                     Logger.Info($"{serversRemoved} servers were removed due to timeout");
                 }

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -15,7 +15,9 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Linq;
 using Hangfire.Logging;
+using Hangfire.Notification;
 
 namespace Hangfire.Server
 {
@@ -42,6 +44,20 @@ namespace Hangfire.Server
                 var serversRemoved = connection.RemoveTimedOutServers(_serverTimeout);
                 if (serversRemoved != 0)
                 {
+                    var msg = "The servers with machine name and server ID: \n";
+
+                    var timedOutServers = connection.GetTimedOutServers(_serverTimeout);
+                    foreach (var item in timedOutServers)
+                    {
+                        var servername = item.Split(':');
+                        var machineName = servername.First();
+                        var serverId = servername.Last();
+                        msg += $"\n{machineName}  ::  {serverId}, ";
+                    }
+                    msg += "\n \n have timed out.";
+
+                    NotificationStore.Current.NotifyAll(EventTypes.Events.ServerTimeout, "Server timeout", msg);
+
                     Logger.Info($"{serversRemoved} servers were removed due to timeout");
                 }
             }

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -41,12 +41,12 @@ namespace Hangfire.Server
         {
             using (var connection = context.Storage.GetConnection())
             {
+                var timedOutServers = connection.GetTimedOutServers(_serverTimeout);
                 var serversRemoved = connection.RemoveTimedOutServers(_serverTimeout);
                 if (serversRemoved != 0)
                 {
                     var msg = "The servers with machine name and server ID: \n";
 
-                    var timedOutServers = connection.GetTimedOutServers(_serverTimeout);
                     foreach (var item in timedOutServers)
                     {
                         var servername = item.Split(':');

--- a/src/Hangfire.Core/Server/Worker.cs
+++ b/src/Hangfire.Core/Server/Worker.cs
@@ -38,13 +38,14 @@ namespace Hangfire.Server
     /// <threadsafety static="true" instance="true"/>
     /// 
     /// <seealso cref="EnqueuedState"/>
-    public class Worker : IBackgroundProcess
+    public class Worker : IBackgroundProcess, IWorkerObservable
     {
         private static readonly TimeSpan JobInitializationWaitTimeout = TimeSpan.FromMinutes(1);
         private static readonly ILog Logger = LogProvider.For<Worker>();
 
         private readonly string _workerId;
         private readonly string[] _queues;
+        private List<IWorkerObserver> _observers;
 
         private readonly IBackgroundJobPerformer _performer;
         private readonly IBackgroundJobStateChanger _stateChanger;
@@ -68,6 +69,7 @@ namespace Hangfire.Server
             if (stateChanger == null) throw new ArgumentNullException(nameof(stateChanger));
             
             _queues = queues.ToArray();
+            _observers = new List<IWorkerObserver>();
             _performer = performer;
             _stateChanger = stateChanger;
             _workerId = Guid.NewGuid().ToString();
@@ -130,6 +132,14 @@ namespace Hangfire.Server
                             fetchedJob.JobId, 
                             state, 
                             ProcessingState.StateName));
+
+                        if (state.Name == FailedState.StateName)
+                        {
+                            foreach (var item in _observers)
+                            {
+                                item.Update();
+                            }
+                        }
                     }
 
                     // Checkpoint #4. The job was performed, and it is in the one
@@ -223,5 +233,10 @@ namespace Hangfire.Server
                 };
             }
         }
+
+        public void Subscribe(IWorkerObserver observer)
+        {
+            _observers.Add(observer);
+        }    
     }
 }

--- a/src/Hangfire.Core/Storage/IStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/IStorageConnection.cs
@@ -49,6 +49,7 @@ namespace Hangfire.Storage
         void RemoveServer(string serverId);
         void Heartbeat(string serverId);
         int RemoveTimedOutServers(TimeSpan timeOut);
+        List<string> GetTimedOutServers(TimeSpan timeout);
 
         // Set operations
 

--- a/src/Hangfire.Core/Storage/JobStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/JobStorageConnection.cs
@@ -46,6 +46,7 @@ namespace Hangfire.Storage
         public abstract void RemoveServer(string serverId);
         public abstract void Heartbeat(string serverId);
         public abstract int RemoveTimedOutServers(TimeSpan timeOut);
+        public abstract List<string> GetTimedOutServers(TimeSpan timeOut);
 
         // Sets
         public abstract HashSet<string> GetAllItemsFromSet(string key);

--- a/src/Hangfire.EmailNotification/ClientConfiguration/SmtpConfiguration.cs
+++ b/src/Hangfire.EmailNotification/ClientConfiguration/SmtpConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.EmailNotification
+{
+    public class SmtpConfiguration
+    {
+        public string Host{ get; private set; }
+        public string Username { get; private set; }
+        public string Password { get; private set; }
+        public int Port { get; private set; }
+
+        public SmtpConfiguration(string host, string username, string password, int port)
+        {
+            Host = host;
+            Username = username;
+            Password = password;
+            Port = port;
+        }
+    }
+}

--- a/src/Hangfire.EmailNotification/ClientNotifiers/SmtpClientNotifier.cs
+++ b/src/Hangfire.EmailNotification/ClientNotifiers/SmtpClientNotifier.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Text;
+using System.Threading.Tasks;
+using Hangfire.Notification;
+
+namespace Hangfire.EmailNotification
+{
+    public class SmtpClientNotifier : INotifier
+    {
+        private readonly SmtpClient _smtpClient;
+        private readonly Dictionary<EventTypes.Events, List<string>> _eventReceivers;
+        private readonly string _fromEmail;
+        private readonly string _fromName;
+        
+        public SmtpClientNotifier(string fromEmail, string fromName, SmtpConfiguration sendgridConfig)
+        {
+            _fromEmail = fromEmail;
+            _fromName = fromName;
+            _smtpClient = new SmtpClient(sendgridConfig.Host, sendgridConfig.Port);
+            _eventReceivers = new Dictionary<EventTypes.Events, List<string>>();
+            _smtpClient.Credentials = new System.Net.NetworkCredential(sendgridConfig.Username, sendgridConfig.Password);
+        }
+
+        public void Notify(EventTypes.Events eventType, string subject, string message)
+        {
+            var mailMsg = new MailMessage();
+
+            List<string> emails;
+            var success = _eventReceivers.TryGetValue(eventType, out emails);
+
+            if (success && emails.Count > 0)
+            {
+                foreach (var email in emails)
+                {
+                    mailMsg.To.Add(email);
+                }
+
+                mailMsg.From = new MailAddress(_fromEmail, _fromName);
+                mailMsg.Subject = subject;
+                mailMsg.AlternateViews.Add(AlternateView.CreateAlternateViewFromString(message, null, MediaTypeNames.Text.Plain));
+
+                _smtpClient.Send(mailMsg);
+            }
+        }
+
+        public void Subscribe(EventTypes.Events eventType, List<string> toEmails)
+        {
+            if (toEmails == null) throw new NullReferenceException();
+
+            _eventReceivers.Add(eventType, toEmails);
+        }
+    }
+}

--- a/src/Hangfire.EmailNotification/ClientNotifiers/SmtpClientNotifier.cs
+++ b/src/Hangfire.EmailNotification/ClientNotifiers/SmtpClientNotifier.cs
@@ -12,7 +12,7 @@ namespace Hangfire.EmailNotification
     public class SmtpClientNotifier : INotifier
     {
         private readonly SmtpClient _smtpClient;
-        private readonly Dictionary<EventTypes.Events, List<string>> _eventReceivers;
+        private readonly Dictionary<EventTypes, List<string>> _eventReceivers;
         private readonly string _fromEmail;
         private readonly string _fromName;
         
@@ -21,11 +21,11 @@ namespace Hangfire.EmailNotification
             _fromEmail = fromEmail;
             _fromName = fromName;
             _smtpClient = new SmtpClient(sendgridConfig.Host, sendgridConfig.Port);
-            _eventReceivers = new Dictionary<EventTypes.Events, List<string>>();
+            _eventReceivers = new Dictionary<EventTypes, List<string>>();
             _smtpClient.Credentials = new System.Net.NetworkCredential(sendgridConfig.Username, sendgridConfig.Password);
         }
 
-        public void Notify(EventTypes.Events eventType, string subject, string message)
+        public void Notify(EventTypes eventType, string subject, string message)
         {
             var mailMsg = new MailMessage();
 
@@ -47,7 +47,7 @@ namespace Hangfire.EmailNotification
             }
         }
 
-        public void Subscribe(EventTypes.Events eventType, List<string> toEmails)
+        public void Subscribe(EventTypes eventType, List<string> toEmails)
         {
             if (toEmails == null) throw new NullReferenceException();
 

--- a/src/Hangfire.EmailNotification/EmailNotificationExtensions.cs
+++ b/src/Hangfire.EmailNotification/EmailNotificationExtensions.cs
@@ -1,0 +1,36 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2015 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using Hangfire.Annotations;
+using Hangfire.Notification;
+
+namespace Hangfire.EmailNotification
+{
+    public static class EmailNotificationExtensions
+    {
+        public static IGlobalConfiguration<NotificationStore> AddNotificationSystem(
+            [NotNull] this IGlobalConfiguration configuration,
+            [NotNull] List<INotifier> notifiers )
+        {
+            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+
+            var storage = new NotificationStore(notifiers);
+            return configuration.UseNotificationStorage(storage);
+        }
+    }
+}

--- a/src/Hangfire.EmailNotification/Hangfire.EmailNotification.csproj
+++ b/src/Hangfire.EmailNotification/Hangfire.EmailNotification.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FEA5CB33-AD1F-47A9-92F8-90D10F158C69}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Hangfire.EmailNotification</RootNamespace>
+    <AssemblyName>Hangfire.EmailNotification</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ClientConfiguration\SmtpConfiguration.cs" />
+    <Compile Include="ClientNotifiers\SmtpClientNotifier.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="EmailNotificationExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Hangfire.Core\Hangfire.Core.csproj">
+      <Project>{c995ea9e-56ee-4951-8260-d94260a7f4c2}</Project>
+      <Name>Hangfire.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Hangfire.EmailNotification/Properties/AssemblyInfo.cs
+++ b/src/Hangfire.EmailNotification/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Hangfire.EmailNotification")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Hangfire.EmailNotification")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fea5cb33-ad1f-47a9-92f8-90d10f158c69")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -341,6 +341,20 @@ when not matched then insert (Id, Data, LastHeartbeat) values (Source.Id, Source
                 new { timeOutAt = DateTime.UtcNow.Add(timeOut.Negate()) }));
         }
 
+        public override List<string> GetTimedOutServers(TimeSpan timeOut)
+        {
+            if (timeOut.Duration() != timeOut)
+            {
+                throw new ArgumentException("The `timeOut` value must be positive.", nameof(timeOut));
+            }
+
+            var query = $@"select Id from [{nameof(_storage)}].Server where LastHeartbeat < @timeOutAt";
+
+            return _storage.UseConnection(connection => connection
+                .Query<string>(query, new { timeOutAt = DateTime.UtcNow.Add(timeOut.Negate()) }))
+                .ToList();
+        }
+
         public override long GetSetCount(string key)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -348,7 +348,7 @@ when not matched then insert (Id, Data, LastHeartbeat) values (Source.Id, Source
                 throw new ArgumentException("The `timeOut` value must be positive.", nameof(timeOut));
             }
 
-            var query = $@"select Id from [{nameof(_storage)}].Server where LastHeartbeat < @timeOutAt";
+            var query = $@"select Id from [{_storage.SchemaName}].Server where LastHeartbeat < @timeOutAt";
 
             return _storage.UseConnection(connection => connection
                 .Query<string>(query, new { timeOutAt = DateTime.UtcNow.Add(timeOut.Negate()) }))

--- a/tests/Hangfire.Core.Tests/Server/ServerWatchdogFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/ServerWatchdogFacts.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
+using Hangfire.Notification;
 using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
@@ -24,12 +26,15 @@ namespace Hangfire.Core.Tests.Server
 
             _connection = new Mock<IStorageConnection>();
             _context.Storage.Setup(x => x.GetConnection()).Returns(_connection.Object);
+
+            NotificationStore.Current = new NotificationStore(new List<INotifier>());
         }
 
         [Fact]
         public void Execute_DelegatesRemovalToStorageConnection()
         {
             _connection.Setup(x => x.RemoveTimedOutServers(It.IsAny<TimeSpan>())).Returns(1);
+            _connection.Setup(x => x.GetTimedOutServers(It.IsAny<TimeSpan>())).Returns(new List<string> {});
             var watchdog = new ServerWatchdog(_checkInterval, _serverTimeout);
 
 			watchdog.Execute(_context.Object);


### PR DESCRIPTION
Without having to open the Hangfire Dashboard to monitor the status of Hangfire Server it can be difficult to check their statuses.  We have created a notification system which is extendible by adding modules such as the email one we have created as an example.

The email notification module only works for **full .NET only** (does not work for .NET Core) and not sure if you want this email notification module moved to a different repo? If you want we could expand the email notification module to support .NET Core with the help of MailKit.

We have also updated the IStorageConnection interface with an extra method to implement dunno if you are happy with us adding this method or do you want us to move it out as part of a new interface?

Here is an example of setting it up in startup.cs :

```
List<string> toEmails = new List<string>() { "email1@testdomain.com" };
List<string> toEmails2 = new List<string>() { "email2@testdomain.com" };

// You can register custom configuration and email clients in the EmailNotification project. This example uses Sendgrid.
SmtpConfiguration sendgridConfig = new SmtpConfiguration("smtp.sendgrid.net", "username", "password", 587);
SmtpClientNotifier client =  new SmtpClientNotifier("fromemail@testdomain.com", "fromname", sendgridConfig);

//Only 2 types of events for now, it is possible to create custom event types and implement detection for it in the core code.
client.Subscribe(EventTypes.Events.FailedJobPeak, toEmails);
client.Subscribe(EventTypes.Events.ServerTimeout, toEmails2);

List<INotifier> clientList = new List<INotifier>();
clientList.Add(client);

GlobalConfiguration.Configuration.AddNotificationSystem(clientList);

app.UseHangfireServer(new BackgroundJobServerOptions()
{
      JobCheckInterval = new TimeSpan(0, 5, 0),
      JobCheckThreshold = 20,
      ServerName = "Server One"
});

```

The notification store can then be accessed using the static method, NotificationStore.Current, in the same way as JobStorage.
This can then be used to call the NotifyAll method, which takes a EventType parameter and alerts all emails registered for that EventType in each registered client. For example,

```
//Server timeout detected in server watchdog
NotificationStore.Current.NotifyAll(EventType.Event.ServerTimeout. "Subject", "Message");
```
