### PR TITLE
Respond with authentication challenge instead of 401 redirect

### DIFF
--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.project.json
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.project.json
@@ -2,6 +2,7 @@
     "dependencies": {
         "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
         "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
+        "Microsoft.AspNetCore.Http.Extensions": "1.0.0",
         "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0",
         "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
     },

--- a/src/Hangfire.AspNetCore/project.json
+++ b/src/Hangfire.AspNetCore/project.json
@@ -6,6 +6,7 @@
         "System.ComponentModel": "4.0.1",
         "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
         "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
+        "Microsoft.AspNetCore.Http.Extensions": "1.0.0",
         "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0",
         "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
     },


### PR DESCRIPTION
This PR is connected to #638.

This pull request only affects .NET Core deployments, and changes "access denied" workflow as follows:

1) If there's an authentication middleware present in the pipeline, Dashboard will issue the authentication challenge. If the user is not authenticated, he will be redirected to the login page. After successful authentication he will be redirected back to Dashboard (with initial url preserved, so if he opened a link from bookmarks or email, he would get to the right location after login).

2) If the user was already logged in, or authorization filters still reject him (e.g. because of insufficient rights, or suspicious request origin etc.), another challenge will be issued. But this time, authentication middleware will know the user is authenticated, and redirect him to "Access Denied" page (if configured), or just return error 403 Forbidden.

3) If there's no authentication middleware available, it will fallback to 403 Forbidden.

This pull request also removes response status message in case of 403, as it is a common practice for .NET Core application. The app should only return HTTP status code, while displaying status message (or a nice status page) is a job for upstream middlewares, and returning any status message would break this behavior.