### PR TITLE
Make Queue name accessible from RecurringJobDto

### DIFF
--- a/src/Hangfire.Core/Storage/RecurringJobDto.cs
+++ b/src/Hangfire.Core/Storage/RecurringJobDto.cs
@@ -23,6 +23,7 @@ namespace Hangfire.Storage
     {
         public string Id { get; set; }
         public string Cron { get; set; }
+        public string Queue { get; set; }
         public Job Job { get; set; }
         public JobLoadException LoadException { get; set; }
         public DateTime? NextExecution { get; set; }

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -77,8 +77,7 @@ namespace Hangfire.Storage
                 var dto = new RecurringJobDto
                 {
                     Id = id,
-                    Cron = hash["Cron"],
-                    Queue = hash["Queue"]
+                    Cron = hash["Cron"]
                 };
 
                 try
@@ -105,6 +104,11 @@ namespace Hangfire.Storage
                     {
                         dto.LastJobState = stateData.Name;
                     }
+                }
+                
+                if (hash.ContainsKey("Queue"))
+                {
+                    dto.Queue = hash["Queue"]
                 }
 
                 if (hash.ContainsKey("LastExecution"))

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -108,7 +108,7 @@ namespace Hangfire.Storage
                 
                 if (hash.ContainsKey("Queue"))
                 {
-                    dto.Queue = hash["Queue"]
+                    dto.Queue = hash["Queue"];
                 }
 
                 if (hash.ContainsKey("LastExecution"))

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -77,7 +77,8 @@ namespace Hangfire.Storage
                 var dto = new RecurringJobDto
                 {
                     Id = id,
-                    Cron = hash["Cron"]
+                    Cron = hash["Cron"],
+                    Queue = hash["Queue"]
                 };
 
                 try


### PR DESCRIPTION
useful for:

```
using (var connection = JobStorage.Current.GetConnection())
            {
                var recurrings = StorageConnectionExtensions.GetRecurringJobs(connection);
              
                foreach (RecurringJobDto recurring in recurrings)
                {

                    if(recurring.Queue == "APPNAME")
                    {

                        if (recurring.Id != "ID_IN_APP_DATABASE_USING_ORM")
                        {
                            RecurringJob.RemoveIfExists(recurring.Id);
                        }

                    }
                 
                }

            }
```