### PR TITLE
Split json serializer settings into core settings and arguments settings

### DIFF
--- a/Hangfire.sln.DotSettings
+++ b/Hangfire.sln.DotSettings
@@ -3,5 +3,6 @@
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ERedis_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ESqlServer_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DB/@EntryIndexedValue">DB</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters&gt;&lt;Filter ModuleMask="Hangfire.Core.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;Filter ModuleMask="Hangfire.SqlServer.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;/ExcludeFilters&gt;&lt;/data&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
+++ b/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
@@ -34,7 +34,7 @@ namespace Hangfire.Client
 
         public BackgroundJob Create(CreateContext context)
         {
-            var parameters = context.Parameters.ToDictionary(x => x.Key, x => JobHelper.ToJson(x.Value));
+            var parameters = context.Parameters.ToDictionary(x => x.Key, x => JobHelper.SerializeParameter(x.Value));
 
             var createdAt = DateTime.UtcNow;
             var jobId = context.Connection.CreateExpiredJob(

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -25,17 +25,29 @@ namespace Hangfire.Common
     {
         private static JsonSerializerSettings _coreSerializerSettings;
         private static JsonSerializerSettings _arugumentsSerializerSettings;
+        private static JsonSerializerSettings _parametersSerializerSettings;
 
-        [Obsolete("Please use 'SetArgumentsSerializerSettings' method instead. Will be removed in version 2.0.0.")]
-        public static void SetSerializerSettings(JsonSerializerSettings setting)
+        [Obsolete(@"This method is here for compatibility reasons.
+Please use 'SetArgumentsSerializerSettings', 'SerializeArgument', 'DeserializeArgument' instead 
+to serialize/deserialize arguments.
+Please use 'SetParametersSerializerSettings', 'SerializeParameter', 'DeserializeParameter' instead 
+to serialize/deserialize job parameters.
+Will be removed in version 2.0.0.")]
+        public static void SetSerializerSettings(JsonSerializerSettings settings)
         {
-            _coreSerializerSettings = setting;
-            _arugumentsSerializerSettings = _arugumentsSerializerSettings ?? setting;
+            _coreSerializerSettings = settings;
+            _arugumentsSerializerSettings = settings;
+            _parametersSerializerSettings = settings;
         }
 
-        public static void SetArgumentsSerializerSettings(JsonSerializerSettings setting)
+        public static void SetArgumentsSerializerSettings(JsonSerializerSettings settings)
         {
-            _arugumentsSerializerSettings = setting;
+            _arugumentsSerializerSettings = settings;
+        }
+
+        public static void SetParametersSerializerSettings(JsonSerializerSettings settings)
+        {
+            _parametersSerializerSettings = settings;
         }
 
         public static string ToJson(object value)
@@ -61,19 +73,49 @@ namespace Hangfire.Common
                 : null;
         }
 
-        public static string ArgumentToJson(object value)
+        public static string SerializeArgument(object value)
         {
             return value != null
                ? JsonConvert.SerializeObject(value, _arugumentsSerializerSettings)
                : null;
         }
 
-        public static object ArgumentFromJson(string value, [NotNull] Type type)
+        public static T DeserializeArgument<T>(string value)
+        {
+            return value != null
+                ? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
+                : default(T);
+        }
+
+        public static object DeserializeArgument(string value, [NotNull] Type type)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
 
             return value != null
                 ? JsonConvert.DeserializeObject(value, type, _arugumentsSerializerSettings)
+                : null;
+        }
+
+        public static T DeserializeParameter<T>(string value)
+        {
+            return value != null
+                ? JsonConvert.DeserializeObject<T>(value, _parametersSerializerSettings)
+                : default(T);
+        }
+
+        public static string SerializeParameter(object value)
+        {
+            return value != null
+               ? JsonConvert.SerializeObject(value, _parametersSerializerSettings)
+               : null;
+        }
+
+        public static object DeserializeParameter(string value, [NotNull] Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return value != null
+                ? JsonConvert.DeserializeObject(value, type, _parametersSerializerSettings)
                 : null;
         }
 

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -27,11 +27,9 @@ namespace Hangfire.Common
         private static JsonSerializerSettings _arugumentsSerializerSettings;
         private static JsonSerializerSettings _parametersSerializerSettings;
 
-        [Obsolete(@"This method is here for compatibility reasons.
-Please use 'SetArgumentsSerializerSettings', 'SerializeArgument', 'DeserializeArgument' instead 
-to serialize/deserialize arguments.
-Please use 'SetParametersSerializerSettings', 'SerializeParameter', 'DeserializeParameter' instead 
-to serialize/deserialize job parameters.
+        [Obsolete(@"This method is here for compatibility reasons. 
+Please use 'SetArgumentsSerializerSettings', 'SetParametersSerializerSettings' methods instead.
+It will be impossible to affect 'ToJson', 'FromJson' methods behavior in version 2.0.0.
 Will be removed in version 2.0.0.")]
         public static void SetSerializerSettings(JsonSerializerSettings settings)
         {
@@ -63,36 +61,6 @@ Will be removed in version 2.0.0.")]
         public static object FromJson(string value, [NotNull] Type type)
         {
             return Deserialize(value, type, _coreSerializerSettings);
-        }
-
-        public static string SerializeArgument(object value)
-        {
-            return Serialize(value, _arugumentsSerializerSettings);
-        }
-
-        public static T DeserializeArgument<T>(string value)
-        {
-            return Deserialize<T>(value, _arugumentsSerializerSettings);
-        }
-
-        public static object DeserializeArgument(string value, [NotNull] Type type)
-        {
-            return Deserialize(value, type, _arugumentsSerializerSettings);
-        }
-
-        public static string SerializeParameter(object value)
-        {
-            return Serialize(value, _parametersSerializerSettings);
-        }
-
-        public static object DeserializeParameter(string value, [NotNull] Type type)
-        {
-            return Deserialize(value, type, _parametersSerializerSettings);
-        }
-
-        public static T DeserializeParameter<T>(string value)
-        {
-            return Deserialize<T>(value, _parametersSerializerSettings);
         }
 
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -132,6 +100,26 @@ Will be removed in version 2.0.0.")]
             }
 
             return DeserializeDateTime(value);
+        }
+
+        internal static string SerializeArgument(object value)
+        {
+            return Serialize(value, _arugumentsSerializerSettings);
+        }
+
+        internal static object DeserializeArgument(string value, [NotNull] Type type)
+        {
+            return Deserialize(value, type, _arugumentsSerializerSettings);
+        }
+
+        internal static string SerializeParameter(object value)
+        {
+            return Serialize(value, _parametersSerializerSettings);
+        }
+
+        internal static T DeserializeParameter<T>(string value)
+        {
+            return Deserialize<T>(value, _parametersSerializerSettings);
         }
 
         private static string Serialize(object value, JsonSerializerSettings settings)

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -44,17 +44,13 @@ namespace Hangfire.Common
 		}
 
 		public static string ToJson(object value)
-        {
-            return value != null
-                ? JsonConvert.SerializeObject(value, _coreSerializerSettings)
-                : null;
-        }
+		{
+		    return ToJson(value, _coreSerializerSettings);
+		}
 
 	    public static string ArgumentsToJson(object value)
 	    {
-			return value != null
-			   ? JsonConvert.SerializeObject(value, _arugumentsSerializerSettings)
-			   : null;
+			return ToJson(value, _arugumentsSerializerSettings);
 		}
 
         public static T FromJson<T>(string value)
@@ -117,6 +113,13 @@ namespace Hangfire.Common
             }
 
             return DeserializeDateTime(value);
+        }
+
+        private static string ToJson(object value, JsonSerializerSettings serializerSettings)
+        {
+            return value != null
+                ? JsonConvert.SerializeObject(value, serializerSettings)
+                : null;
         }
     }
 }

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -52,71 +52,47 @@ Will be removed in version 2.0.0.")]
 
         public static string ToJson(object value)
         {
-            return value != null
-                ? JsonConvert.SerializeObject(value, _coreSerializerSettings)
-                : null;
+            return Serialize(value, _coreSerializerSettings);
         }
 
         public static T FromJson<T>(string value)
         {
-            return value != null
-                ? JsonConvert.DeserializeObject<T>(value, _coreSerializerSettings)
-                : default(T);
+            return Deserialize<T>(value, _coreSerializerSettings);
         }
 
         public static object FromJson(string value, [NotNull] Type type)
         {
-            if (type == null) throw new ArgumentNullException(nameof(type));
-
-            return value != null
-                ? JsonConvert.DeserializeObject(value, type, _coreSerializerSettings)
-                : null;
+            return Deserialize(value, type, _coreSerializerSettings);
         }
 
         public static string SerializeArgument(object value)
         {
-            return value != null
-               ? JsonConvert.SerializeObject(value, _arugumentsSerializerSettings)
-               : null;
+            return Serialize(value, _arugumentsSerializerSettings);
         }
 
         public static T DeserializeArgument<T>(string value)
         {
-            return value != null
-                ? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
-                : default(T);
+            return Deserialize<T>(value, _arugumentsSerializerSettings);
         }
 
         public static object DeserializeArgument(string value, [NotNull] Type type)
         {
-            if (type == null) throw new ArgumentNullException(nameof(type));
-
-            return value != null
-                ? JsonConvert.DeserializeObject(value, type, _arugumentsSerializerSettings)
-                : null;
-        }
-
-        public static T DeserializeParameter<T>(string value)
-        {
-            return value != null
-                ? JsonConvert.DeserializeObject<T>(value, _parametersSerializerSettings)
-                : default(T);
+            return Deserialize(value, type, _arugumentsSerializerSettings);
         }
 
         public static string SerializeParameter(object value)
         {
-            return value != null
-               ? JsonConvert.SerializeObject(value, _parametersSerializerSettings)
-               : null;
+            return Serialize(value, _parametersSerializerSettings);
         }
 
         public static object DeserializeParameter(string value, [NotNull] Type type)
         {
-            if (type == null) throw new ArgumentNullException(nameof(type));
+            return Deserialize(value, type, _parametersSerializerSettings);
+        }
 
-            return value != null
-                ? JsonConvert.DeserializeObject(value, type, _parametersSerializerSettings)
-                : null;
+        public static T DeserializeParameter<T>(string value)
+        {
+            return Deserialize<T>(value, _parametersSerializerSettings);
         }
 
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -156,6 +132,29 @@ Will be removed in version 2.0.0.")]
             }
 
             return DeserializeDateTime(value);
