### PR TITLE
Window resize cause errors and uncontrolled growth of event and poll listeners

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -89,7 +89,17 @@
         };
 
         RealtimeGraph.prototype.update = function() {
-            this._graph.update();
+            var graph = this._graph;
+
+            var width = $(graph.element).innerWidth();
+            if (width !== graph.width) {
+                graph.configure({
+                    width: width,
+                    height: 200
+                });
+            }
+
+            graph.update();
         };
 
         return RealtimeGraph;
@@ -134,7 +144,17 @@
         }
 
         HistoryGraph.prototype.update = function() {
-            this._graph.update();
+            var graph = this._graph;
+
+            var width = $(graph.element).innerWidth();
+            if (width !== graph.width) {
+                graph.configure({
+                    width: width,
+                    height: 200
+                });
+            }
+
+            graph.update();
         };
 
         return HistoryGraph;
@@ -204,9 +224,9 @@
         }
 
         Page.prototype._createGraphs = function() {
-            this.realtimeGraph = this._createRealtimeGraph('realtimeGraph');
-            this.historyGraph = this._createHistoryGraph('historyGraph');
-            
+            var realtime = this.realtimeGraph = this._createRealtimeGraph('realtimeGraph');
+            var history = this.historyGraph = this._createHistoryGraph('historyGraph');
+
             var debounce = function (fn, timeout) {
                 var timeoutId = -1;
                 return function() {
@@ -217,12 +237,9 @@
                 };
             };
 
-            var self = this;
             window.onresize = debounce(function () {
-                $('#realtimeGraph').html('');
-                $('#historyGraph').html('');
-
-                self._createGraphs();
+                realtime.update();
+                history.update();
             }, 125);
         };
 

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -131,7 +131,7 @@
             var yAxis = new Rickshaw.Graph.Axis.Y({
                 graph: this._graph,
                 tickFormat: Rickshaw.Fixtures.Number.formatKMBT,
-                tickTreatment: 'glow'
+                ticksTreatment: 'glow'
             });
             
             var hoverDetail = new Rickshaw.Graph.HoverDetail({

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -245,13 +245,12 @@
 
         Page.prototype._createRealtimeGraph = function(elementId) {
             var realtimeElement = document.getElementById(elementId);
-            var succeeded = parseInt($(realtimeElement).data('succeeded'));
-            var failed = parseInt($(realtimeElement).data('failed'));
-
-            var succeededStr = $(realtimeElement).data('succeeded-string');
-            var failedStr = $(realtimeElement).data('failed-string');
-
             if (realtimeElement) {
+                var succeeded = parseInt($(realtimeElement).data('succeeded'));
+                var failed = parseInt($(realtimeElement).data('failed'));
+
+                var succeededStr = $(realtimeElement).data('succeeded-string');
+                var failedStr = $(realtimeElement).data('failed-string');
                 var realtimeGraph = new Hangfire.RealtimeGraph(realtimeElement, succeeded, failed, succeededStr, failedStr);
 
                 this._poller.addListener(function (data) {


### PR DESCRIPTION
## Preamble

In the ongoing project I was integrating Hangfire dashboard into the existing UI using simple iframe approach. To auto-size the iframe I used custom resizing handler and noticed that Hangfire throws a lot of exceptions.

## Steps to reproduce

1. Execute MvcSample and navigate to /hangfire URL (Chrome, Firefox, IE - all are affected).
2. Open browser's developer console.
3. Resize the window.
4. Move mouse over graphs on the dashboard.
5. Each mouse movement event will throw "Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null(…)".
6. The same exception will be also thrown periodically, event without mouse moving.

## Problem

In the window.onresize handler (hangfire.js:221) existing graphs placeholders are emptied and new graphs created. During the creation phase, Rickshaw.Graph.HoverDetail adds listeners for mousemove and mouseout events of the graph placeholder. But it is just emptied, so on resize these listeners aren't removed and still exists. Therefor each resize adds 2 new listeners. Besides this listeners growth the old ones are working with detached nodes those and this causes an error mentioned above.

Another problem is caused by statistics poller. When realtim graph is created, it adds a listener. But when recreated during resize old listener is not removed, but new one is added.

## Solution

1. I have added graph placeholder node recreation, This removes obsolete handlers from it,
2. Instead of calling _createGraphs, I'm calling new Hangfire.Page creation. It calls _createGraphs and also recreate poller. So this removes obsolete poller listeners.
3. Slight fix in _createRealtimeGraph. It has a condition if placeholder exists, but not all code that manipulate with the placeholder is inside of this condition (just compare to _createHistoryGraph that has a proper wrap).