### PR TITLE
Typo - "Nexts jobs" should be "Next jobs"

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
@@ -326,7 +326,7 @@
     <value>Length</value>
   </data>
   <data name="QueuesPage_Table_NextsJobs" xml:space="preserve">
-    <value>Nexts jobs</value>
+    <value>Next jobs</value>
   </data>
   <data name="QueuesPage_Table_Queue" xml:space="preserve">
     <value>Queue</value>


### PR DESCRIPTION
Typo - "Nexts jobs" should be "Next jobs"