### PR TITLE
Fixes #657

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -1,5 +1,5 @@
 // This file is part of Hangfire.
-// Copyright © 2013-2014 Sergey Odinokov.
+// Copyright Â© 2013-2014 Sergey Odinokov.
 // 
 // Hangfire is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as 
@@ -62,7 +62,9 @@ namespace Hangfire.SqlServer
             if (String.IsNullOrEmpty(resource)) throw new ArgumentNullException(nameof(resource));
             if (timeout.TotalSeconds + CommandTimeoutAdditionSeconds > Int32.MaxValue) throw new ArgumentException(
                 $"The timeout specified is too large. Please supply a timeout equal to or less than {Int32.MaxValue - CommandTimeoutAdditionSeconds} seconds", nameof(timeout));
-
+            if (timeout.TotalMilliseconds > Int32.MaxValue) throw new ArgumentException(
+                $"The timeout specified is too large. Please supply a timeout equal to or less than {(int)TimeSpan.FromMilliseconds(Int32.MaxValue).TotalSeconds} seconds", nameof(timeout));
+                
             _storage = storage;
             _resource = resource;
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerDistributedLockFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerDistributedLockFacts.cs
@@ -38,6 +38,19 @@ namespace Hangfire.SqlServer.Tests
                 Assert.Equal("timeout", exception.ParamName);
             });
         }
+        
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenTimeoutTooLargeForLock()
+        {
+            UseConnection(connection =>
+            {
+                var storage = CreateStorage(connection);
+                var tooLargeTimeout = TimeSpan.FromDays(25);
+                var exception = Assert.Throws<ArgumentException>(() => new SqlServerDistributedLock(storage, "hello", tooLargeTimeout));
+
+                Assert.Equal("timeout", exception.ParamName);
+            });
+        }
 
         [Fact, CleanDatabase]
         public void Ctor_ThrowsAnException_WhenResourceIsNullOrEmpty()


### PR DESCRIPTION
Throw argument exception when timeout milliseconds exceeds int.max. Prevents issue with sp_getapplock's @LockTimeout param.
