### PR TITLE
Validate BackgroundJobServerOptions properties

### DIFF
--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -64,7 +64,7 @@ namespace Hangfire
             set
             {
                 if (value == null) throw new ArgumentNullException(nameof(value));
-                if (value.Length == 0) throw new ArgumentOutOfRangeException("You should specify at least one queue to listen.", nameof(value));
+                if (value.Length == 0) throw new ArgumentException("You should specify at least one queue to listen.", nameof(value));
 
                 _queues = value;
             }
@@ -80,7 +80,7 @@ namespace Hangfire
             get { return _serverTimeout; }
             set
             {
-                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {ServerWatchdogMaxServerTimeout.Hours} hours", nameof(value));
+                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentOutOfRangeException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {ServerWatchdog.MaxServerTimeout.Hours} hours", nameof(value));
 
                 _serverTimeout = value;
 

--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -80,7 +80,7 @@ namespace Hangfire
             get { return _shutdownTimeout; }
             set
             {
-                if (value != Timeout.InfiniteTimeSpan && value < TimeSpan.Zero || value.TotalMilliseconds > Int32.MaxValue)
+                if ((value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan) || value.TotalMilliseconds > Int32.MaxValue)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), $"ShutdownTimeout must be either equal to or less than {Int32.MaxValue} milliseconds and non-negative or infinite");
                 }
@@ -93,9 +93,9 @@ namespace Hangfire
             get { return _schedulePollingInterval; }
             set
             {
-                if (value != Timeout.InfiniteTimeSpan && value < TimeSpan.Zero || value.TotalMilliseconds > Int32.MaxValue)
+                if (value < TimeSpan.Zero || value.TotalMilliseconds > Int32.MaxValue)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), $"SchedulePollingInterval must be either equal to or less than {Int32.MaxValue} milliseconds and non-negative or infinite");
+                    throw new ArgumentOutOfRangeException(nameof(value), $"SchedulePollingInterval must be non-negative and either equal to or less than {Int32.MaxValue} milliseconds");
                 }
 
                 _schedulePollingInterval = value;

--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -27,8 +27,11 @@ namespace Hangfire
         // https://github.com/HangfireIO/Hangfire/issues/246
         private const int MaxDefaultWorkerCount = 20;
 
+        private static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
+
         private int _workerCount;
         private string[] _queues;
