### PR TITLE
Customize CSS for Dashboard UI

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -14,10 +14,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     @{ var version = GetType().GetTypeInfo().Assembly.GetName().Version; }
-    <link rel="stylesheet" href="@Url.To($"/css{version.Major}{version.Minor}{version.Build}")">
+    <link rel="stylesheet" href="@Url.To($"/css{version.Major}{version.Minor}{version.Build}")"/>
     @if (@ExtraCssUrl != null)
     {
-    <link rel="stylesheet" href="@ExtraCssUrl">
+    <link rel="stylesheet" href="@ExtraCssUrl" />
     }
 </head>
     <body>

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -15,6 +15,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     @{ var version = GetType().GetTypeInfo().Assembly.GetName().Version; }
     <link rel="stylesheet" href="@Url.To($"/css{version.Major}{version.Minor}{version.Build}")">
+    @if (@ExtraCssUrl != null)
+    {
+    <link rel="stylesheet" href="@ExtraCssUrl">
+    }
 </head>
     <body>
         <!-- Wrap all page content here -->
@@ -67,7 +71,7 @@
                 </ul>
             </div>
         </div>
-        
+
         <script>
             (function (hangFire) {
                 hangFire.config = {

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
@@ -111,8 +111,38 @@ WriteLiteral("    <link rel=\"stylesheet\" href=\"");
             
             #line default
             #line hidden
-WriteLiteral(@""">
-</head>
+WriteLiteral("\"/>\r\n");
+
+
+            
+            #line 18 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+     if (@ExtraCssUrl != null)
+    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("    <link rel=\"stylesheet\" href=\"");
+
+
+            
+            #line 20 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                            Write(ExtraCssUrl);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\" />\r\n");
+
+
+            
+            #line 21 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+    }
+
+            
+            #line default
+            #line hidden
+WriteLiteral(@"</head>
     <body>
         <!-- Wrap all page content here -->
         <div id=""wrap"">
@@ -130,7 +160,7 @@ WriteLiteral(@""">
 
 
             
-            #line 32 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 36 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                  Write(Url.Home());
 
             
@@ -141,7 +171,7 @@ WriteLiteral("\">Hangfire Dashboard</a>\r\n                    </div>\r\n       
 
 
             
-            #line 35 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 39 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Html.RenderPartial(new Navigation()));
 
             
@@ -151,7 +181,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 36 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 40 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                          if(@AppPath != null) {
 
             
@@ -162,7 +192,7 @@ WriteLiteral("                            <ul class=\"nav navbar-nav navbar-righ
 
 
             
-            #line 39 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 43 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                         Write(AppPath);
 
             
@@ -173,7 +203,7 @@ WriteLiteral("\">\r\n                                        <span class=\"glyph
 
 
             
-            #line 41 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 45 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                    Write(Strings.LayoutPage_Back);
 
             
@@ -184,7 +214,7 @@ WriteLiteral("\r\n                                    </a>\r\n                  
 
 
             
-            #line 45 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 49 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                         }
 
             
@@ -197,7 +227,7 @@ WriteLiteral("                    </div>\r\n                    <!--/.nav-collap
 
 
             
-            #line 53 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 57 "..\..\Dashboard\Pages\LayoutPage.cshtml"
            Write(RenderBody());
 
             
@@ -215,7 +245,7 @@ WriteLiteral(@"
 
 
             
-            #line 61 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 65 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                                            Write($"{version.Major}.{version.Minor}.{version.Build}");
 
             
@@ -226,7 +256,7 @@ WriteLiteral("\r\n                        </a>\r\n                    </li>\r\n 
 
 
             
-            #line 64 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 68 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Storage);
 
             
@@ -236,7 +266,7 @@ WriteLiteral("</li>\r\n                    <li>");
 
 
             
-            #line 65 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 69 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(String.Format(Strings.LayoutPage_Footer_Time, DateTime.UtcNow));
 
             
@@ -246,19 +276,19 @@ WriteLiteral("</li>\r\n                    <li>");
 
 
             
-            #line 66 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 70 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(String.Format(Strings.LayoutPage_Footer_Generatedms, GenerationTime.Elapsed.TotalMilliseconds.ToString("N")));
 
             
             #line default
             #line hidden
-WriteLiteral("</li>\r\n                </ul>\r\n            </div>\r\n        </div>\r\n        \r\n     " +
-"   <script>\r\n            (function (hangFire) {\r\n                hangFire.config" +
-" = {\r\n                    pollInterval: ");
+WriteLiteral("</li>\r\n                </ul>\r\n            </div>\r\n        </div>\r\n\r\n        <scri" +
+"pt>\r\n            (function (hangFire) {\r\n                hangFire.config = {\r\n  " +
+"                  pollInterval: ");
 
 
             
-            #line 74 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 78 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                              Write(StatsPollingInterval);
 
             
@@ -268,7 +298,7 @@ WriteLiteral(",\r\n                    pollUrl: \'");
 
 
             
-            #line 75 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 79 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                           Write(Url.To("/stats"));
 
             
@@ -278,7 +308,7 @@ WriteLiteral("\',\r\n                    locale: \'");
 
 
             
-            #line 76 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                         Write(CultureInfo.CurrentUICulture);
 
             
@@ -289,7 +319,7 @@ WriteLiteral("\'\r\n                };\r\n            })(window.Hangfire = windo
 
 
             
-            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 84 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                 Write(Url.To($"/js{version.Major}{version.Minor}{version.Build}"));
 
             

--- a/src/Hangfire.Core/Dashboard/RazorPage.cs
+++ b/src/Hangfire.Core/Dashboard/RazorPage.cs
@@ -1,17 +1,17 @@
 ﻿// This file is part of Hangfire.
 // Copyright © 2013-2014 Sergey Odinokov.
-// 
+//
 // Hangfire is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as 
-// published by the Free Software Foundation, either version 3 
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, either version 3
 // of the License, or any later version.
-// 
+//
 // Hangfire is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Lesser General Public License for more details.
-// 
-// You should have received a copy of the GNU Lesser General Public 
+//
+// You should have received a copy of the GNU Lesser General Public
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
@@ -22,7 +22,7 @@ using Hangfire.Storage.Monitoring;
 
 namespace Hangfire.Dashboard
 {
-    public abstract class RazorPage 
+    public abstract class RazorPage
     {
         private Lazy<StatisticsDto> _statisticsLazy;
 
@@ -42,6 +42,7 @@ namespace Hangfire.Dashboard
         public JobStorage Storage { get; internal set; }
         public string AppPath { get; internal set; }
         public int StatsPollingInterval { get; internal set; }
+        public string ExtraCssUrl { get; internal set; }
         public Stopwatch GenerationTime { get; private set; }
 
         public StatisticsDto Statistics
@@ -79,6 +80,7 @@ namespace Hangfire.Dashboard
             Storage = parentPage.Storage;
             AppPath = parentPage.AppPath;
             StatsPollingInterval = parentPage.StatsPollingInterval;
+            ExtraCssUrl = parentPage.ExtraCssUrl;
             Url = parentPage.Url;
 
             GenerationTime = parentPage.GenerationTime;
@@ -93,6 +95,7 @@ namespace Hangfire.Dashboard
             Storage = context.Storage;
             AppPath = context.Options.AppPath;
             StatsPollingInterval = context.Options.StatsPollingInterval;
+            ExtraCssUrl = context.Options.ExtraCssUrl;
             Url = new UrlHelper(context);
 
             _statisticsLazy = new Lazy<StatisticsDto>(() =>
@@ -127,15 +130,15 @@ namespace Hangfire.Dashboard
         private string TransformText(string body)
         {
             _body = body;
-            
+
             Execute();
-            
+
             if (Layout != null)
             {
                 Layout.Assign(this);
                 return Layout.TransformText(_content.ToString());
             }
-            
+
             return _content.ToString();
         }
 

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -1,20 +1,22 @@
 ﻿// This file is part of Hangfire.
 // Copyright © 2013-2014 Sergey Odinokov.
-// 
+//
 // Hangfire is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as 
-// published by the Free Software Foundation, either version 3 
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, either version 3
 // of the License, or any later version.
-// 
+//
 // Hangfire is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Lesser General Public License for more details.
-// 
-// You should have received a copy of the GNU Lesser General Public 
+//
+// You should have received a copy of the GNU Lesser General Public
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
+#if NETFULL
 using System;
+#endif
 using System.Collections.Generic;
 using Hangfire.Dashboard;
 
@@ -45,5 +47,10 @@ namespace Hangfire
         /// The interval the /stats endpoint should be polled with.
         /// </summary>
         public int StatsPollingInterval { get; set; }
+
+        /// <summary>
+        /// Url to a custom stylesheet to also include in the dashboard.
+        /// </summary>
+        public string ExtraCssUrl { get; set; }
     }
 }


### PR DESCRIPTION
Refer to https://discuss.hangfire.io/t/customize-css-for-ui/1141

As described in the above discussion, added `ExtraCssUrl` parameter to `DashboardOptions`, which will be added into the `LayoutPage` as a linked stylesheet if it has been set to a non-null value.