### PR TITLE
Add support an array of generic type as parameter type

### DIFF
--- a/src/Hangfire.Core/Common/TypeExtensions.cs
+++ b/src/Hangfire.Core/Common/TypeExtensions.cs
@@ -125,6 +125,17 @@ namespace Hangfire.Common
 
             if (parameterType.ContainsGenericParameters)
             {
+                if (parameterType.IsArray)
+                {
+                    // Return false if parameterType is array whereas actualType isn't
+                    if (!actualType.IsArray) return false;
+
+                    var parameterElementType = parameterType.GetElementType();
+                    var actualElementType = actualType.GetElementType();
+
+                    return TypesMatchRecursive(parameterElementType.GetTypeInfo(), actualElementType.GetTypeInfo(), genericArguments);
+                }
+
                 if (!actualType.IsGenericType || parameterType.GetGenericTypeDefinition() != actualType.GetGenericTypeDefinition())
                 {
                     return false;

--- a/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
@@ -265,6 +265,35 @@ namespace Hangfire.Core.Tests.Common
 
             Assert.Equal(null, method);
         }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_ReturnsCorrectMethod_WhenParameterTypeIsGenericArray()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new[] { typeof(string[]) });
+
+            Assert.Equal("GenericMethod", method.Name);
+            Assert.Equal(typeof(string[]), method.GetParameters()[0].ParameterType);
+        }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_ReturnsCorrectMethod_WhenParameterTypeIsComplicatedGenericArray()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new[] { typeof(List<int>[]) });
+
+            Assert.Equal("GenericMethod", method.Name);
+            Assert.Equal(typeof(List<int>[]), method.GetParameters()[0].ParameterType);
+        }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_ReturnsNull_WhenMatchingGenricMethodNotBeFound()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new[] { typeof(Tuple<List<int>, string>) });
+
+            Assert.Null(method);
+        }
     }
 
     public class GenericClass<T1>
@@ -314,6 +343,10 @@ namespace Hangfire.Core.Tests.Common
         public void GenericMethod<T>(int arg0, T arg1, double arg2) { }
 
         public void GenericMethod<T>(Tuple<T, List<int>> arg) { }
+
+        public void GenericMethod<T>(T[] arg) { }
+
+        public void GenericMethod<T>(List<T>[] arg) { }
 
         public class NestedNonGenericClass
         {


### PR DESCRIPTION
Add support for array of generic types like `T[]` or `Tuple<T,T>[]` as parameter type.

Related issue:  #408 

You can enqueue method with generic array parameters:
```csharp
public void Foo<T>(T[] argArray) ;

...

string[] aArray = ...;
BackgroundJob.Enqueue(() => Foo(aArray);
```
Also you can enqueue a method which has more complicated parameter type:
```csharp
public void Foo<T>(Tuple<T,int>[] argArray) ;

...

Tuple<string,int>[] aArray = ...;
BackgroundJob.Enqueue(() => Foo(aArray);
```