+        private TimeSpan _serverTimeout;
 
         public BackgroundJobServerOptions()
         {
@@ -72,8 +75,19 @@ namespace Hangfire
         public TimeSpan ShutdownTimeout { get; set; }
         public TimeSpan SchedulePollingInterval { get; set; }
         public TimeSpan HeartbeatInterval { get; set; }
-        public TimeSpan ServerTimeout { get; set; }
         public TimeSpan ServerCheckInterval { get; set; }
+
+        public TimeSpan ServerTimeout
+        {
+            get { return _serverTimeout; }
+            set
+            {
+                if (value > MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
+
+                _serverTimeout = value;
+
+            }
+        }
 
         [Obsolete("Please use `ServerTimeout` or `ServerCheckInterval` options instead. Will be removed in 2.0.0.")]
         public ServerWatchdogOptions ServerWatchdogOptions { get; set; }

--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -27,8 +27,6 @@ namespace Hangfire
         // https://github.com/HangfireIO/Hangfire/issues/246
         private const int MaxDefaultWorkerCount = 20;
 
-        private static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
-
         private int _workerCount;
         private string[] _queues;
         private TimeSpan _serverTimeout;
@@ -66,7 +64,7 @@ namespace Hangfire
             set
             {
                 if (value == null) throw new ArgumentNullException(nameof(value));
-                if (value.Length == 0) throw new ArgumentException("You should specify at least one queue to listen.", nameof(value));
+                if (value.Length == 0) throw new ArgumentOutOfRangeException("You should specify at least one queue to listen.", nameof(value));
 
                 _queues = value;
             }
@@ -82,7 +80,7 @@ namespace Hangfire
             get { return _serverTimeout; }
             set
             {
-                if (value > MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
+                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {ServerWatchdogMaxServerTimeout.Hours} hours", nameof(value));
 
                 _serverTimeout = value;
 

--- a/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
+++ b/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
@@ -23,13 +23,27 @@ namespace Hangfire.Server
     [Obsolete("Please use `BackgroundJobServerOptions` properties instead. Will be removed in 2.0.0.")]
     public class ServerWatchdogOptions
     {
-        public ServerWatchdogOptions()
+        private static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
+
+        private TimeSpan _serverTimeout;
+
+	    public ServerWatchdogOptions()
         {
             ServerTimeout = ServerWatchdog.DefaultServerTimeout;
             CheckInterval = ServerWatchdog.DefaultCheckInterval;
         }
 
-        public TimeSpan ServerTimeout { get; set; }
+        public TimeSpan ServerTimeout
+        {
+            get { return _serverTimeout; }
+            set
+            {
+                if (value > MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
+
+                _serverTimeout = value; 
+            }
+        }
+
         public TimeSpan CheckInterval { get; set; }
     }
 }

--- a/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
+++ b/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
@@ -36,7 +36,7 @@ namespace Hangfire.Server
             get { return _serverTimeout; }
             set
             {
-                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentOutOfRangeException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
+                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentOutOfRangeException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {ServerWatchdog.MaxServerTimeout.Hours} hours", nameof(value));
 
                 _serverTimeout = value; 
             }

--- a/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
+++ b/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
@@ -23,8 +23,6 @@ namespace Hangfire.Server
     [Obsolete("Please use `BackgroundJobServerOptions` properties instead. Will be removed in 2.0.0.")]
     public class ServerWatchdogOptions
     {
-        private static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
-
         private TimeSpan _serverTimeout;
 
 	    public ServerWatchdogOptions()
@@ -38,7 +36,7 @@ namespace Hangfire.Server
             get { return _serverTimeout; }
             set
             {
-                if (value > MaxServerTimeout) throw new ArgumentException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
+                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentOutOfRangeException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {MaxServerTimeout.Hours} hours", nameof(value));
 
                 _serverTimeout = value; 
             }

--- a/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
+++ b/src/Hangfire.Core/Obsolete/ServerWatchdogOptions.cs
@@ -24,8 +24,9 @@ namespace Hangfire.Server
     public class ServerWatchdogOptions
     {
         private TimeSpan _serverTimeout;
+        private TimeSpan _checkInterval;
 
-	    public ServerWatchdogOptions()
+        public ServerWatchdogOptions()
         {
             ServerTimeout = ServerWatchdog.DefaultServerTimeout;
             CheckInterval = ServerWatchdog.DefaultCheckInterval;
@@ -36,12 +37,27 @@ namespace Hangfire.Server
             get { return _serverTimeout; }
             set
             {
-                if (value > ServerWatchdog.MaxServerTimeout) throw new ArgumentOutOfRangeException($"The specified server timeout is too large. Please supply a server timeout equal to or less than {ServerWatchdog.MaxServerTimeout.Hours} hours", nameof(value));
+                if (value < TimeSpan.Zero || value > ServerWatchdog.MaxServerTimeout)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), $"ServerTimeout must be either non-negative and equal to or less than {ServerWatchdog.MaxServerTimeout.Hours} hours");
+                }
 
-                _serverTimeout = value; 
+                _serverTimeout = value;
             }
         }
 
-        public TimeSpan CheckInterval { get; set; }
+        public TimeSpan CheckInterval
+        {
+            get { return _checkInterval; }
+            set
+            {
+                if (value < TimeSpan.Zero || value > ServerWatchdog.MaxServerCheckInterval)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), $"CheckInterval must be either non-negative and equal to or less than {ServerWatchdog.MaxServerCheckInterval.Hours} hours");
+
+                };
+                _checkInterval = value;
+            }
+        }
     }
 }

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -24,6 +24,8 @@ namespace Hangfire.Server
         public static readonly TimeSpan DefaultCheckInterval = TimeSpan.FromMinutes(5);
         public static readonly TimeSpan DefaultServerTimeout = TimeSpan.FromMinutes(5);
         public static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