+        }
+
+        private static string Serialize(object value, JsonSerializerSettings settings)
+        {
+            return value != null
+               ? JsonConvert.SerializeObject(value, settings)
+               : null;
+        }
+
+        private static object Deserialize(string value, [NotNull] Type type, JsonSerializerSettings settings)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return value != null
+                ? JsonConvert.DeserializeObject(value, type, settings)
+                : null;
+        }
+
+        private static T Deserialize<T>(string value, JsonSerializerSettings settings)
+        {
+            return value != null
+                ? JsonConvert.DeserializeObject<T>(value, settings)
+                : default(T);
         }
     }
 }

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -23,24 +23,44 @@ namespace Hangfire.Common
 {
     public static class JobHelper
     {
-        private static JsonSerializerSettings _serializerSettings;
+        private static JsonSerializerSettings _coreSerializerSettings;
+	    private static JsonSerializerSettings _arugumentsSerializerSettings;
 
-        public static void SetSerializerSettings(JsonSerializerSettings setting)
+		internal static void SetCoreSerializerSettings(JsonSerializerSettings setting)
+		{
+			_coreSerializerSettings = setting;
+		}
+
+		[Obsolete("Please use 'SetCoreSerializerSettings' method instead. Will be removed in version 2.0.0.")]
+		public static void SetSerializerSettings(JsonSerializerSettings setting)
         {
-            _serializerSettings = setting;
+            _coreSerializerSettings = setting;
+	        _arugumentsSerializerSettings = _arugumentsSerializerSettings ?? setting;
         }
 
-        public static string ToJson(object value)
+		public static void SetArgumentsSerializerSettings(JsonSerializerSettings setting)
+		{
+			_arugumentsSerializerSettings = setting;
+		}
+
+		public static string ToJson(object value)
         {
             return value != null
-                ? JsonConvert.SerializeObject(value, _serializerSettings)
+                ? JsonConvert.SerializeObject(value, _coreSerializerSettings)
                 : null;
         }
+
+	    public static string ArgumentsToJson(object value)
+	    {
+			return value != null
+			   ? JsonConvert.SerializeObject(value, _arugumentsSerializerSettings)
+			   : null;
+		}
 
         public static T FromJson<T>(string value)
         {
             return value != null
-                ? JsonConvert.DeserializeObject<T>(value, _serializerSettings)
+                ? JsonConvert.DeserializeObject<T>(value, _coreSerializerSettings)
                 : default(T);
         }
 
@@ -49,11 +69,18 @@ namespace Hangfire.Common
             if (type == null) throw new ArgumentNullException(nameof(type));
 
             return value != null
-                ? JsonConvert.DeserializeObject(value, type, _serializerSettings)
+                ? JsonConvert.DeserializeObject(value, type, _coreSerializerSettings)
                 : null;
         }
 
-        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+		public static T ArgumentsFromJson<T>(string value)
+		{
+			return value != null
+				? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
+				: default(T);
+		}
+
+		private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public static long ToTimestamp(DateTime value)
         {

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -26,11 +26,6 @@ namespace Hangfire.Common
         private static JsonSerializerSettings _coreSerializerSettings;
         private static JsonSerializerSettings _arugumentsSerializerSettings;
 
-        internal static void SetCoreSerializerSettings(JsonSerializerSettings setting)
-        {
-            _coreSerializerSettings = setting;
-        }
-
         [Obsolete("Please use 'SetArgumentsSerializerSettings' method instead. Will be removed in version 2.0.0.")]
         public static void SetSerializerSettings(JsonSerializerSettings setting)
         {

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -31,7 +31,7 @@ namespace Hangfire.Common
             _coreSerializerSettings = setting;
         }
 
-        [Obsolete("Please use 'SetCoreSerializerSettings' method instead. Will be removed in version 2.0.0.")]
+        [Obsolete("Please use 'SetArgumentsSerializerSettings' method instead. Will be removed in version 2.0.0.")]
         public static void SetSerializerSettings(JsonSerializerSettings setting)
         {
             _coreSerializerSettings = setting;
@@ -45,12 +45,9 @@ namespace Hangfire.Common
 
         public static string ToJson(object value)
         {
-            return ToJson(value, _coreSerializerSettings);
-        }
-
-        public static string ArgumentsToJson(object value)
-        {
-            return ToJson(value, _arugumentsSerializerSettings);
+            return value != null
+                ? JsonConvert.SerializeObject(value, _coreSerializerSettings)
+                : null;
         }
 
         public static T FromJson<T>(string value)
@@ -69,11 +66,20 @@ namespace Hangfire.Common
                 : null;
         }
 
-        public static T ArgumentsFromJson<T>(string value)
+        public static string ArgumentToJson(object value)
         {
             return value != null
-                ? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
-                : default(T);
+               ? JsonConvert.SerializeObject(value, _arugumentsSerializerSettings)
+               : null;
+        }
+
+        public static object ArgumentFromJson(string value, [NotNull] Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return value != null
+                ? JsonConvert.DeserializeObject(value, type, _arugumentsSerializerSettings)
+                : null;
         }
 
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -113,13 +119,6 @@ namespace Hangfire.Common
             }
 
             return DeserializeDateTime(value);
-        }
-
-        private static string ToJson(object value, JsonSerializerSettings serializerSettings)
-        {
-            return value != null
-                ? JsonConvert.SerializeObject(value, serializerSettings)
-                : null;
         }
     }
 }

