### PR TITLE
Add entry point for custom job naming strategies

### DIFF
--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -106,6 +106,16 @@ namespace Hangfire.Dashboard
                 return Strings.Common_CannotFindTargetMethod;
             }
 
+            var jobNameProvider = _page.JobNameProvider;
+            if (jobNameProvider != null)
+            {
+                var jobName = jobNameProvider.GetName(_page.Context, job);
+                if (!string.IsNullOrEmpty(jobName))
+                {
+                    return jobName;
+                }
+            }
+
 #if NETFULL
             var displayNameAttribute = job.Method.GetCustomAttribute(typeof(DisplayNameAttribute)) as DisplayNameAttribute;
             if (displayNameAttribute != null && displayNameAttribute.DisplayName != null)

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -106,14 +106,10 @@ namespace Hangfire.Dashboard
                 return Strings.Common_CannotFindTargetMethod;
             }
 
-            var jobNameProvider = _page.JobNameProvider;
-            if (jobNameProvider != null)
+            var jobName = _page.JobNameProvider?.GetName(_page.Context, job);
+            if (!string.IsNullOrEmpty(jobName))
             {
-                var jobName = jobNameProvider.GetName(_page.Context, job);
-                if (!string.IsNullOrEmpty(jobName))
-                {
-                    return jobName;
-                }
+                return jobName;
             }
 
 #if NETFULL

--- a/src/Hangfire.Core/Dashboard/IDashboardJobNameProvider.cs
+++ b/src/Hangfire.Core/Dashboard/IDashboardJobNameProvider.cs
@@ -1,0 +1,15 @@
+﻿using Hangfire.Annotations;
+using Hangfire.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Hangfire.Dashboard
+{
+    public interface IDashboardJobNameProvider
+    {
+        string GetName([NotNull] DashboardContext context, [NotNull] Job job);
+    }
+}

--- a/src/Hangfire.Core/Dashboard/RazorPage.cs
+++ b/src/Hangfire.Core/Dashboard/RazorPage.cs
@@ -41,6 +41,7 @@ namespace Hangfire.Dashboard
 
         public JobStorage Storage { get; internal set; }
         public string AppPath { get; internal set; }
+        public IDashboardJobNameProvider JobNameProvider { get; internal set; }
         public int StatsPollingInterval { get; internal set; }
         public Stopwatch GenerationTime { get; private set; }
 
@@ -53,8 +54,10 @@ namespace Hangfire.Dashboard
             }
         }
 
-        internal DashboardRequest Request { private get; set; }
-        internal DashboardResponse Response { private get; set; }
+        internal DashboardContext Context { get; private set; }
+
+        internal DashboardRequest Request => Context.Request;
+        internal DashboardResponse Response => Context.Response;
 
         public string RequestPath => Request.Path;
 
@@ -74,10 +77,10 @@ namespace Hangfire.Dashboard
         /// <exclude />
         public void Assign(RazorPage parentPage)
         {
-            Request = parentPage.Request;
-            Response = parentPage.Response;
+            Context = parentPage.Context;
             Storage = parentPage.Storage;
             AppPath = parentPage.AppPath;
+            JobNameProvider = parentPage.JobNameProvider;
             StatsPollingInterval = parentPage.StatsPollingInterval;
             Url = parentPage.Url;
 
@@ -87,11 +90,10 @@ namespace Hangfire.Dashboard
 
         internal void Assign(DashboardContext context)
         {
-            Request = context.Request;
-            Response = context.Response;
-
+            Context = context;
             Storage = context.Storage;
             AppPath = context.Options.AppPath;
+            JobNameProvider = context.Options.JobNameProvider;
             StatsPollingInterval = context.Options.StatsPollingInterval;
             Url = new UrlHelper(context);
 

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -27,6 +27,7 @@ namespace Hangfire
             AppPath = "/";
             Authorization = new[] { new LocalRequestsOnlyAuthorizationFilter() };
             StatsPollingInterval = 2000;
+            JobNameProvider = null;
         }
 
         /// <summary>
@@ -45,5 +46,10 @@ namespace Hangfire
         /// The interval the /stats endpoint should be polled with.
         /// </summary>
         public int StatsPollingInterval { get; set; }
+
+        /// <summary>
+        /// Display name provider for jobs
+        /// </summary>
+        public IDashboardJobNameProvider JobNameProvider { get; set; }
     }
 }

--- a/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Dashboard\HtmlHelper.cs" />
     <Compile Include="Dashboard\IDashboardAuthorizationFilter.cs" />
     <Compile Include="Dashboard\IDashboardDispatcher.cs" />
+    <Compile Include="Dashboard\IDashboardJobNameProvider.cs" />
     <Compile Include="Dashboard\JobHistoryRenderer.cs" />
     <Compile Include="Dashboard\JobMethodCallRenderer.cs" />
     <Compile Include="Dashboard\JobsSidebarMenu.cs" />

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Dashboard\DashboardResponse.cs" />
     <Compile Include="Dashboard\IDashboardAuthorizationFilter.cs" />
     <Compile Include="Dashboard\IDashboardDispatcher.cs" />
+    <Compile Include="Dashboard\IDashboardJobNameProvider.cs" />
     <Compile Include="Dashboard\Owin\OwinDashboardContext.cs" />
     <Compile Include="Dashboard\Owin\OwinDashboardContextExtensions.cs" />
     <Compile Include="Dashboard\Owin\OwinDashboardRequest.cs" />


### PR DESCRIPTION
Because of shortcomings of `DisplayNameAttribute` (or lack thereof on .NET Core), I'd like to propose another approach to job naming: `IDashboardJobNameProvider`.

Like `IDashboardAuthorizationFilter`s, name provider is configured in `DashboardOptions` during startup, and implements a single method taking current `DashboardContext` (so you have access to Owin environment or .NET Core's `HttpContext`) and the `Job` of interest. 

Here's an example of what it looks like:

``` c#
public class SampleJobNameProvider : IDashboardJobNameProvider
{

    public string GetName([NotNull] DashboardContext context, [NotNull] Job job)
    {
        // You may implement different approaches for job naming, be it an attribute ...

        string jobName = job.Method.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName;
        if (jobName == null)
        {
            // ... or something else you might think of ...

            jobName = Regex.Replace(job.Type.Name, "([a-z])([A-Z])", "$1 $2");
        }

        // ... then you might want to translate it into user's preferred UI language ...

        var localizerFactory = context.GetHttpContext().RequestServices
                                      .GetService<IStringLocalizerFactory>();
        if (localizerFactory != null)
        {
            var baseName = job.Type.FullName;
            var location = job.Type.GetTypeInfo().Assembly.GetName().Name;

            jobName = localizerFactory.Create(baseName, location)[jobName];
        }

        // ... or maybe apply some formatting afterwards ...

        try
        {
            return string.Format(jobName, job.Args.ToArray());
        }
        catch
        {
            return jobName;
        }
    }

}
```
