### PR TITLE
Rewrite JobActivatorScope

### DIFF
--- a/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
+++ b/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
@@ -32,10 +32,12 @@ namespace Hangfire.AspNetCore
 
         public override object Resolve(Type type)
         {
+            AssertNotDisposed();
+
             return _serviceScope.ServiceProvider.GetRequiredService(type);
         }
 
-        public override void DisposeScope()
+        protected override void DisposeScope()
         {
             _serviceScope.Dispose();
         }

--- a/src/Hangfire.Core/AsyncLocal.cs
+++ b/src/Hangfire.Core/AsyncLocal.cs
@@ -1,0 +1,67 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2015 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+#if !NETSTANDARD1_3
+
+using System;
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Messaging;
+
+namespace System.Threading
+{
+    /// <summary>
+    /// A drop-in replacement for <see cref="System.Threading.AsyncLocal{T}"/> for pre-net46 environment.
+    /// </summary>
+    /// <typeparam name="T">Value type</typeparam>
+    internal class AsyncLocal<T>
+    {
+        private readonly string _slotName;
+
+        public AsyncLocal()
+        {
+            _slotName = Guid.NewGuid().ToString();
+        }
+
+        public T Value
+        {
+            get
+            {
+                var handle = CallContext.LogicalGetData(_slotName) as ObjectHandle;
+                if (handle == null)
+                {
+                    return default(T);
+                }
+
+                // won't fail for value types, since nulls are never wrapped in ObjectHandle
+                return (T)handle.Unwrap();
+            }
+            set
+            {
+                if (value == null)
+                {
+                    CallContext.LogicalSetData(_slotName, null);
+                }
+                else
+                {
+                    // wrap non-null values in ObjectHandle for cross-AppDomain safety
+                    CallContext.LogicalSetData(_slotName, new ObjectHandle(value));
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="AppBuilderExtensions.cs" />
     <Compile Include="App_Packages\LibLog.1.4\LibLog.cs" />
+    <Compile Include="AsyncLocal.cs" />
     <Compile Include="AttemptsExceededAction.cs" />
     <Compile Include="App_Packages\StackTraceFormatter\StackTraceFormatter.cs" />
     <Compile Include="App_Packages\StackTraceParser\StackTraceParser.cs" />

--- a/src/Hangfire.Core/JobActivator.cs
+++ b/src/Hangfire.Core/JobActivator.cs
@@ -61,7 +61,7 @@ namespace Hangfire
 #pragma warning restore 618
         }
 
-        class SimpleJobActivatorScope : JobActivatorScope
+        private class SimpleJobActivatorScope : JobActivatorScope
         {
             private readonly JobActivator _activator;
             private readonly List<IDisposable> _disposables = new List<IDisposable>();
@@ -74,6 +74,8 @@ namespace Hangfire
 
             public override object Resolve(Type type)
             {
+                AssertNotDisposed();
+
                 var instance = _activator.ActivateJob(type);
                 var disposable = instance as IDisposable;
 
@@ -85,7 +87,7 @@ namespace Hangfire
                 return instance;
             }
 
-            public override void DisposeScope()
+            protected override void DisposeScope()
             {
                 foreach (var disposable in _disposables)
                 {

--- a/src/Hangfire.Core/JobActivatorScope.cs
+++ b/src/Hangfire.Core/JobActivatorScope.cs
@@ -19,36 +19,82 @@ using System.Threading;
 
 namespace Hangfire
 {
+    /// <summary>
+    /// Base class for <see cref="JobActivator"/> scopes.
+    /// </summary>
     public abstract class JobActivatorScope : IDisposable
     {
         // ReSharper disable once InconsistentNaming
-        private static readonly ThreadLocal<JobActivatorScope> _current
-            = new ThreadLocal<JobActivatorScope>(trackAllValues: false);
+        private static readonly AsyncLocal<JobActivatorScope> _current
+            = new AsyncLocal<JobActivatorScope>();
+
+        private readonly JobActivatorScope _parent;
+        private bool _disposed;
 
         protected JobActivatorScope()
         {
+            _parent = _current.Value;
             _current.Value = this;
+            _disposed = false;
         }
 
+        /// <summary>
+        /// Returns <see cref="JobActivatorScope"/> the code is running in.
+        /// </summary>
         public static JobActivatorScope Current => _current.Value;
 
-        public object InnerScope { get; set; }
+        /// <summary>
+        /// Returns an enclosing <see cref="JobActivatorScope"/> for this scope.
+        /// </summary>
+        internal JobActivatorScope ParentScope => _parent;
 
+        /// <summary>
+        /// Resolve and activate an instance of <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">Class or interface type to activate</param>
+        /// <returns>
+        /// Instance of a <paramref name="type"/>, 
+        /// or <c>null</c> if the specified type cannot be activated
+        /// </returns>
         public abstract object Resolve(Type type);
 
-        public virtual void DisposeScope()
+        /// <summary>
+        /// Called when current <see cref="JobActivatorScope"/> is about to be disposed.
+        /// Subclasses may override this to perform some cleanup before leaving scope.
+        /// </summary>
+        protected virtual void DisposeScope()
         {
+        }
+
+        /// <summary>
+        /// Throws <seealso cref="ObjectDisposedException"/> if the current scope is already disposed.
+        /// First thing for subclasses to check in their <seealso cref="Resolve(Type)"/> implementations!
+        /// </summary>
+        protected void AssertNotDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(JobActivatorScope));
         }
 
         public void Dispose()
         {
+            if (_disposed) return;
+
+            // immediately mark as disposed, so Dispose() will never be reentered, 
+            // even if mistakenly called from within DisposeScope() override
+            _disposed = true;
+
+            if (_current.Value != this)
+                throw new InvalidOperationException("Messed up JobActivatorScope dispose order");
+
             try
             {
                 DisposeScope();
             }
             finally
             {
-                _current.Value = null;
+                // restore previous scope
+                _current.Value = _parent;
             }
         }
     }

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Common\JobLoadExceptionFacts.cs" />
     <Compile Include="Common\TypeExtensionsFacts.cs" />
     <Compile Include="CronFacts.cs" />
+    <Compile Include="JobActivatorScopeFacts.cs" />
     <Compile Include="LatencyTimeoutAttributeFacts.cs" />
     <Compile Include="GlobalStateHandlersFacts.cs" />
     <Compile Include="JobActivatorFacts.cs" />

--- a/tests/Hangfire.Core.Tests/JobActivatorScopeFacts.cs
+++ b/tests/Hangfire.Core.Tests/JobActivatorScopeFacts.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using Moq;
+using Xunit;
+using Moq.Protected;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hangfire.Core.Tests
+{
+    public class JobActivatorScopeFacts
+    {
+        [Fact]
+        public void JobActivatorScope_Current_SetOnEnter_RestoredOnExit()
+        {
+            var activator = new JobActivator();
+
+            using (var outer = activator.BeginScope(null))
+            {
+                Assert.Same(outer, JobActivatorScope.Current);
+
+                using (var scope = activator.BeginScope(null))
+                {
+                    Assert.Same(scope, JobActivatorScope.Current);
+                }
+
+                Assert.Same(outer, JobActivatorScope.Current);
+            }
+        }
+
+        [Fact]
+        public void JobActivatorScope_DisposeCalledMultipleTimes_DisposedOnce()
+        {
+            int disposeCount = 0;
+            var scope = Mock.Of<JobActivatorScope>();
+            Mock.Get(scope).Protected().Setup("DisposeScope").Callback(() => disposeCount++);
+
+            scope.Dispose();
+            scope.Dispose();
+
+            Assert.Equal(1, disposeCount);
+        }
+
+        [Fact]
+        public void JobActivatorScope_Current_RestoredAfterManualDispose()
+        {
+            var activator = new JobActivator();
+
+            using (var outer = activator.BeginScope(null))
+            {
+                Assert.Same(outer, JobActivatorScope.Current);
+
+                using (var scope = activator.BeginScope(null))
+                {
+                    Assert.Same(scope, JobActivatorScope.Current);
+
+                    scope.Dispose();
+
+                    Assert.Same(outer, JobActivatorScope.Current);
+                }
+
+                Assert.Same(outer, JobActivatorScope.Current);
+            }
+        }
+
+        [Fact]
+        public void JobActivatorScope_ThrowsInvalidOperationException_OnWrongDisposeOrder()
+        {
+            var activator = new JobActivator();
+            
+            using (var outer = activator.BeginScope(null))
+            {
+                using (activator.BeginScope(null))
+                {
+                    Assert.Throws<InvalidOperationException>(() => outer.Dispose());
+                }
+            }
+        }
+        
+        [Fact]
+        public void JobActivatorScope_ThrowsObjectDisposedException_OnResolveAfterDispose()
+        {
+            var activator = new JobActivator();
+
+            using (var scope = activator.BeginScope(null))
+            {
+                scope.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() => scope.Resolve(typeof(DefaultConstructor)));
+            }
+        }
+
+        [Fact]
+        public async Task JobActivatorScope_Current_DoesntChangeBetweenAwaits()
+        {
+            var activator = new JobActivator();
+
+            using (activator.BeginScope(null))
+            {
+                var prev = JobActivatorScope.Current;
+
+                await Task.Yield();
+
+                Assert.Same(prev, JobActivatorScope.Current);
+
+                await Task.Yield();
+
+                Assert.Same(prev, JobActivatorScope.Current);
+            }
+        }
+
+        [Fact]
+        public async Task JobActivatorScope_Current_SameForChildTask()
+        {
+            var activator = new JobActivator();
+
+            using (activator.BeginScope(null))
+            {
+                var prev = JobActivatorScope.Current;
+
+                await Task.Run(() => Assert.Same(prev, JobActivatorScope.Current)).ConfigureAwait(false);
+
+                Assert.Same(prev, JobActivatorScope.Current);
+            }
+        }
+
+        [Fact]
+        public Task JobActivatorScope_Current_BranchesInParallelChildTasks()
+        {
+            var activator = new JobActivator();
+
+            Task[] tasks;
+
+            using (activator.BeginScope(null))
+            {
+                var prev = JobActivatorScope.Current;
+
+                tasks = new[] {
+                    Task.Run(() =>
+                    {
+                        Assert.Same(prev, JobActivatorScope.Current);
+                        
+                        using (var child = activator.BeginScope(null))
+                        {
+                            Assert.Same(child, JobActivatorScope.Current);
+                            Assert.Same(prev, child.ParentScope);
+                        }
+
+                        Assert.Same(prev, JobActivatorScope.Current);
+
+                        Assert.Throws<ObjectDisposedException>(() => prev.Resolve(typeof(DefaultConstructor)));
+                    }),
+                    Task.Run(() => 
+                    {
+                        Assert.Same(prev, JobActivatorScope.Current);
+
+                        using (var child = activator.BeginScope(null))
+                        {
+                            Assert.Same(child, JobActivatorScope.Current);
+                            Assert.Same(prev, child.ParentScope);
+                        }
+
+                        Assert.Same(prev, JobActivatorScope.Current);
+
+                        Assert.Throws<ObjectDisposedException>(() => prev.Resolve(typeof(DefaultConstructor)));
+                    })
+                };
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        private class DefaultConstructor
+        {
+        }
+    }
+}


### PR DESCRIPTION
Here we go. Based on `AsyncLocal<>` and supports nested scopes.

I've looked through all @HangfireIO repos, and haven't find any mentions of `InnerScope`, so it was dropped. Added some unit tests instead :)