### PR TITLE
Add possibility to detect aborted requests in Dashboard UI

### DIFF
--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardRequest.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardRequest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Hangfire.Annotations;
 using Microsoft.AspNetCore.Http;
@@ -37,11 +38,13 @@ namespace Hangfire.Dashboard
         public override string PathBase => _context.Request.PathBase.Value;
         public override string LocalIpAddress => _context.Connection.LocalIpAddress.ToString();
         public override string RemoteIpAddress => _context.Connection.RemoteIpAddress.ToString();
+        public override CancellationToken Aborted => _context.RequestAborted;
+
         public override string GetQuery(string key) => _context.Request.Query[key];
 
         public override async Task<IList<string>> GetFormValuesAsync(string key)
         {
-            var form = await _context.Request.ReadFormAsync();
+            var form = await _context.Request.ReadFormAsync(Aborted);
             return form[key];
         }
     }

--- a/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
+++ b/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
@@ -48,10 +48,13 @@ namespace Hangfire.Dashboard
 
             foreach (var jobId in jobIds)
             {
+                if (context.Request.Aborted.IsCancellationRequested) break;
                 _command(context, jobId);
             }
-
-            context.Response.StatusCode = (int)HttpStatusCode.NoContent;
+            
+            context.Response.StatusCode = context.Request.Aborted.IsCancellationRequested
+                ? (int)HttpStatusCode.RequestTimeout
+                : (int)HttpStatusCode.NoContent;
         }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardRequest.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRequest.cs
@@ -15,6 +15,7 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Hangfire.Dashboard
@@ -27,6 +28,8 @@ namespace Hangfire.Dashboard
 
         public abstract string LocalIpAddress { get; }
         public abstract string RemoteIpAddress { get; }
+
+        public abstract CancellationToken Aborted { get; }
 
         public abstract string GetQuery(string key);
         public abstract Task<IList<string>> GetFormValuesAsync(string key);

--- a/src/Hangfire.Core/Dashboard/Owin/OwinDashboardRequest.cs
+++ b/src/Hangfire.Core/Dashboard/Owin/OwinDashboardRequest.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Hangfire.Annotations;
 using Microsoft.Owin;
@@ -37,6 +38,7 @@ namespace Hangfire.Dashboard
         public override string PathBase => _context.Request.PathBase.Value;
         public override string LocalIpAddress => _context.Request.LocalIpAddress;
         public override string RemoteIpAddress => _context.Request.RemoteIpAddress;
+        public override CancellationToken Aborted => _context.Request.CallCancelled;
 
         public override string GetQuery(string key) => _context.Request.Query[key];
 


### PR DESCRIPTION
Batch commands sometimes iterate over hundreds of background jobs. In case of an application shutdown, there will be unwanted delay that may prevent the graceful shutdown. It is better to allow request to abort instead.
