### PR TITLE
Job Filter as a Service

### DIFF
--- a/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobFilterProviders.cs
+++ b/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobFilterProviders.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Hangfire.Common;
+using Hangfire.Annotations;
+
+namespace Hangfire.AspNetCore
+{
+    /// <summary>
+    /// Composite job filter provider for ASP.NET Core. Uses the following sources:
+    /// 1) providers registered under <see cref="JobFilterProviders.Providers"/>
+    ///    (includes <see cref="GlobalJobFilters.Filters"/> and <see cref="JobFilterAttribute"/>s from job class/method);
+    /// 2) services of type <see cref="IJobFilter"/> from service container;
+    /// </summary>
+    internal class AspNetCoreJobFilterProviders : JobFilterProviderCollection
+    {
+        public AspNetCoreJobFilterProviders([NotNull] IServiceProvider services)
+        {
+            Add(JobFilterProviders.Providers);
+            Add(new ServiceProviderJobFilterProvider(services));
+        }
+
+        /// <summary>
+        /// Implementation of <see cref="IJobFilterProvider"/> backed by <see cref="IServiceProvider"/>
+        /// </summary>
+        private class ServiceProviderJobFilterProvider : IJobFilterProvider
+        {
+            private readonly IServiceProvider _services;
+
+            public ServiceProviderJobFilterProvider([NotNull] IServiceProvider services)
+            {
+                if (services == null) throw new ArgumentNullException(nameof(services));
+
+                _services = services;
+            }
+
+            /// <summary>
+            /// Returns global job filters for all services of type <see cref="IJobFilter"/>
+            /// </summary>
+            /// <param name="job">Job to return filters for (currently not used)</param>
+            /// <returns>Job filters from service container</returns>
+            public IEnumerable<JobFilter> GetFilters(Job job)
+            {
+                return _services.GetServices<IJobFilter>()
+                                .Select(x => new JobFilter(x, JobFilterScope.Global, null));
+            }
+        }
+    }
+}

--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.NetStandard.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.NetStandard.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AspNetCore\AspNetCoreJobFilterProviders.cs" />
     <Compile Include="AspNetCore\AspNetCoreJobActivator.cs" />
     <Compile Include="AspNetCore\AspNetCoreJobActivatorScope.cs" />
     <Compile Include="AspNetCore\AspNetCoreLog.cs" />

--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AspNetCore\AspNetCoreJobFilterProviders.cs" />
     <Compile Include="AspNetCore\AspNetCoreJobActivator.cs" />
     <Compile Include="AspNetCore\AspNetCoreJobActivatorScope.cs" />
     <Compile Include="AspNetCore\AspNetCoreLog.cs" />

--- a/src/Hangfire.AspNetCore/HangfireApplicationBuilderExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireApplicationBuilderExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Hangfire.Common;
 
 namespace Hangfire
 {
@@ -66,6 +67,8 @@ namespace Hangfire
             storage = storage ?? services.GetRequiredService<JobStorage>();
             options = options ?? services.GetService<BackgroundJobServerOptions>() ?? new BackgroundJobServerOptions();
             additionalProcesses = additionalProcesses ?? services.GetServices<IBackgroundProcess>();
+
+            options.FilterProvider = options.FilterProvider ?? services.GetRequiredService<IJobFilterProvider>();
 
             var server = new BackgroundJobServer(options, storage, additionalProcesses);
 

--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ namespace Hangfire
             services.TryAddSingleton(_ => JobActivator.Current);
             services.TryAddSingleton(_ => DashboardRoutes.Routes);
 
-            services.TryAddSingleton<IJobFilterProvider>(_ => GlobalJobFilters.Filters);
+            services.TryAddSingleton<IJobFilterProvider>(x => new AspNetCoreJobFilterProviders(x));
 
             services.TryAddSingleton<IBackgroundJobFactory>(x => new BackgroundJobFactory(
                 x.GetRequiredService<IJobFilterProvider>()));
@@ -84,7 +84,7 @@ namespace Hangfire
                     {
                         config.UseActivator(new AspNetCoreJobActivator(scopeFactory));
                     }
-
+                    
                     configuration(config);
                 };
             });


### PR DESCRIPTION
The current implementation of job filters suggests two possible ways of using them:

- Local filters added as attributes to Job class/method, - or -
- Global filters' instances added to `GlobalJobFilters.Filters` collection.

Both these ways appear to be virtually useless on .NET Core, because none of them provides any relevant information about current execution context. Since there's no `HttpContext.Current` and the likes available anymore (because of async nature, and the ugly looks too, I suppose :) ), so accessing anything beyond job filter's `filterContext` argument becomes quite troublesome.

The following PR provides a way to store job filters in a DI container, and to interact with other services.

For example, you might want to capture username (role, IP address, cookie, etc.) of the user who initiated the background task: 
```c#
/// <summary>
/// Sample job filter implemented as a service
/// </summary>
public class CaptureUserNameJobFilter : IJobFilter, IClientFilter
{
    private readonly IHttpContextAccessor _contextAccessor;

    public CaptureUserNameJobFilter(IHttpContextAccessor contextAccessor)
    {
        if (contextAccessor == null)
            throw new ArgumentNullException(nameof(contextAccessor));

        _contextAccessor = contextAccessor;
    }

    public bool AllowMultiple => false;

    public int Order => JobFilter.DefaultOrder;
    
    public void OnCreating(CreatingContext filterContext)
    {
        var httpContext = _contextAccessor.HttpContext;
        if (httpContext == null)
            throw new InvalidOperationException("HttpContext is not available");

        filterContext.SetJobParameter("CurrentUserId", httpContext.User.Identity.Name);
    }
    
    public void OnCreated(CreatedContext filterContext)
    {
    }
}
```
Now register it in `Startup.cs`:
```c#
public void ConfigureServices(IServiceCollection services)
{
    // ... ... ...
    // ... other services' configuration
    // ... ... ...

    services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobFilter, CaptureUserNameJobFilter>());
}
```
And... voila! All registered services implementing `IJobFilter` will be treated as job filters.

---
P.S. The only thing is, you cannot use `BackgroundJob` / `RecurringJob` static methods anymore. The reason is, they use a private (non-DI) instance of client class, hence they will ignore the new lookup method.

You'll need to inject a proper instance of `IBackgroundJobClient` / `IRecurringJobManager` and use its methods instead. It is not actually a bad thing, since it employs a typical .NET Core pattern instead of a dubious static wrapper, but the static wrapper still shouldn't produce "partial success" results (failing with exception would be better).

---
P.P.S. `BackgroundJob` and `RecurringJob` appear to use different ways of storing a local instance. Feels like `BackgroundJob` was designed with possibility to switch implementations in mind (even though not actually used), while `RecurringJob` never bothered to.