--- a/src/Hangfire.Core/Common/JobHelper.cs
+++ b/src/Hangfire.Core/Common/JobHelper.cs
@@ -24,34 +24,34 @@ namespace Hangfire.Common
     public static class JobHelper
     {
         private static JsonSerializerSettings _coreSerializerSettings;
-	    private static JsonSerializerSettings _arugumentsSerializerSettings;
+        private static JsonSerializerSettings _arugumentsSerializerSettings;
 
-		internal static void SetCoreSerializerSettings(JsonSerializerSettings setting)
-		{
-			_coreSerializerSettings = setting;
-		}
-
-		[Obsolete("Please use 'SetCoreSerializerSettings' method instead. Will be removed in version 2.0.0.")]
-		public static void SetSerializerSettings(JsonSerializerSettings setting)
+        internal static void SetCoreSerializerSettings(JsonSerializerSettings setting)
         {
             _coreSerializerSettings = setting;
-	        _arugumentsSerializerSettings = _arugumentsSerializerSettings ?? setting;
         }
 
-		public static void SetArgumentsSerializerSettings(JsonSerializerSettings setting)
-		{
-			_arugumentsSerializerSettings = setting;
-		}
+        [Obsolete("Please use 'SetCoreSerializerSettings' method instead. Will be removed in version 2.0.0.")]
+        public static void SetSerializerSettings(JsonSerializerSettings setting)
+        {
+            _coreSerializerSettings = setting;
+            _arugumentsSerializerSettings = _arugumentsSerializerSettings ?? setting;
+        }
 
-		public static string ToJson(object value)
-		{
-		    return ToJson(value, _coreSerializerSettings);
-		}
+        public static void SetArgumentsSerializerSettings(JsonSerializerSettings setting)
+        {
+            _arugumentsSerializerSettings = setting;
+        }
 
-	    public static string ArgumentsToJson(object value)
-	    {
-			return ToJson(value, _arugumentsSerializerSettings);
-		}
+        public static string ToJson(object value)
+        {
+            return ToJson(value, _coreSerializerSettings);
+        }
+
+        public static string ArgumentsToJson(object value)
+        {
+            return ToJson(value, _arugumentsSerializerSettings);
+        }
 
         public static T FromJson<T>(string value)
         {
@@ -69,19 +69,19 @@ namespace Hangfire.Common
                 : null;
         }
 
-		public static T ArgumentsFromJson<T>(string value)
-		{
-			return value != null
-				? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
-				: default(T);
-		}
+        public static T ArgumentsFromJson<T>(string value)
+        {
+            return value != null
+                ? JsonConvert.DeserializeObject<T>(value, _arugumentsSerializerSettings)
+                : default(T);
+        }
 
-		private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public static long ToTimestamp(DateTime value)
         {
             TimeSpan elapsedTime = value - Epoch;
-            return (long)elapsedTime.TotalSeconds;
+            return (long) elapsedTime.TotalSeconds;
         }
 
         public static DateTime FromTimestamp(long value)

--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -107,7 +107,7 @@ namespace Hangfire.Dashboard
 
                     try
                     {
-                        argumentValue = JobHelper.ArgumentFromJson(argument, parameter.ParameterType);
+                        argumentValue = JobHelper.DeserializeArgument(argument, parameter.ParameterType);
                     }
                     catch (Exception)
                     {

--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -107,7 +107,7 @@ namespace Hangfire.Dashboard
 
                     try
                     {
-                        argumentValue = JobHelper.FromJson(argument, parameter.ParameterType);
+                        argumentValue = JobHelper.ArgumentFromJson(argument, parameter.ParameterType);
                     }
                     catch (Exception)
                     {

--- a/src/Hangfire.Core/JobActivatorContext.cs
+++ b/src/Hangfire.Core/JobActivatorContext.cs
@@ -50,7 +50,7 @@ namespace Hangfire
         {
             if (String.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
 
-            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.ToJson(value));
+            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.SerializeParameter(value));
         }
 
         public T GetJobParameter<T>(string name)
@@ -59,7 +59,7 @@ namespace Hangfire
 
             try
             {
-                return JobHelper.FromJson<T>(Connection.GetJobParameter(BackgroundJob.Id, name));
+                return JobHelper.DeserializeParameter<T>(Connection.GetJobParameter(BackgroundJob.Id, name));
             }
             catch (Exception ex)
             {

--- a/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
+++ b/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Hangfire.Annotations;
 using Hangfire.Server;
 using Hangfire.Storage;
@@ -107,7 +105,7 @@ namespace Hangfire.Common
                         try
                         {
                             value = argument != null
-                                ? JobHelper.FromJson(argument, parameter.ParameterType)
+                                ? JobHelper.ArgumentFromJson(argument, parameter.ParameterType)
                                 : null;
                         }
                         catch (Exception)

--- a/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
+++ b/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
@@ -105,7 +105,7 @@ namespace Hangfire.Common
                         try
                         {
                             value = argument != null
-                                ? JobHelper.ArgumentFromJson(argument, parameter.ParameterType)
+                                ? JobHelper.DeserializeArgument(argument, parameter.ParameterType)
                                 : null;
                         }
                         catch (Exception)

--- a/src/Hangfire.Core/Server/PerformContext.cs
+++ b/src/Hangfire.Core/Server/PerformContext.cs
@@ -80,7 +80,7 @@ namespace Hangfire.Server
         {
             if (String.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
 
-            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.ToJson(value));
+            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.SerializeParameter(value));
         }
 
         public T GetJobParameter<T>(string name)
@@ -89,7 +89,7 @@ namespace Hangfire.Server
 
             try
             {
-                return JobHelper.FromJson<T>(Connection.GetJobParameter(BackgroundJob.Id, name));
+                return JobHelper.DeserializeParameter<T>(Connection.GetJobParameter(BackgroundJob.Id, name));
             }
             catch (Exception ex)
             {

--- a/src/Hangfire.Core/States/ElectStateContext.cs
+++ b/src/Hangfire.Core/States/ElectStateContext.cs
@@ -81,12 +81,12 @@ namespace Hangfire.States
 
         public void SetJobParameter<T>(string name, T value)
         {
-            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.ToJson(value));
+            Connection.SetJobParameter(BackgroundJob.Id, name, JobHelper.SerializeParameter(value));
         }
 
         public T GetJobParameter<T>(string name)
         {
-            return JobHelper.FromJson<T>(Connection.GetJobParameter(
+            return JobHelper.DeserializeParameter<T>(Connection.GetJobParameter(
                 BackgroundJob.Id, name));
         }
     }

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -99,7 +99,7 @@ namespace Hangfire.Storage
                     }
                     else
                     {
-                        value = JobHelper.ToJson(argument);
+                        value = JobHelper.ArgumentsToJson(argument);
                     }
                 }
                 else

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -99,7 +99,7 @@ namespace Hangfire.Storage
                     }
                     else
                     {
-                        value = JobHelper.ArgumentsToJson(argument);
+                        value = JobHelper.ArgumentToJson(argument);
                     }
                 }
                 else
