### PR TITLE
Fix bug related to incorrect choosing overloading method

### DIFF
--- a/src/Hangfire.Core/Common/TypeExtensions.cs
+++ b/src/Hangfire.Core/Common/TypeExtensions.cs
@@ -169,7 +169,7 @@ namespace Hangfire.Common
                     continue;
                 }
 
-                return method2ParameterType.IsAssignableFrom(method1ParameterType)
+                return method2ParameterType.GetTypeInfo().IsAssignableFrom(method1ParameterType.GetTypeInfo())
                     ? overloadedMethod1
                     : overloadedMethod2;
             }

--- a/src/Hangfire.Core/Common/TypeExtensions.cs
+++ b/src/Hangfire.Core/Common/TypeExtensions.cs
@@ -96,7 +96,7 @@ namespace Hangfire.Common
 
                 if (!parameterTypesMatched) continue;
 
-                // Return first found method candidate with matching parameters
+                // Return first found method candidate with matching parameters.
                 return methodCandidate.ContainsGenericParameters
                     ? methodCandidate.MakeGenericMethod(genericArguments.ToArray())
                     : methodCandidate;
@@ -104,7 +104,7 @@ namespace Hangfire.Common
 
             return null;
         }
-        
+
         private static string GetFullNameWithoutNamespace(this Type type)
         {
             if (type.IsGenericParameter)

--- a/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
@@ -160,26 +160,12 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
-        public void GetNonOpenMatchingMethod_HandlesMethodParameterTypeIsAssignableFromPassedType()
-        {
-            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "Method",
-                new Type[] { typeof(IChild) });
-
-            Assert.Equal("Method", method.Name);
-            Assert.Equal(typeof(NonGenericClass), method.DeclaringType);
-            Assert.Equal(1, method.GetParameters().Length);
-            Assert.Equal(typeof(IParent), method.GetParameters()[0].ParameterType);
-        }
-
-        [Fact]
-        public void GetNonOpenMatchingMethod_HandlesOveroladingPriority()
+        public void GetNonOpenMatchingMethod_ReturnsNull_WhenMethodParameterTypeIsAssignableFromPassedType()
         {
             var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "Method",
                 new Type[] { typeof(NonGenericClass) });
 
-            Assert.Equal("Method", method.Name);
-            Assert.Equal(1, method.GetParameters().Length);
-            Assert.Equal(typeof(NonGenericClass), method.GetParameters()[0].ParameterType);
+            Assert.Equal(null, method);
         }
     }
 
@@ -201,9 +187,7 @@ namespace Hangfire.Core.Tests.Common
 
     public interface IChild : IParent { }
 
-    public class BaseClass { }
-
-    public class NonGenericClass : BaseClass
+    public class NonGenericClass
     {
         public void Method() { }
 
@@ -212,10 +196,6 @@ namespace Hangfire.Core.Tests.Common
         public void Method(int arg0, int arg1) { }
 
         public void Method(IParent arg) { }
-
-        public void Method(BaseClass arg) { }
-
-        public void Method(NonGenericClass arg) { }
 
         public void Method(object arg) { }
 

--- a/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
@@ -170,8 +170,19 @@ namespace Hangfire.Core.Tests.Common
             Assert.Equal(1, method.GetParameters().Length);
             Assert.Equal(typeof(IParent), method.GetParameters()[0].ParameterType);
         }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_HandlesOveroladingPriority()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "Method",
+                new Type[] { typeof(NonGenericClass) });
+
+            Assert.Equal("Method", method.Name);
+            Assert.Equal(1, method.GetParameters().Length);
+            Assert.Equal(typeof(NonGenericClass), method.GetParameters()[0].ParameterType);
+        }
     }
-    
+
     public class GenericClass<T0>
     {
         public class NestedNonGenericClass
@@ -190,7 +201,9 @@ namespace Hangfire.Core.Tests.Common
 
     public interface IChild : IParent { }
 
-    public class NonGenericClass
+    public class BaseClass { }
+
+    public class NonGenericClass : BaseClass
     {
         public void Method() { }
 
@@ -198,9 +211,13 @@ namespace Hangfire.Core.Tests.Common
 
         public void Method(int arg0, int arg1) { }
 
+        public void Method(IParent arg) { }
+
+        public void Method(BaseClass arg) { }
+
         public void Method(NonGenericClass arg) { }
 
-        public void Method(IParent arg) { }
+        public void Method(object arg) { }
 
         public void GenericMethod<T0, T1, T2>(T0 arg0, T1 arg1, T2 arg2) { }
 


### PR DESCRIPTION
Fixed a bug related to the method `GetNonOpenMatchingMethod` returns incorrect method from existing overloaded methods. So if you have two methods:
```csharp
void Method(object arg) { }
void Method(SomeClass arg) {}
```
And you try enqueue job:
```csharp
var someObject = new SomeClass();
BackgroundJob.Enqueue(() => Method(someObject);
```
You expect invocation of `void Method(SomeClass arg)` method but Hangfire invokes `void Method(object arg)`.