+        public static readonly TimeSpan MaxServerCheckInterval = TimeSpan.FromHours(24);
+        public static readonly TimeSpan MaxHeartbeatInterval = TimeSpan.FromHours(24);
 
         private static readonly ILog Logger = LogProvider.For<ServerWatchdog>();
 

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -23,6 +23,7 @@ namespace Hangfire.Server
     {
         public static readonly TimeSpan DefaultCheckInterval = TimeSpan.FromMinutes(5);
         public static readonly TimeSpan DefaultServerTimeout = TimeSpan.FromMinutes(5);
+        public static readonly TimeSpan MaxServerTimeout = TimeSpan.FromHours(24);
 
         private static readonly ILog Logger = LogProvider.For<ServerWatchdog>();
 

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Mocks\ElectStateContextMock.cs" />
     <Compile Include="Mocks\PerformContextMock.cs" />
     <Compile Include="Mocks\StateChangeContextMock.cs" />
+    <Compile Include="Obsolete\ServerWatchdogOptionsFacts.cs" />
     <Compile Include="PreserveCultureAttributeFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueueAttributeFacts.cs" />

--- a/tests/Hangfire.Core.Tests/Obsolete/ServerWatchdogOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Obsolete/ServerWatchdogOptionsFacts.cs
@@ -10,19 +10,78 @@ namespace Hangfire.Core.Tests.Obsolete
         [Fact]
         public void Ctor_InitializeProperties_WithCorrectValues()
         {
-            var options = new ServerWatchdogOptions();
+            var options = CreateOptions();
 
-            Assert.True(options.CheckInterval >= TimeSpan.Zero || options.CheckInterval == Timeout.InfiniteTimeSpan);
-            Assert.True(options.ServerTimeout > TimeSpan.Zero && options.ServerTimeout <= TimeSpan.FromHours(24));
+            Assert.Equal(TimeSpan.FromMinutes(5), options.CheckInterval);
+            Assert.Equal(TimeSpan.FromMinutes(5), options.ServerTimeout);
         }
 
         [Fact]
         public void ServerTimeout_ThrowsAnException_WhenValueIsTooLarge()
         {
-            var options = new ServerWatchdogOptions();
+            var options = CreateOptions();
 
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => options.ServerTimeout = TimeSpan.FromHours(25));
+        }
+
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerTimeout = TimeSpan.FromHours(-5));
+        }
+
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerTimeout = Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void CheckInterval_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.CheckInterval = TimeSpan.FromHours(-5));
+        }
+
+        [Fact]
+        public void CheckInterval_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.CheckInterval = TimeSpan.FromHours(25));
+        }
+
+        [Fact]
+        public void CheckInterval_ThrowsAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.CheckInterval = Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void CheckInterval_DoesNotThrowException_WhenValueIsZero()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.CheckInterval = Timeout.InfiniteTimeSpan);
+        }
+
+        private static ServerWatchdogOptions CreateOptions()
+        {
+            return new ServerWatchdogOptions();
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Obsolete/ServerWatchdogOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Obsolete/ServerWatchdogOptionsFacts.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+using Hangfire.Server;
+using Xunit;
+
+namespace Hangfire.Core.Tests.Obsolete
+{
+    public class ServerWatchdogOptionsFacts
+    {
+        [Fact]
+        public void Ctor_InitializeProperties_WithCorrectValues()
+        {
+            var options = new ServerWatchdogOptions();
+
+            Assert.True(options.CheckInterval >= TimeSpan.Zero || options.CheckInterval == Timeout.InfiniteTimeSpan);
+            Assert.True(options.ServerTimeout > TimeSpan.Zero && options.ServerTimeout <= TimeSpan.FromHours(24));
+        }
+
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = new ServerWatchdogOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerTimeout = TimeSpan.FromHours(25));
+        }
+    }
+}

--- a/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
@@ -59,7 +59,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var options = CreateOptions();
         
-            Assert.Throws<ArgumentException>(
+            Assert.Throws<ArgumentOutOfRangeException>(
                 () => options.ServerTimeout = TimeSpan.FromHours(25));
         }
 

--- a/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
@@ -53,6 +53,15 @@ namespace Hangfire.Core.Tests.Server
                 () => options.Queues = new string[0]);
         }
 
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+        
+            Assert.Throws<ArgumentException>(
+                () => options.ServerTimeout = TimeSpan.FromHours(25));
+        }
+
         private static BackgroundJobServerOptions CreateOptions()
         {
             return new BackgroundJobServerOptions();

--- a/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
@@ -185,13 +185,12 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void SchedulePollingInterval_DoesNotThrowAnException_WhenValueIsInfinite()
+        public void SchedulePollingInterval_ThrowsAnException_WhenValueIsInfinite()
         {
             var options = CreateOptions();
 
-            options.SchedulePollingInterval = Timeout.InfiniteTimeSpan;
-
-            Assert.Equal(Timeout.InfiniteTimeSpan, options.SchedulePollingInterval);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.SchedulePollingInterval = Timeout.InfiniteTimeSpan);
         }
 
         private static BackgroundJobServerOptions CreateOptions()

--- a/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Hangfire.States;
 using Xunit;
 
@@ -13,9 +14,11 @@ namespace Hangfire.Core.Tests.Server
 
             Assert.Equal(Math.Min(Environment.ProcessorCount * 5, 20), options.WorkerCount);
             Assert.Equal(EnqueuedState.DefaultQueue, options.Queues[0]);