@@ -152,7 +152,7 @@ namespace Hangfire.Storage
             try
             {
                 value = argument != null
-                    ? JobHelper.FromJson(argument, type)
+                    ? JobHelper.ArgumentFromJson(argument, type)
                     : null;
             }
             catch (Exception

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -99,7 +99,7 @@ namespace Hangfire.Storage
                     }
                     else
                     {
-                        value = JobHelper.ArgumentToJson(argument);
+                        value = JobHelper.SerializeArgument(argument);
                     }
                 }
                 else
@@ -152,7 +152,7 @@ namespace Hangfire.Storage
             try
             {
                 value = argument != null
-                    ? JobHelper.ArgumentFromJson(argument, type)
+                    ? JobHelper.DeserializeArgument(argument, type)
                     : null;
             }
             catch (Exception

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -151,10 +151,40 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
-        public void ForArgumnetsSerializeUseDefaultConfigurationOfJsonNet()
+        public void ArgumentsToJson_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsNotDefined()
         {
             var result = JobHelper.ArgumentsToJson(new ClassA("B"));
             Assert.Equal(@"{""PropertyA"":""B""}", result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void ArgumentsToJson_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
+        {
+            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                TypeNameHandling = TypeNameHandling.All
+            });
+
+            var result = JobHelper.ArgumentsToJson(new ClassA("A"));
+            Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""propertyA"":""A""}", result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void ArgumentsToJson_HandlesCoreSerizlizerSettingsDoNotOverwriteArgumentsSerializerSettings()
+        {
+            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All
+            });
+
+            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            });
+
+            var result = JobHelper.ArgumentsToJson(new ClassA("A"));
+            Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", result);
         }
 
         [Fact, CleanJsonSerializersSettings]
