### PR TITLE
Configure AppVeyor and Travis CI build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,5 @@ script:
 notifications:
   slack:
     secure: LZuLPI1Cj9DgNAtFsZ/zk1fWBDS2PTHHIjvtCV3Fa9qNajzna2qR6Ui3sM/FQirvoXp0JHAqNYkFDI216YativqabWXZp6dQgw3u64bdlc1IWxQ4C6XHpp8WVe1wsNi19vfwKVHfvaNXpvNp9OGHXkmoTS74arRtPhpzSXO/IXw=
+    on_success: change
+    on_failure: always

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,3 +96,6 @@ notifications:
   - provider: Slack
     incoming_webhook:
       secure: bqJhjmwwsSMJ/8imZJBOOtwbsNF51p24M8HZlIx1+asIHHUhXWHrP9vkuOPK3OnqNopmloLOOBoaEpYAkClkDuEC61a5Go5NY9KSSB9UMjk=
+    on_build_success: false
+    on_build_failure: true
+    on_build_status_changed: true


### PR DESCRIPTION
Configure AppVeyor and Travis CI build notifications. Notifications will be sent to Slack if build status is failure or build status is changed