-            Assert.True(options.ShutdownTimeout > TimeSpan.Zero);
-            Assert.True(options.SchedulePollingInterval > TimeSpan.Zero);
-            Assert.True(options.ServerTimeout > TimeSpan.Zero && options.ServerTimeout <= TimeSpan.FromHours(24));
+            Assert.Equal(TimeSpan.FromSeconds(15), options.ShutdownTimeout);
+            Assert.Equal(TimeSpan.FromSeconds(15), options.SchedulePollingInterval);
+            Assert.Equal(TimeSpan.FromMinutes(5), options.ServerTimeout);
+            Assert.Equal(TimeSpan.FromMinutes(5), options.ServerCheckInterval);
+            Assert.Equal(TimeSpan.FromSeconds(30), options.HeartbeatInterval);
         }
 
         [Fact]
@@ -61,6 +64,134 @@ namespace Hangfire.Core.Tests.Server
         
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => options.ServerTimeout = TimeSpan.FromHours(25));
+        }
+
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerTimeout = TimeSpan.FromHours(-1));
+        }
+
+        [Fact]
+        public void ServerTimeout_ThrowsAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerTimeout = Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void ServerCheckInterval_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerCheckInterval = TimeSpan.FromHours(25));
+        }
+
+        [Fact]
+        public void ServerCheckInterval_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerCheckInterval = TimeSpan.FromHours(-1));
+        }
+
+        [Fact]
+        public void ServerCheckInterval_ThrowsAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ServerCheckInterval = Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void HeartbeatInterval_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.HeartbeatInterval = TimeSpan.FromHours(25));
+        }
+
+        [Fact]
+        public void HeartbeatInterval_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.HeartbeatInterval = TimeSpan.FromHours(-1));
+        }
+
+        [Fact]
+        public void HeartbeatInterval_ThrowsAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.HeartbeatInterval = Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void ShutdownTimeout_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ShutdownTimeout = TimeSpan.FromMilliseconds((double)Int32.MaxValue+1));
+        }
+
+        [Fact]
+        public void ShutdownTimeout_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.ShutdownTimeout = TimeSpan.FromHours(-1));
+        }
+
+        [Fact]
+        public void ShutdownTimeout_DoesNotThrowAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            options.ShutdownTimeout = Timeout.InfiniteTimeSpan;
+
+            Assert.Equal(Timeout.InfiniteTimeSpan, options.ShutdownTimeout);
+        }
+
+        [Fact]
+        public void SchedulePollingInterval_ThrowsAnException_WhenValueIsTooLarge()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.SchedulePollingInterval = TimeSpan.FromMilliseconds((double)Int32.MaxValue + 1));
+        }
+
+        [Fact]
+        public void SchedulePollingInterval_ThrowsAnException_WhenValueIsNegative()
+        {
+            var options = CreateOptions();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => options.SchedulePollingInterval = TimeSpan.FromHours(-1));
+        }
+
+        [Fact]
+        public void SchedulePollingInterval_DoesNotThrowAnException_WhenValueIsInfinite()
+        {
+            var options = CreateOptions();
+
+            options.SchedulePollingInterval = Timeout.InfiniteTimeSpan;
+
+            Assert.Equal(Timeout.InfiniteTimeSpan, options.SchedulePollingInterval);
         }
 
         private static BackgroundJobServerOptions CreateOptions()

--- a/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/BackgroundJobServerOptionsFacts.cs
@@ -15,6 +15,7 @@ namespace Hangfire.Core.Tests.Server
             Assert.Equal(EnqueuedState.DefaultQueue, options.Queues[0]);
             Assert.True(options.ShutdownTimeout > TimeSpan.Zero);
             Assert.True(options.SchedulePollingInterval > TimeSpan.Zero);
+            Assert.True(options.ServerTimeout > TimeSpan.Zero && options.ServerTimeout <= TimeSpan.FromHours(24));
         }
 
         [Fact]


### PR DESCRIPTION
Validate BackgroundJobServerOptions properties:
* if ServerTimeout is non-negative and less than or equal to 24 hours. If it's not ArgumentOutOfRangeException will be thrown.
* if HeartbeatInterval  is non-negative and less than or equal to 24 hours. If it's not ArgumentOutOfRangeException will be thrown.
* if ServerCheckInterval is non-negative less than or equal to 24 hours. If it's not ArgumentOutOfRangeException will be thrown.
* if SchedulePollingInterval is less than or equal to Int32.MaxValue milliseconds and non-negative or infinite. If it's not ArgumentOutOfRangeException will be thrown.
* if ServerCheckInterva is less than or equal to Int32.MaxValue milliseconds and non-negative or infinite. If it's not ArgumentOutOfRangeException will be thrown.

Fixes #518