@@ -167,15 +197,6 @@ namespace Hangfire.Core.Tests.Common
 
             var result = JobHelper.ToJson(new ClassA("A"));
             Assert.Equal(@"{""propertyA"":""A""}", result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ArgumentsToJson_ReturnCorrectValue_WhenArgumentsSerializerSettingsWasDefined()
-        {
-                JobHelper.SetSerializerSettings(new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
-
-                var result = JobHelper.ToJson(new ClassA("A"));
-                Assert.Equal(@"{""propertyA"":""A""}", result);
         }
 
         [Fact, CleanJsonSerializersSettings]

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -130,28 +130,28 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
-        public void ArgumentToJson_ReturnsNull_WhenValueIsNull()
+        public void SerializeArgument_ReturnsNull_WhenValueIsNull()
         {
-            var result = JobHelper.ArgumentToJson(null);
+            var result = JobHelper.SerializeArgument(null);
             Assert.Null(result);
         }
 
         [Fact]
-        public void ArgumentToJson_ReturnCorrectResult_WhenValueIsString()
+        public void SerializeArgument_ReturnCorrectResult_WhenValueIsString()
         {
-            var result = JobHelper.ArgumentToJson("Simple string");
+            var result = JobHelper.SerializeArgument("Simple string");
             Assert.Equal("\"Simple string\"", result);
         }
 
         [Fact]
-        public void ArgumentToJson_ReturnsCorrectValue_WhenValueIsCustomObject()
+        public void SerializeArgument_ReturnsCorrectValue_WhenValueIsCustomObject()
         {
-            var result = JobHelper.ArgumentToJson(new ClassA("B"));
+            var result = JobHelper.SerializeArgument(new ClassA("B"));
             Assert.Equal(@"{""PropertyA"":""B""}", result);
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void ArgumentToJson_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
+        public void SerializeArgument_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
         {
             JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
             {
@@ -159,42 +159,42 @@ namespace Hangfire.Core.Tests.Common
                 TypeNameHandling = TypeNameHandling.All
             });
 
-            var result = JobHelper.ArgumentToJson(new ClassA("A"));
+            var result = JobHelper.SerializeArgument(new ClassA("A"));
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""propertyA"":""A""}", result);
         }
 
         [Fact]
-        public void ArgumentFromJson_ThrowsAnException_WhenTypeIsNull()
+        public void DeserializeArgument_ThrowsAnException_WhenTypeIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => JobHelper.ArgumentFromJson("1", null));
+            Assert.Throws<ArgumentNullException>(() => JobHelper.DeserializeArgument("1", null));
         }
 
         [Fact]
-        public void ArgumentFromJson_ReturnsCorrectValue_WhenValueIsString()
+        public void DeserializeArgument_ReturnsCorrectValue_WhenValueIsString()
         {
-            var result = (string)JobHelper.ArgumentFromJson("\"hello\"", typeof(string));
+            var result = (string)JobHelper.DeserializeArgument("\"hello\"", typeof(string));
             Assert.Equal("hello", result);
         }
 
         [Fact]
