### PR TITLE
Add l10n resource files to NuGet packages

### DIFF
--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -78,10 +78,14 @@
     <file src="net45\Hangfire.Core.dll" target="lib\net45" />
     <file src="net45\Hangfire.Core.xml" target="lib\net45" />
     <file src="net45\Hangfire.Core.pdb" target="lib\net45" />
+
+    <file src="net45\**\Hangfire.Core.resources.dll" target="lib\net45" />
     
     <file src="netstandard1.3\Hangfire.Core.dll" target="lib\netstandard1.3" />
     <file src="netstandard1.3\Hangfire.Core.xml" target="lib\netstandard1.3" />
     <file src="netstandard1.3\Hangfire.Core.pdb" target="lib\netstandard1.3" />
+
+    <file src="netstandard1.3\**\Hangfire.Core.resources.dll" target="lib\netstandard1.3" />
     
     <file src="..\src\Hangfire.Core\**\*.cs;..\src\Hangfire.Core\**\*.cshtml" target="src" exclude="**\obj*\**\*.cs" />
   </files>

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -40,6 +40,9 @@ Task Collect -Depends Merge -Description "Copy all artifacts to the build folder
     
     Collect-Content "content\readme.txt"
     Collect-Tool "src\Hangfire.SqlServer\DefaultInstall.sql"
+
+    Collect-Localizations "Hangfire.Core" "net45"
+    Collect-Localizations "Hangfire.Core" "netstandard1.3"
 }
 
 Task Pack -Depends Collect -Description "Create NuGet packages and archive files." {
@@ -69,6 +72,26 @@ Task CoverityScan -Depends Restore -PreCondition { return $env:APPVEYOR_SCHEDULE
 
         .$publish compress -o coverity.zip -i cov-int --nologo
         .$publish publish -z coverity.zip -r HangfireIO/Hangfire -t $env:COVERITY_TOKEN -e $env:COVERITY_EMAIL --codeVersion $env:APPVEYOR_BUILD_VERSION --nologo
+    }
+}
+
+function Collect-Localizations($project, $target) {
+    Write-Host "Collecting localizations for '$target/$project'..." -ForegroundColor "Green"
+    
+    $output = (Get-SrcOutputDir $project $target)
+    $dirs = Get-ChildItem -Path $output -Directory
+
+    foreach ($dir in $dirs) {
+        $source = "$output\$dir\$project.resources.dll"
+
+        if (Test-Path $source) {
+            Write-Host "  Collecting '$dir' localization..."
+
+            $destination = "$build_dir\$target\$dir"
+
+            Create-Directory $destination
+            Copy-Files $source $destination
+        }
     }
 }
 


### PR DESCRIPTION
Despite of the fact that internationalization support was already added to Hangfire 1.6, resource files weren't copied to their corresponding NuGet packages, leading localizations to a non-working state.