### PR TITLE
Fixes error 500 in the dashboard

### DIFF
--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -130,7 +130,7 @@ namespace Hangfire.Dashboard
                         foreach (var item in (IEnumerable)argumentValue)
                         {
                             var argumentRenderer = ArgumentRenderer.GetRenderer(enumerableArgument);
-                            renderedItems.Add(argumentRenderer.Render(isJson, item.ToString(),
+                            renderedItems.Add(argumentRenderer.Render(isJson, item?.ToString(),
                                 JobHelper.ToJson(item)));
                         }
 


### PR DESCRIPTION
Fixes error 500 in the dashboard when rendering an array of reference types where an element could be null.

#734 