-        public void ArgumentFromJson_ReturnsNull_WhenValueIsNull()
+        public void DeserializeArgument_ReturnsNull_WhenValueIsNull()
         {
-            var result = (string)JobHelper.ArgumentFromJson(null, typeof(string));
+            var result = (string)JobHelper.DeserializeArgument(null, typeof(string));
             Assert.Null(result);
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void ArgumentFromJson_RetrunsObject_WhenTypeIsCustomClass()
+        public void DeserializeArgument_RetrunsObject_WhenTypeIsCustomClass()
         {
             var argumentJson = @"{""PropertyA"":""A""}";
 
-            var argumentValue = JobHelper.ArgumentFromJson(argumentJson, typeof(ClassA)) as ClassA;
+            var argumentValue = JobHelper.DeserializeArgument(argumentJson, typeof(ClassA)) as ClassA;
             Assert.NotNull(argumentValue);
             Assert.Equal("A", argumentValue.PropertyA);
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void ArgumentFromJson_ReturnsObject_WhenTypeIsInterface()
+        public void DeserializeArgument_ReturnsObject_WhenTypeIsInterface()
         {
             JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
             {
@@ -203,13 +203,170 @@ namespace Hangfire.Core.Tests.Common
 
             var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
 
-            var argumentValue = JobHelper.ArgumentFromJson(argumentJson, typeof(IClass)) as ClassA;
+            var argumentValue = JobHelper.DeserializeArgument(argumentJson, typeof(IClass)) as ClassA;
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact]
+        public void DeserializeArgumentGeneric_ReturnsCorrectValue_WhenValueIsString()
+        {
+            var result = JobHelper.DeserializeArgument<string>("\"Hi!\"");
+            Assert.Equal("Hi!", result);
+        }
+
+        [Fact]
+        public void DeserializeArgumentGeneric_ReturnsNull_WhenValueIsNull()
+        {
+            var result = JobHelper.DeserializeArgument<object>(null);
+            Assert.Null(result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void DeserializeArgumentGeneric_RetrunsObject_WhenGenericArgumentIsCustomClass()
+        {
+            var argumentJson = @"{""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeArgument<ClassA>(argumentJson);
             Assert.NotNull(argumentValue);
             Assert.Equal("A", argumentValue.PropertyA);
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void SetSerializerSettings_SetsBothArgumentAndCoreSerializerSettings()
+        public void DeserializeArgumentGeneric_ReturnsObject_WhenGenericArgumentIsInterface()
+        {
+            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Objects
+            });
+
+            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeArgument<IClass>(argumentJson) as ClassA;
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact]
+        public void SerializeParameter_ReturnsNull_WhenValueIsNull()
+        {
+            var result = JobHelper.SerializeParameter(null);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void SerializeParameter_ReturnCorrectResult_WhenValueIsString()
+        {
+            var result = JobHelper.SerializeParameter("Simple string");
+            Assert.Equal("\"Simple string\"", result);
+        }
+
+        [Fact]
+        public void SerializeParameter_ReturnsCorrectValue_WhenValueIsCustomObject()
+        {
+            var result = JobHelper.SerializeParameter(new ClassA("B"));
+            Assert.Equal(@"{""PropertyA"":""B""}", result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void SSerializeParameter_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
+        {
+            JobHelper.SetParametersSerializerSettings(new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                TypeNameHandling = TypeNameHandling.All
+            });
+
+            var result = JobHelper.SerializeParameter(new ClassA("A"));
+            Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""propertyA"":""A""}", result);
+        }
+
+        [Fact]
+        public void DeserializeParameter_ThrowsAnException_WhenTypeIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => JobHelper.DeserializeParameter("1", null));
+        }
+
+        [Fact]
+        public void DeserializeParameter_ReturnsCorrectValue_WhenValueIsString()
+        {
+            var result = (string)JobHelper.DeserializeParameter("\"hello\"", typeof(string));
+            Assert.Equal("hello", result);
+        }
+
+        [Fact]
+        public void DeserializeParameter_ReturnsNull_WhenValueIsNull()
+        {
+            var result = (string)JobHelper.DeserializeParameter(null, typeof(string));
+            Assert.Null(result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void DeserializeParameter_RetrunsObject_WhenTypeIsCustomClass()
+        {
+            var argumentJson = @"{""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeParameter(argumentJson, typeof(ClassA)) as ClassA;
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void DeserializeParameter_ReturnsObject_WhenTypeIsInterface()
+        {
+            JobHelper.SetParametersSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Objects
+            });
+
+            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeParameter(argumentJson, typeof(IClass)) as ClassA;
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact]
+        public void DeserializeParameterGeneric_ReturnsCorrectValue_WhenValueIsString()
+        {
+            var result = JobHelper.DeserializeParameter<string>("\"Hi!\"");
+            Assert.Equal("Hi!", result);
+        }
+
+        [Fact]
+        public void DeserializeParameterGeneric_ReturnsNull_WhenValueIsNull()
+        {
+            var result = JobHelper.DeserializeArgument<object>(null);
+            Assert.Null(result);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void DeserializeParameterGeneric_RetrunsObject_WhenGenericArgumentIsCustomClass()
+        {
+            var argumentJson = @"{""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeArgument<ClassA>(argumentJson);
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void DeserializeParameter_ReturnsObject_WhenGenericArgumentIsInterface()
+        {
+            JobHelper.SetParametersSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Objects
+            });
+
+            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
+
+            var argumentValue = JobHelper.DeserializeParameter<IClass>(argumentJson) as ClassA;
+            Assert.NotNull(argumentValue);
+            Assert.Equal("A", argumentValue.PropertyA);
+        }
+
+        [Fact, CleanJsonSerializersSettings]
+        public void SetSerializerSettings_SetsArgumentAndParameterAndCoreSerializerSettings()
         {
 #pragma warning disable 618
             JobHelper.SetSerializerSettings(new JsonSerializerSettings
@@ -219,9 +376,11 @@ namespace Hangfire.Core.Tests.Common
             });
 
             var coreSerializerResult = JobHelper.ToJson(new ClassA("A"));
-            var argumentsSerializerResult = JobHelper.ArgumentToJson(new ClassA("A"));
+            var argumentsSerializerResult = JobHelper.SerializeArgument(new ClassA("A"));
+            var parametersSerializerResult = JobHelper.SerializeParameter(new ClassA("A"));
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", coreSerializerResult);
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", argumentsSerializerResult);
+            Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", parametersSerializerResult);
         }
 
         private interface IClass

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-// ReSharper disable once RedundantUsingDirective
 using System.Reflection;
 using System.Runtime.Serialization.Formatters;
 using Hangfire.Annotations;
@@ -164,42 +163,6 @@ namespace Hangfire.Core.Tests.Common
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""propertyA"":""A""}", result);
         }
 
-        [Fact, CleanJsonSerializersSettings]
-        public void ArgumentToJson_HandlesCoreSerizlizerSettingsDoNotOverwriteArgumentsSerializerSettings()
-        {
-            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All
-            });
-
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                TypeNameHandling = TypeNameHandling.None
-            });
-
-            var result = JobHelper.ArgumentToJson(new ClassA("A"));
-            Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ArgumentToJson_HandlesArgumentsSerizlizerSettingsDoNotOverwriteCoreSerializerSettings()
-        {
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.None
-            });
-
-            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                TypeNameHandling = TypeNameHandling.All
-            });
-
-            var result = JobHelper.ToJson(new ClassA("A"));
-            Assert.Equal(@"{""PropertyA"":""A""}", result);
-        }
-
         [Fact]
         public void ArgumentFromJson_ThrowsAnException_WhenTypeIsNull()
         {
@@ -223,7 +186,7 @@ namespace Hangfire.Core.Tests.Common
         [Fact, CleanJsonSerializersSettings]
         public void ArgumentFromJson_RetrunsObject_WhenTypeIsCustomClass()
         {
-            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
+            var argumentJson = @"{""PropertyA"":""A""}";
 
             var argumentValue = JobHelper.ArgumentFromJson(argumentJson, typeof(ClassA)) as ClassA;
             Assert.NotNull(argumentValue);
@@ -231,7 +194,7 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void ArgumentFromJson_RetrunsObject_WhenTypeIsInterface()
+        public void ArgumentFromJson_ReturnsObject_WhenTypeIsInterface()
         {
             JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
             {
@@ -243,70 +206,6 @@ namespace Hangfire.Core.Tests.Common
             var argumentValue = JobHelper.ArgumentFromJson(argumentJson, typeof(IClass)) as ClassA;
             Assert.NotNull(argumentValue);
             Assert.Equal("A", argumentValue.PropertyA);
-        }
-
-        [Fact]
-        public void ForSerializeUseDefaultConfigurationOfJsonNet()
-        {
-            var result = JobHelper.ToJson(new ClassA("A"));
-            Assert.Equal(@"{""PropertyA"":""A""}", result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ForSerializeCanUseCustomConfigurationOfJsonNet()
-        {
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
-            });
-
-            var result = JobHelper.ToJson(new ClassA("A"));
-            Assert.Equal(@"{""propertyA"":""A""}", result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ForDeserializeCanUseCustomConfigurationOfJsonNet()
-        {
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Objects
-            });
-
-            var result = (ClassA)JobHelper.FromJson<IClass>(@"{ ""$type"": ""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"", ""propertyA"":""A"" }");
-            Assert.Equal("A", result.PropertyA);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ForDeserializeCanUseCustomConfigurationOfJsonNetWithInvocationData()
-        {
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.All,
-                TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple
-            });
-
-            var method = typeof(BackgroundJob).GetMethod("DoWork");
-            var args = new object[] { "123", "Test" };
-            var job = new Job(typeof(BackgroundJob), method, args);
-
-            var invocationData = InvocationData.Serialize(job);
-            var deserializedJob = invocationData.Deserialize();
-
-            Assert.Equal(typeof(BackgroundJob), deserializedJob.Type);
-            Assert.Equal(method, deserializedJob.Method);
-            Assert.Equal(args, deserializedJob.Args);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void ForDeserializeWithGenericMethodCanUseCustomConfigurationOfJsonNet()
-        {
-            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Objects
-            });
-
-            var result = (ClassA)JobHelper.FromJson(@"{ ""$type"": ""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"", ""propertyA"":""A"" }", typeof(IClass));
-            Assert.Equal("A", result.PropertyA);
         }
 
         [Fact, CleanJsonSerializersSettings]

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+// ReSharper disable once RedundantUsingDirective
+using System.Reflection;
 using System.Runtime.Serialization.Formatters;
 using Hangfire.Annotations;
 using Hangfire.Common;

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -269,7 +269,7 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact, CleanJsonSerializersSettings]
-        public void SSerializeParameter_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
+        public void SerializeParameter_ReturnCorrectValue_WhenArgumentsSerializerSettingsIsDefined()
         {
             JobHelper.SetParametersSerializerSettings(new JsonSerializerSettings
             {
@@ -336,7 +336,7 @@ namespace Hangfire.Core.Tests.Common
         [Fact]
         public void DeserializeParameterGeneric_ReturnsNull_WhenValueIsNull()
         {
-            var result = JobHelper.DeserializeArgument<object>(null);
+            var result = JobHelper.DeserializeParameter<object>(null);
             Assert.Null(result);
         }
 
@@ -345,7 +345,7 @@ namespace Hangfire.Core.Tests.Common
         {
             var argumentJson = @"{""PropertyA"":""A""}";
 
-            var argumentValue = JobHelper.DeserializeArgument<ClassA>(argumentJson);
+            var argumentValue = JobHelper.DeserializeParameter<ClassA>(argumentJson);
             Assert.NotNull(argumentValue);
             Assert.Equal("A", argumentValue.PropertyA);
         }

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -209,45 +209,6 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
-        public void DeserializeArgumentGeneric_ReturnsCorrectValue_WhenValueIsString()
-        {
-            var result = JobHelper.DeserializeArgument<string>("\"Hi!\"");
-            Assert.Equal("Hi!", result);
-        }
-
-        [Fact]
-        public void DeserializeArgumentGeneric_ReturnsNull_WhenValueIsNull()
-        {
-            var result = JobHelper.DeserializeArgument<object>(null);
-            Assert.Null(result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void DeserializeArgumentGeneric_RetrunsObject_WhenGenericArgumentIsCustomClass()
-        {
-            var argumentJson = @"{""PropertyA"":""A""}";
-
-            var argumentValue = JobHelper.DeserializeArgument<ClassA>(argumentJson);
-            Assert.NotNull(argumentValue);
-            Assert.Equal("A", argumentValue.PropertyA);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void DeserializeArgumentGeneric_ReturnsObject_WhenGenericArgumentIsInterface()
-        {
-            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Objects
-            });
-
-            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
-
-            var argumentValue = JobHelper.DeserializeArgument<IClass>(argumentJson) as ClassA;
-            Assert.NotNull(argumentValue);
-            Assert.Equal("A", argumentValue.PropertyA);
-        }
-
-        [Fact]
         public void SerializeParameter_ReturnsNull_WhenValueIsNull()
         {
             var result = JobHelper.SerializeParameter(null);
@@ -279,51 +240,6 @@ namespace Hangfire.Core.Tests.Common
 
             var result = JobHelper.SerializeParameter(new ClassA("A"));
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""propertyA"":""A""}", result);
-        }
-
-        [Fact]
-        public void DeserializeParameter_ThrowsAnException_WhenTypeIsNull()
-        {
-            Assert.Throws<ArgumentNullException>(() => JobHelper.DeserializeParameter("1", null));
-        }
-
-        [Fact]
-        public void DeserializeParameter_ReturnsCorrectValue_WhenValueIsString()
-        {
-            var result = (string)JobHelper.DeserializeParameter("\"hello\"", typeof(string));
-            Assert.Equal("hello", result);
-        }
-
-        [Fact]
-        public void DeserializeParameter_ReturnsNull_WhenValueIsNull()
-        {
-            var result = (string)JobHelper.DeserializeParameter(null, typeof(string));
-            Assert.Null(result);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void DeserializeParameter_RetrunsObject_WhenTypeIsCustomClass()
-        {
-            var argumentJson = @"{""PropertyA"":""A""}";
-
-            var argumentValue = JobHelper.DeserializeParameter(argumentJson, typeof(ClassA)) as ClassA;
-            Assert.NotNull(argumentValue);
-            Assert.Equal("A", argumentValue.PropertyA);
-        }
-
-        [Fact, CleanJsonSerializersSettings]
-        public void DeserializeParameter_ReturnsObject_WhenTypeIsInterface()
-        {
-            JobHelper.SetParametersSerializerSettings(new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Objects
-            });
-
-            var argumentJson = @"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}";
-
-            var argumentValue = JobHelper.DeserializeParameter(argumentJson, typeof(IClass)) as ClassA;
-            Assert.NotNull(argumentValue);
-            Assert.Equal("A", argumentValue.PropertyA);
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobHelperFacts.cs
@@ -180,6 +180,24 @@ namespace Hangfire.Core.Tests.Common
             Assert.Equal(@"{""$type"":""Hangfire.Core.Tests.Common.JobHelperFacts+ClassA, Hangfire.Core.Tests"",""PropertyA"":""A""}", result);
         }
 
+        [Fact, CleanJsonSerializersSettings]
+        public void ArgumentToJson_HandlesArgumentsSerizlizerSettingsDoNotOverwriteCoreSerializerSettings()
+        {
+            JobHelper.SetCoreSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.None
+            });
+
+            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                TypeNameHandling = TypeNameHandling.All
+            });
+
+            var result = JobHelper.ToJson(new ClassA("A"));
+            Assert.Equal(@"{""PropertyA"":""A""}", result);
+        }
+
         [Fact]
         public void ArgumentFromJson_ThrowsAnException_WhenTypeIsNull()
         {

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Storage\InvocationDataFacts.cs" />
     <Compile Include="Storage\MonitoringTypeFacts.cs" />
     <Compile Include="Storage\StorageConnectionExtensionsFacts.cs" />
+    <Compile Include="Utils\CleanJsonSerializerSettingsAttribute.cs" />
     <Compile Include="Utils\CultureHelper.cs" />
     <Compile Include="Utils\GlobalLockAttribute.cs" />
     <Compile Include="Utils\PlatformHelper.cs" />

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.Serialization.Formatters;
 using Hangfire.Common;
 using Hangfire.Storage;
 using Newtonsoft.Json;
@@ -75,6 +76,24 @@ namespace Hangfire.Core.Tests.Storage
             Assert.Equal("Sample", invocationData.Method);
             Assert.Equal(JobHelper.ToJson(new[] { typeof(string) }), invocationData.ParameterTypes);
             Assert.Equal(JobHelper.ToJson(new[] { "\"Hello\"" }), invocationData.Arguments);
+        }
+
+        [Fact]
+        public void Serialize_CorrectlySerializesTheData_WhenArgumentsJsonSerializerSettingsIsDefined()
+        {
+            JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameAssemblyFormat = FormatterAssemblyStyle.Full,
+                TypeNameHandling = TypeNameHandling.All
+            });
+            var job = Job.FromExpression(() => ListMethod(new List<string> { "Hello"}));
+
+            var invocationData = InvocationData.Serialize(job);
+
+            Assert.Equal(typeof(InvocationDataFacts).AssemblyQualifiedName, invocationData.Type);
+            Assert.Equal("ListMethod", invocationData.Method);
+            Assert.Equal(JobHelper.ToJson(new[] { typeof(IList<string>) }), invocationData.ParameterTypes);
+            Assert.Equal(JobHelper.ToJson(new [] {JobHelper.ArgumentsToJson(new List<string>{"Hello"})}), invocationData.Arguments);
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -39,7 +39,7 @@ namespace Hangfire.Core.Tests.Storage
             Assert.Equal(typeof(InvocationDataFacts).AssemblyQualifiedName, invocationData.Type);
             Assert.Equal("ListMethod", invocationData.Method);
             Assert.Equal(JobHelper.ToJson(new[] { typeof(IList<string>) }), invocationData.ParameterTypes);
-            Assert.Equal(JobHelper.ToJson(new[] { JobHelper.ArgumentToJson(new List<string> { "Hello" }) }), invocationData.Arguments);
+            Assert.Equal(JobHelper.ToJson(new[] { JobHelper.SerializeArgument(new List<string> { "Hello" }) }), invocationData.Arguments);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Hangfire.Core.Tests.Storage
                 typeof(InvocationDataFacts).AssemblyQualifiedName,
                 "ListMethod",
                 JobHelper.ToJson(new[] { typeof(IList<string>) }),
-                JobHelper.ToJson(new[] { JobHelper.ArgumentToJson(new List<string> { "I'm correct"}) }));
+                JobHelper.ToJson(new[] { JobHelper.SerializeArgument(new List<string> { "I'm correct"}) }));
 
             var job = serializedData.Deserialize();
 

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -78,8 +78,8 @@ namespace Hangfire.Core.Tests.Storage
             Assert.Equal(JobHelper.ToJson(new[] { "\"Hello\"" }), invocationData.Arguments);
         }
 
-        [Fact]
-        public void Serialize_CorrectlySerializesTheData_WhenArgumentsJsonSerializerSettingsIsDefined()
+        [Fact, CleanJsonSerializersSettings]
+        public void Serialize_CorrectlySerializesTheData_WhenArgumentJsonSerializerSettingsIsDefined()
         {
             JobHelper.SetArgumentsSerializerSettings(new JsonSerializerSettings
             {
@@ -93,7 +93,7 @@ namespace Hangfire.Core.Tests.Storage
             Assert.Equal(typeof(InvocationDataFacts).AssemblyQualifiedName, invocationData.Type);
             Assert.Equal("ListMethod", invocationData.Method);
             Assert.Equal(JobHelper.ToJson(new[] { typeof(IList<string>) }), invocationData.ParameterTypes);
-            Assert.Equal(JobHelper.ToJson(new [] {JobHelper.ArgumentsToJson(new List<string>{"Hello"})}), invocationData.Arguments);
+            Assert.Equal(JobHelper.ToJson(new [] {JobHelper.ArgumentToJson(new List<string>{"Hello"})}), invocationData.Arguments);
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
+++ b/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
@@ -9,7 +9,11 @@ namespace Hangfire.Core.Tests
     {
         public override void After(MethodInfo methodUnderTest)
         {
+#pragma warning disable 618
+           JobHelper.SetSerializerSettings(null);
+#pragma warning restore 618
            JobHelper.SetArgumentsSerializerSettings(null);
+           JobHelper.SetParametersSerializerSettings(null);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
+++ b/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
@@ -10,7 +10,6 @@ namespace Hangfire.Core.Tests
         public override void After(MethodInfo methodUnderTest)
         {
            JobHelper.SetArgumentsSerializerSettings(null);
-           JobHelper.SetCoreSerializerSettings(null);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
+++ b/tests/Hangfire.Core.Tests/Utils/CleanJsonSerializerSettingsAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using Hangfire.Common;
+using Newtonsoft.Json;
+using Xunit.Sdk;
+
+namespace Hangfire.Core.Tests
+{
+    internal class CleanJsonSerializersSettingsAttribute: BeforeAfterTestAttribute
+    {
+        public override void After(MethodInfo methodUnderTest)
+        {
+           JobHelper.SetArgumentsSerializerSettings(null);
+           JobHelper.SetCoreSerializerSettings(null);
+        }
+    }
+}


### PR DESCRIPTION
Split json serializer settings into:
* **core settings** - json serializer settings which are responsible for serialization and desiarilation internal Hangfire data
* **arguments settings** - json serializer settings which affect serialization/deserialization of enqueuing method arguments.

Additional:
* add **DB** to abbreviations to avoid Resharper warnings
* add `CleanJsonSerializersSettingsAttribute` which clean `ArgumentsSerializerSettings` and `CoreSerializerSettings` after test