### PR TITLE
Make Job Scheduling Aware of Queues the Server is Responsible For

### DIFF
--- a/Hangfire.sln.DotSettings
+++ b/Hangfire.sln.DotSettings
@@ -3,5 +3,8 @@
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ERedis_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ESqlServer_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHIN_SINGLE_LINE_ARRAY_INITIALIZER_BRACES/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters&gt;&lt;Filter ModuleMask="Hangfire.Core.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;Filter ModuleMask="Hangfire.SqlServer.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;/ExcludeFilters&gt;&lt;/data&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -141,6 +141,11 @@ namespace Hangfire
             set { lock (_lockObject) { _logEvents = value; } }
         }
 
+        /// <summary>
+        /// Gets the name of the queue that the job should be placed into on retry attempts.
+        /// </summary>
+        public string RetryQueueName { get; }
+
         /// <inheritdoc />
         public void OnStateElection(ElectStateContext context)
         {
@@ -211,7 +216,7 @@ namespace Hangfire
 
             // If attempt number is less than max attempts, we should
             // schedule the job to run again later.
-            context.CandidateState = new ScheduledState(delay)
+            context.CandidateState = new ScheduledState(delay, context.BackgroundJob.Job.QueueName)
             {
                 Reason = $"Retry attempt {retryAttempt} of {Attempts}: {exceptionMessage}"
             };

--- a/src/Hangfire.Core/BackgroundJob.cs
+++ b/src/Hangfire.Core/BackgroundJob.cs
@@ -75,6 +75,7 @@ namespace Hangfire
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -83,16 +84,19 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue([NotNull, InstantHandle] Expression<Action> methodCall)
+        public static string Enqueue(
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, queueName);
         }
 
         /// <summary>
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -101,16 +105,19 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue([NotNull, InstantHandle] Expression<Func<Task>> methodCall)
+        public static string Enqueue(
+            [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, queueName);
         }
 
         /// <summary>
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -119,16 +126,19 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue<T>([NotNull, InstantHandle] Expression<Action<T>> methodCall)
+        public static string Enqueue<T>(
+            [NotNull, InstantHandle] Expression<Action<T>> methodCall,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, queueName);
         }
 
         /// <summary>
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -137,10 +147,12 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue<T>([NotNull, InstantHandle] Expression<Func<T, Task>> methodCall)
+        public static string Enqueue<T>(
+            [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, queueName);
         }
 
         /// <summary>
@@ -150,13 +162,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, queueName);
         }
 
         /// <summary>
@@ -166,13 +180,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, queueName);
         }
 
         /// <summary>
@@ -182,13 +198,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, queueName);
         }
 
         /// <summary>
@@ -198,13 +216,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, queueName);
         }
 
         /// <summary>
@@ -215,13 +235,15 @@ namespace Hangfire
         /// <typeparam name="T">Type whose method will be invoked during job processing.</typeparam>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule<T>(
             [NotNull, InstantHandle] Expression<Action<T>> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, queueName);
         }
 
         /// <summary>
@@ -232,13 +254,15 @@ namespace Hangfire
         /// <typeparam name="T">Type whose method will be invoked during job processing.</typeparam>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule<T>(
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, queueName);
         }
 
         /// <summary>
@@ -249,13 +273,15 @@ namespace Hangfire
         /// <typeparam name="T">The type whose method will be invoked during the job processing.</typeparam>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule<T>(
             [NotNull, InstantHandle] Expression<Action<T>> methodCall, 
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, queueName);
         }
 
         /// <summary>
@@ -266,13 +292,15 @@ namespace Hangfire
         /// <typeparam name="T">The type whose method will be invoked during the job processing.</typeparam>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule<T>(
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, queueName);
         }
 
         /// <summary>
@@ -304,19 +332,6 @@ namespace Hangfire
             var client = ClientFactory();
             return client.Delete(jobId, fromState);
         }
-        
-        /// <summary>
-        /// Changes state of a job with the specified <paramref name="jobId"/>
-        /// to the <see cref="EnqueuedState"/>.
-        /// </summary>
-        /// 
-        /// <param name="jobId">Identifier of job, whose state is being changed.</param>
-        /// <returns>True, if state change succeeded, otherwise false.</returns>
-        public static bool Requeue([NotNull] string jobId)
-        {
-            var client = ClientFactory();
-            return client.Requeue(jobId);
-        }
 
         /// <summary>
         /// Changes state of a job with the specified <paramref name="jobId"/>
@@ -327,11 +342,12 @@ namespace Hangfire
         /// 
         /// <param name="jobId">Identifier of job, whose state is being changed.</param>
         /// <param name="fromState">Current state assertion, or null if unneeded.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>True, if state change succeeded, otherwise false.</returns>
-        public static bool Requeue([NotNull] string jobId, [CanBeNull] string fromState)
+        public static bool Requeue([NotNull] string jobId, [CanBeNull] string fromState = null, [CanBeNull] string queueName = null)
         {
             var client = ClientFactory();
-            return client.Requeue(jobId, fromState);
+            return client.Requeue(jobId, fromState, queueName);
         }
 
         /// <summary>
@@ -340,13 +356,16 @@ namespace Hangfire
         /// </summary>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId, 
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall);
+            return client.ContinueWith(parentId, methodCall, continuationQueueName);
         }
 
         /// <summary>
@@ -355,13 +374,16 @@ namespace Hangfire
         /// </summary>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] string parentId, 
-            [NotNull, InstantHandle] Expression<Action<T>> methodCall)
+            [NotNull, InstantHandle] Expression<Action<T>> methodCall,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall);
+            return client.ContinueWith(parentId, methodCall, continuationQueueName);
         }
 
         /// <summary>
@@ -370,14 +392,17 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId, 
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options);
+            return client.ContinueWith(parentId, methodCall, options, continuationQueueName);
         }
 
         /// <summary>
@@ -387,14 +412,17 @@ namespace Hangfire
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options: options);
+            return client.ContinueWith(parentId, methodCall, options: options, continuationQueueName: continuationQueueName);
         }
 
         /// <summary>
@@ -403,14 +431,17 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] string parentId, 
             [NotNull, InstantHandle] Expression<Action<T>> methodCall, 
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options);
+            return client.ContinueWith(parentId, methodCall, options, continuationQueueName);
         }
 
         /// <summary>
@@ -420,14 +451,17 @@ namespace Hangfire
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] string continuationQueueName = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options: options);
+            return client.ContinueWith(parentId, methodCall, options: options, continuationQueueName: continuationQueueName);
         }
     }
 }

--- a/src/Hangfire.Core/BackgroundJobClientExtensions.cs
+++ b/src/Hangfire.Core/BackgroundJobClientExtensions.cs
@@ -40,14 +40,19 @@ namespace Hangfire
         /// 
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue(
             [NotNull] this IBackgroundJobClient client, 
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            if (queueName != null) return client.Create(methodCall, new EnqueuedState(queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -59,14 +64,19 @@ namespace Hangfire
         /// 
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue(
             [NotNull] this IBackgroundJobClient client,
-            [NotNull, InstantHandle] Expression<Func<Task>> methodCall)
+            [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            if (queueName != null) return client.Create(methodCall, new EnqueuedState(queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -79,14 +89,19 @@ namespace Hangfire
         /// <typeparam name="T">Type whose method will be invoked during job processing.</typeparam>
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue<T>(
             [NotNull] this IBackgroundJobClient client, 
-            [NotNull, InstantHandle] Expression<Action<T>> methodCall)
+            [NotNull, InstantHandle] Expression<Action<T>> methodCall,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            if (queueName != null) return client.Create(methodCall, new EnqueuedState(queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -99,14 +114,19 @@ namespace Hangfire
         /// <typeparam name="T">Type whose method will be invoked during job processing.</typeparam>
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue<T>(
             [NotNull] this IBackgroundJobClient client,
-            [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall)
+            [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            if (queueName != null) return client.Create(methodCall, new EnqueuedState(queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -116,15 +136,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            if (queueName != null) return client.Create(methodCall, new ScheduledState(delay, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(delay, job.QueueName));
         }
 
         /// <summary>
@@ -134,15 +159,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            if (queueName != null) return client.Create(methodCall, new ScheduledState(delay, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(delay, job.QueueName));
         }
 
         /// <summary>
@@ -152,15 +182,21 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier or a created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            if (queueName != null)
+                return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, job.QueueName));
         }
 
         /// <summary>
@@ -170,15 +206,21 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment of time at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier or a created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            if (queueName != null)
+                return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, job.QueueName));
         }
 
         /// <summary>
@@ -190,15 +232,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule<T>(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull, InstantHandle] Expression<Action<T>> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            if (queueName != null) return client.Create(methodCall, new ScheduledState(delay, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(delay, job.QueueName));
         }
 
         /// <summary>
@@ -210,15 +257,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule<T>(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            if (queueName != null) return client.Create(methodCall, new ScheduledState(delay, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(delay, job.QueueName));
         }
 
         /// <summary>
@@ -229,15 +281,21 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule<T>(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Action<T>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            if (queueName != null)
+                return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, job.QueueName));
         }
 
         /// <summary>
@@ -248,15 +306,21 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment at which the job will be enqueued.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule<T>(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            if (queueName != null)
+                return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, queueName));
+
+            var job = Job.FromExpression(methodCall);
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime, job.QueueName));
         }
 
         /// <summary>
@@ -408,20 +472,7 @@ namespace Hangfire
             var state = new DeletedState();
             return client.ChangeState(jobId, state, fromState);
         }
-
-        /// <summary>
-        /// Changes state of a job with the specified <paramref name="jobId"/>
-        /// to the <see cref="EnqueuedState"/>.
-        /// </summary>
-        /// 
-        /// <param name="client">An instance of <see cref="IBackgroundJobClient"/> implementation.</param>
-        /// <param name="jobId">Identifier of job, whose state is being changed.</param>
-        /// <returns>True, if state change succeeded, otherwise false.</returns>
-        public static bool Requeue([NotNull] this IBackgroundJobClient client, [NotNull] string jobId)
-        {
-            return Requeue(client, jobId, null);
-        }
-
+        
         /// <summary>
         /// Changes state of a job with the specified <paramref name="jobId"/>
         /// to the <see cref="EnqueuedState"/>. If <paramref name="fromState"/> value 
@@ -432,15 +483,27 @@ namespace Hangfire
         /// <param name="client">An instance of <see cref="IBackgroundJobClient"/> implementation.</param>
         /// <param name="jobId">Identifier of job, whose state is being changed.</param>
         /// <param name="fromState">Current state assertion, or null if unneeded.</param>
+        /// <param name="queueName">The name of the queue to place the job in. This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>True, if state change succeeded, otherwise false.</returns>
         public static bool Requeue(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull] string jobId, 
-            [CanBeNull] string fromState)
+            [CanBeNull] string fromState = null,
+            [CanBeNull] string queueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             var state = new EnqueuedState();
+            if (queueName != null)
+            {
+                state.Queue = queueName;
+            }
+            else
+            {
+                var job = JobStorage.Current.GetConnection().GetJobData(jobId)?.Job;
+                if (job != null) state.Queue = job.QueueName;
+            }
+
             return client.ChangeState(jobId, state, fromState);
         }
 
@@ -451,13 +514,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull] string parentId,
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] string continuationQueueName = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState());
+            if (continuationQueueName != null)
+                return ContinueWith(client, parentId, methodCall, new EnqueuedState(continuationQueueName));
+
+            var job = Job.FromExpression(methodCall);
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -467,13 +537,20 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull] string parentId,
-            [NotNull, InstantHandle] Expression<Action<T>> methodCall)
+            [NotNull, InstantHandle] Expression<Action<T>> methodCall,
+            [CanBeNull] string continuationQueueName = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState());
+            if (continuationQueueName != null)
+                return ContinueWith(client, parentId, methodCall, new EnqueuedState(continuationQueueName));
+
+            var job = Job.FromExpression(methodCall);
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(job.QueueName));
         }
 
         /// <summary>
@@ -522,14 +599,21 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] string continuationQueueName = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState(), options);
+            if (continuationQueueName != null)
+                return ContinueWith(client, parentId, methodCall, new EnqueuedState(continuationQueueName), options);
+
+            var job = Job.FromExpression(methodCall);
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(job.QueueName), options);
         }
 
         /// <summary>
@@ -540,14 +624,21 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param> 
         /// <param name="options">Continuation options.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Action<T>> methodCall,
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] string continuationQueueName = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState(), options);
+            if (continuationQueueName != null)
+                return ContinueWith(client, parentId, methodCall, new EnqueuedState(continuationQueueName), options);
+
+            var job = Job.FromExpression(methodCall);
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(job.QueueName), options);
         }
 
         /// <summary>
@@ -582,17 +673,23 @@ namespace Hangfire
         /// If null, then <see cref="EnqueuedState"/> is used.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [InstantHandle] Expression<Func<Task>> methodCall,
             [CanBeNull] IState nextState = null,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] string continuationQueueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            var state = new AwaitingState(parentId, nextState ?? new EnqueuedState(), options);
+            var continuationState = nextState ??
+                                    new EnqueuedState(continuationQueueName ?? Job.FromExpression(methodCall).QueueName);
+
+            var state = new AwaitingState(parentId, continuationState, options);
             return client.Create(Job.FromExpression(methodCall), state);
         }
 
@@ -628,17 +725,23 @@ namespace Hangfire
         /// If null, then <see cref="EnqueuedState"/> is used.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="continuationQueueName">The name of the queue to place the continuation job in. 
+        /// This value overrides <see cref="QueueAttribute"/>.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Func<T, Task>> methodCall,
             [CanBeNull] IState nextState = null,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] string continuationQueueName = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            var state = new AwaitingState(parentId, nextState ?? new EnqueuedState(), options);
+            var continuationState = nextState ??
+                                    new EnqueuedState(continuationQueueName ?? Job.FromExpression(methodCall).QueueName);
+
+            var state = new AwaitingState(parentId, continuationState, options);
             return client.Create(Job.FromExpression(methodCall), state);
         }
     }

--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -139,8 +139,8 @@ namespace Hangfire
                 processes.Add(new Worker(_options.Queues, performer, stateChanger));
             }
             
-            processes.Add(new DelayedJobScheduler(_options.SchedulePollingInterval, stateChanger));
-            processes.Add(new RecurringJobScheduler(factory));
+            processes.Add(new DelayedJobScheduler(_options.SchedulePollingInterval, stateChanger, _options.Queues));
+            processes.Add(new RecurringJobScheduler(factory, _options.Queues));
 
             return processes;
         }

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -21,7 +21,9 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Hangfire.Annotations;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Hangfire.States;
 
 namespace Hangfire.Common
 {
@@ -144,16 +146,44 @@ namespace Hangfire.Common
         /// <exception cref="ArgumentException">Parameter/argument count mismatch.</exception>
         /// <exception cref="NotSupportedException"><paramref name="method"/> is not supported.</exception>
         public Job([NotNull] Type type, [NotNull] MethodInfo method, [NotNull] params object[] args)
+            : this(type, method, args, EnqueuedState.DefaultQueue)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Job"/> class with the 
+        /// type, metadata of a method and the given list of arguments.
+        /// </summary>
+        /// 
+        /// <param name="type">Type that contains the given method.</param>
+        /// <param name="method">Method that should be invoked.</param>
+        /// <param name="args">Arguments that should be passed during the method call.</param>
+        /// <param name="queueName">The queue that the job will be placed in.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> argument is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="method"/> argument is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="args"/> argument is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="queueName"/> argument is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="type"/> does not contain the given <paramref name="method"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">Parameter/argument count mismatch.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="method"/> is not supported.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="queueName"/> does not adhere to requirements.
+        /// </exception>
+        public Job([NotNull] Type type, [NotNull] MethodInfo method, [NotNull] object[] args, [NotNull] string queueName)
         {
             if (type == null) throw new ArgumentNullException(nameof(type));
             if (method == null) throw new ArgumentNullException(nameof(method));
             if (args == null) throw new ArgumentNullException(nameof(args));
-            
-            Validate(type, nameof(type), method, nameof(method), args.Length, nameof(args));
+            if (queueName == null) throw new ArgumentNullException(nameof(queueName));
+
+            Validate(type, nameof(type), method, nameof(method), args.Length, nameof(args), queueName, nameof(queueName));
 
             Type = type;
             Method = method;
             Args = args;
+            QueueName = queueName;
         }
 
         /// <summary>
@@ -176,6 +206,12 @@ namespace Hangfire.Common
         /// </summary>
         [NotNull]
         public IReadOnlyList<object> Args { get; }
+
+        /// <summary>
+        /// Gets the name of the queue that the job belongs to.
+        /// </summary>
+        [NotNull]
+        public string QueueName { get; private set; }
         
         public override string ToString()
         {
@@ -194,6 +230,12 @@ namespace Hangfire.Common
             return useCache
                 ? ReflectedAttributeCache.GetMethodFilterAttributes(Method)
                 : GetFilterAttributes(Method);
+        }
+
+        internal void OverrideQueueName(string queueName)
+        {
+            VerifyQueueName(queueName, nameof(queueName));
+            QueueName = queueName;
         }
 
         private static IEnumerable<JobFilterAttribute> GetFilterAttributes(MemberInfo memberInfo)
@@ -356,11 +398,24 @@ namespace Hangfire.Common
                     callExpression.Method.GetParameters().Select(x => x.ParameterType).ToArray());
             }
 
+            var queueAttribute = ReflectedAttributeCache.GetMethodQueueAttribute(method) ??
+                                 ReflectedAttributeCache.GetTypeQueueAttribute(type);
+
+            if (queueAttribute == null)
+            {
+                return new Job(
+                    // ReSharper disable once AssignNullToNotNullAttribute
+                    type,
+                    method,
+                    GetExpressionValues(callExpression.Arguments));
+            }
+
             return new Job(
                 // ReSharper disable once AssignNullToNotNullAttribute
                 type,
                 method,
-                GetExpressionValues(callExpression.Arguments));
+                GetExpressionValues(callExpression.Arguments),
+                queueAttribute.Queue);
         }
 
         private static void Validate(
@@ -371,7 +426,9 @@ namespace Hangfire.Common
             [InvokerParameterName] string methodParameterName,
             // ReSharper disable once UnusedParameter.Local
             int argumentCount,
-            [InvokerParameterName] string argumentParameterName)
+            [InvokerParameterName] string argumentParameterName,
+            string queueName,
+            [InvokerParameterName] string queueNameParameterName)
         {
             if (!method.IsPublic)
             {
@@ -426,6 +483,18 @@ namespace Hangfire.Common
                     throw new NotSupportedException(
                         "Parameters, passed by reference, are not supported: there is no guarantee that specified method will be invoked inside the same process.");
                 }
+            }
+
+            VerifyQueueName(queueName, queueNameParameterName);
+        }
+
+        private static void VerifyQueueName(string queueName, [InvokerParameterName] string queueNameParameterName)
+        {
+            if (!Regex.IsMatch(queueName, @"^[a-z0-9_]+$"))
+            {
+                throw new ArgumentException(
+                    $"The queue name must consist of lowercase letters, digits and underscore characters only. Given: '{queueName}'.",
+                    queueNameParameterName);
             }
         }
 

--- a/src/Hangfire.Core/QueueAttribute.cs
+++ b/src/Hangfire.Core/QueueAttribute.cs
@@ -14,16 +14,17 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
-using Hangfire.Common;
-using Hangfire.States;
+using System;
 
 namespace Hangfire
 {
     /// <summary>
     /// Represents attribute, that is used to determine queue name
-    /// for background jobs. It can be applied to the methods and classes. 
+    /// for background and recurring jobs. It can be applied to the methods and classes. 
     /// If the attribute is not applied neither to the method, nor the class, 
     /// then default queue will be used.
+    /// This value will be overriden if a queue is provided whenever the BackgroundJob or
+    /// RecurringJob are created
     /// </summary>
     /// 
     /// <example><![CDATA[
@@ -35,6 +36,9 @@ namespace Hangfire
     /// 
     ///     [Queue("critical")]
     ///     public void ReportFatal(string message) { }
+    /// 
+    ///     [Queue("notification")]
+    ///     public void NotifyAdminsOfCurrentErrorCount(params string[] adminEmails) { }
     /// }
     /// 
     /// // Background job will be placed on the 'high' queue.
@@ -43,8 +47,12 @@ namespace Hangfire
     /// // Background job will be placed on the 'critical' queue.
     /// BackgroundJob.Enqueue<ErrorService>(x => x.ReportFatal("Really bad thing!"));
     /// 
+    /// // Recurring job will be placed in the 'email' queue and not the 'notification' queue.
+    /// RecurringJob.AddOrUpdate<ErrorService>(x => x.NotifyAdminsOfCurrentErrorCount("admin@noreply.com"), myCronExpression, myTimeZone, "email"); 
+    /// 
     /// ]]></example>
-    public sealed class QueueAttribute : JobFilterAttribute, IElectStateFilter
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Interface, AllowMultiple = false)]
+    public sealed class QueueAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QueueAttribute"/> class
@@ -57,17 +65,8 @@ namespace Hangfire
         }
 
         /// <summary>
-        /// Gets the queue name that will be used for background jobs.
+        /// Gets the queue name that will be used for jobs.
         /// </summary>
         public string Queue { get; }
-
-        public void OnStateElection(ElectStateContext context)
-        {
-            var enqueuedState = context.CandidateState as EnqueuedState;
-            if (enqueuedState != null)
-            {
-                enqueuedState.Queue = Queue;
-            }
-        }
     }
 }

--- a/src/Hangfire.Core/RecurringJob.cs
+++ b/src/Hangfire.Core/RecurringJob.cs
@@ -22,7 +22,7 @@ using Hangfire.States;
 
 namespace Hangfire
 {
-    public static class RecurringJob
+    public static partial class RecurringJob
     {
         private static readonly Lazy<RecurringJobManager> Instance = new Lazy<RecurringJobManager>(
             () => new RecurringJobManager());
@@ -31,16 +31,7 @@ namespace Hangfire
             Expression<Action> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
-        }
-
-        public static void AddOrUpdate<T>(
-            Expression<Action<T>> methodCall,
-            Func<string> cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
         }
@@ -49,7 +40,7 @@ namespace Hangfire
             Expression<Action> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             var job = Job.FromExpression(methodCall);
             var id = GetRecurringJobId(job);
@@ -59,93 +50,18 @@ namespace Hangfire
 
         public static void AddOrUpdate<T>(
             Expression<Action<T>> methodCall,
-            string cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            var job = Job.FromExpression(methodCall);
-            var id = GetRecurringJobId(job);
-
-            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
-        }
-
-        public static void AddOrUpdate(
-            string recurringJobId,
-            Expression<Action> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
-        }
-
-        public static void AddOrUpdate<T>(
-            string recurringJobId,
-            Expression<Action<T>> methodCall,
-            Func<string> cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
-        }
-
-        public static void AddOrUpdate(
-            string recurringJobId,
-            Expression<Action> methodCall,
-            string cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            var job = Job.FromExpression(methodCall);
-            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
-        }
-
-        public static void AddOrUpdate<T>(
-            string recurringJobId,
-            Expression<Action<T>> methodCall,
-            string cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            var job = Job.FromExpression(methodCall);
-            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
-        }
-
-        public static void AddOrUpdate(
-            Expression<Func<Task>> methodCall,
-            Func<string> cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
         }
 
         public static void AddOrUpdate<T>(
-            Expression<Func<T, Task>> methodCall,
-            Func<string> cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
-        }
-
-        public static void AddOrUpdate(
-            Expression<Func<Task>> methodCall,
+            Expression<Action<T>> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
-        {
-            var job = Job.FromExpression(methodCall);
-            var id = GetRecurringJobId(job);
-
-            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
-        }
-
-        public static void AddOrUpdate<T>(
-            Expression<Func<T, Task>> methodCall,
-            string cronExpression,
-            TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             var job = Job.FromExpression(methodCall);
             var id = GetRecurringJobId(job);
@@ -155,20 +71,94 @@ namespace Hangfire
         
         public static void AddOrUpdate(
             string recurringJobId,
-            Expression<Func<Task>> methodCall,
+            Expression<Action> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Action> methodCall,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+        
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Action<T>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
         {
             AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
         }
 
         public static void AddOrUpdate<T>(
             string recurringJobId,
+            Expression<Action<T>> methodCall,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        public static void AddOrUpdate<T>(
             Expression<Func<T, Task>> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
+        {
+            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Func<T, Task>> methodCall,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
         {
             AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
         }
@@ -178,7 +168,7 @@ namespace Hangfire
             Expression<Func<Task>> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             var job = Job.FromExpression(methodCall);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
@@ -187,9 +177,19 @@ namespace Hangfire
         public static void AddOrUpdate<T>(
             string recurringJobId,
             Expression<Func<T, Task>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = null)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Func<T, Task>> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = null)
         {
             var job = Job.FromExpression(methodCall);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -70,7 +70,7 @@ namespace Hangfire
                 recurringJob["Job"] = JobHelper.ToJson(invocationData);
                 recurringJob["Cron"] = cronExpression;
                 recurringJob["TimeZoneId"] = options.TimeZone.Id;
-                recurringJob["Queue"] = options.QueueName;
+                recurringJob["Queue"] = job.QueueName;
 
                 var existingJob = connection.GetAllEntriesFromHash($"recurring-job:{recurringJobId}");
                 if (existingJob == null)
@@ -84,7 +84,7 @@ namespace Hangfire
                         $"recurring-job:{recurringJobId}",
                         recurringJob);
 
-                    transaction.AddToSet("recurring-jobs", recurringJobId);
+                    transaction.AddToSetQueue("recurring-jobs", recurringJobId, job.QueueName);
 
                     transaction.Commit();
                 }

--- a/src/Hangfire.Core/RecurringJobManagerExtensions.cs
+++ b/src/Hangfire.Core/RecurringJobManagerExtensions.cs
@@ -37,28 +37,22 @@ namespace Hangfire
             [NotNull] string recurringJobId,
             [NotNull] Job job,
             [NotNull] string cronExpression,
-            [NotNull] TimeZoneInfo timeZone)
-        {
-            AddOrUpdate(manager, recurringJobId, job, cronExpression, timeZone, EnqueuedState.DefaultQueue);
-        }
-
-        public static void AddOrUpdate(
-            [NotNull] this IRecurringJobManager manager,
-            [NotNull] string recurringJobId,
-            [NotNull] Job job,
-            [NotNull] string cronExpression,
             [NotNull] TimeZoneInfo timeZone,
-            [NotNull] string queue)
+            string queue = null)
         {
             if (manager == null) throw new ArgumentNullException(nameof(manager));
             if (timeZone == null) throw new ArgumentNullException(nameof(timeZone));
-            if (queue == null) throw new ArgumentNullException(nameof(queue));
+
+            if (queue != null)
+            {
+                job.OverrideQueueName(queue);
+            }
 
             manager.AddOrUpdate(
                 recurringJobId,
                 job,
                 cronExpression,
-                new RecurringJobOptions { QueueName = queue, TimeZone = timeZone });
+                new RecurringJobOptions { TimeZone = timeZone });
         }
     }
 }

--- a/src/Hangfire.Core/RecurringJobOptions.cs
+++ b/src/Hangfire.Core/RecurringJobOptions.cs
@@ -28,7 +28,6 @@ namespace Hangfire
         public RecurringJobOptions()
         {
             TimeZone = TimeZoneInfo.Utc;
-            QueueName = EnqueuedState.DefaultQueue;
         }
 
         [NotNull]
@@ -43,6 +42,7 @@ namespace Hangfire
             }
         }
 
+        [Obsolete("This property is obsolete and should be removed in a future release.")]
         [NotNull]
         public string QueueName
         {

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -71,6 +71,7 @@ namespace Hangfire.Server
         private readonly IBackgroundJobFactory _factory;
         private readonly Func<CrontabSchedule, TimeZoneInfo, IScheduleInstant> _instantFactory;
         private readonly IThrottler _throttler;
+        private readonly string[] _queues;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecurringJobScheduler"/>
@@ -89,22 +90,33 @@ namespace Hangfire.Server
         /// 
         /// <exception cref="ArgumentNullException"><paramref name="factory"/> is null.</exception>
         public RecurringJobScheduler([NotNull] IBackgroundJobFactory factory)
-            : this(factory, ScheduleInstant.Factory, new EveryMinuteThrottler())
+            : this(factory, new string[] { EnqueuedState.DefaultQueue })
         {
         }
 
-        internal RecurringJobScheduler(
-            [NotNull] IBackgroundJobFactory factory,
-            [NotNull] Func<CrontabSchedule, TimeZoneInfo, IScheduleInstant> instantFactory,
-            [NotNull] IThrottler throttler)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RecurringJobScheduler"/>
+        /// class with custom background job factory and isolates scheduling to an array of queues.
+        /// </summary>
+        /// <param name="factory">Factory that will be used to create background jobs.</param>
+        /// <param name="queues">The queues that the scheduler will create jobs for.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="factory"/> is null.</exception>
+        public RecurringJobScheduler([NotNull] IBackgroundJobFactory factory, [NotNull] params string[] queues)
+            : this(factory, ScheduleInstant.Factory, new EveryMinuteThrottler(), queues)
+        {
+        }
+
+        internal RecurringJobScheduler([NotNull] IBackgroundJobFactory factory, [NotNull] Func<CrontabSchedule, TimeZoneInfo, IScheduleInstant> instantFactory, [NotNull] IThrottler throttler, params string[] queues)
         {
             if (factory == null) throw new ArgumentNullException(nameof(factory));
             if (instantFactory == null) throw new ArgumentNullException(nameof(instantFactory));
             if (throttler == null) throw new ArgumentNullException(nameof(throttler));
-            
+            if (queues == null) throw new ArgumentNullException(nameof(queues));
+
             _factory = factory;
             _instantFactory = instantFactory;
             _throttler = throttler;
+            _queues = queues;
         }
 
         /// <inheritdoc />
@@ -114,35 +126,43 @@ namespace Hangfire.Server
 
             _throttler.Throttle(context.CancellationToken);
 
-            using (var connection = context.Storage.GetConnection())
-            using (connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout))
+            foreach (var queueName in _queues)
             {
-                var recurringJobIds = connection.GetAllItemsFromSet("recurring-jobs");
-
-                foreach (var recurringJobId in recurringJobIds)
+                using (var connection = context.Storage.GetConnection())
+                using (connection.AcquireDistributedLock($"recurring-jobs:lock:{ queueName }", LockTimeout))
                 {
-                    var recurringJob = connection.GetAllEntriesFromHash(
-                        $"recurring-job:{recurringJobId}");
+                    ScheduleJobsForQueue(context, queueName, connection);
+                }
+            }
+        }
 
-                    if (recurringJob == null)
-                    {
-                        continue;
-                    }
+        private void ScheduleJobsForQueue(BackgroundProcessContext context, string queueName, IStorageConnection connection)
+        {
+            var recurringJobIds = connection.GetAllItemsFromSetQueue("recurring-jobs", queueName);
 
-                    try
-                    {
-                        TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob);
-                    }
-                    catch (JobLoadException ex)
-                    {
-                        Logger.WarnException(
-                            $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
-                            ex);
-                    }
+            foreach (var recurringJobId in recurringJobIds)
+            {
+                var recurringJob = connection.GetAllEntriesFromHash(
+                    $"recurring-job:{recurringJobId}");
+
+                if (recurringJob == null)
+                {
+                    continue;
                 }
 
-                _throttler.Delay(context.CancellationToken);
+                try
+                {
+                    TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob, queueName);
+                }
+                catch (JobLoadException ex)
+                {
+                    Logger.WarnException(
+                        $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
+                        ex);
+                }
             }
+
+            _throttler.Delay(context.CancellationToken);
         }
 
         /// <inheritdoc />
@@ -155,7 +175,8 @@ namespace Hangfire.Server
             JobStorage storage,
             IStorageConnection connection, 
             string recurringJobId, 
-            IReadOnlyDictionary<string, string> recurringJob)
+            IReadOnlyDictionary<string, string> recurringJob,
+            string queueName)
         {
             var serializedJob = JobHelper.FromJson<InvocationData>(recurringJob["Job"]);
             var job = serializedJob.Deserialize();
@@ -175,11 +196,7 @@ namespace Hangfire.Server
                 
                 if (nowInstant.GetNextInstants(lastInstant).Any())
                 {
-                    var state = new EnqueuedState { Reason = "Triggered by recurring job scheduler" };
-                    if (recurringJob.ContainsKey("Queue") && !String.IsNullOrEmpty(recurringJob["Queue"]))
-                    {
-                        state.Queue = recurringJob["Queue"];
-                    }
+                    var state = new EnqueuedState (queueName) { Reason = "Triggered by recurring job scheduler" };
 
                     var context = new CreateContext(storage, connection, job, state);
                     context.Parameters["RecurringJobId"] = recurringJobId;

--- a/src/Hangfire.Core/States/ScheduledState.cs
+++ b/src/Hangfire.Core/States/ScheduledState.cs
@@ -66,8 +66,9 @@ namespace Hangfire.States
         /// </summary>
         /// <param name="enqueueIn">The time interval after which a job will be
         /// moved to the <see cref="EnqueuedState"/>.</param>
-        public ScheduledState(TimeSpan enqueueIn)
-            : this(DateTime.UtcNow.Add(enqueueIn))
+        /// <param name="queueName">The queue that the job should be scheduled for</param>
+        public ScheduledState(TimeSpan enqueueIn, string queueName)
+            : this(DateTime.UtcNow.Add(enqueueIn), queueName)
         {
         }
 
@@ -78,11 +79,13 @@ namespace Hangfire.States
         /// </summary>
         /// <param name="enqueueAt">The date/time when a job will be moved to the 
         /// <see cref="EnqueuedState"/>.</param>
+        /// <param name="queueName">The queue that the job should be scheduled for</param>
         [JsonConstructor]
-        public ScheduledState(DateTime enqueueAt)
+        public ScheduledState(DateTime enqueueAt, string queueName)
         {
             EnqueueAt = enqueueAt;
             ScheduledAt = DateTime.UtcNow;
+            QueueName = queueName;
         }
 
         /// <summary>
@@ -95,6 +98,11 @@ namespace Hangfire.States
         /// Gets a date/time when the current state instance was created.
         /// </summary>
         public DateTime ScheduledAt { get; }
+
+        /// <summary>
+        /// Gets a the queue that the job will be assigned to.
+        /// </summary>
+        public string QueueName { get; }
 
         /// <inheritdoc />
         /// <remarks>
@@ -172,11 +180,19 @@ namespace Hangfire.States
 
                 var timestamp = JobHelper.ToTimestamp(scheduledState.EnqueueAt);
                 transaction.AddToSet("schedule", context.BackgroundJob.Id, timestamp);
+
+                var hash = new Dictionary<string, string>()
+                {
+                    { "Queue", scheduledState.QueueName }
+                };
+
+                transaction.SetRangeInHash($"scheduled-job:{context.BackgroundJob.Id}", hash);
             }
 
             public void Unapply(ApplyStateContext context, IWriteOnlyTransaction transaction)
             {
                 transaction.RemoveFromSet("schedule", context.BackgroundJob.Id);
+                transaction.RemoveHash($"scheduled-job:{context.BackgroundJob.Id}");
             }
 
             // ReSharper disable once MemberHidesStaticFromOuterClass

--- a/src/Hangfire.Core/Storage/IStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/IStorageConnection.cs
@@ -55,7 +55,11 @@ namespace Hangfire.Storage
         [NotNull]
         HashSet<string> GetAllItemsFromSet([NotNull] string key);
 
+        HashSet<string> GetAllItemsFromSetQueue([NotNull] string key, [NotNull] string queueName);
+
         string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
+
+        Dictionary<string, double> GetAllValuesWithScoresFromSetQueueWithinScoreRange(string key, string queueName, double fromScore, double toScore);
 
         // Hash operations
 

--- a/src/Hangfire.Core/Storage/IWriteOnlyTransaction.cs
+++ b/src/Hangfire.Core/Storage/IWriteOnlyTransaction.cs
@@ -41,6 +41,8 @@ namespace Hangfire.Storage
         // Set operations
         void AddToSet([NotNull] string key, [NotNull] string value);
         void AddToSet([NotNull] string key, [NotNull] string value, double score);
+        void AddToSetQueue([NotNull] string key, [NotNull] string value, [NotNull] string queueName);
+        void AddToSetQueue([NotNull] string key, [NotNull] string value, [NotNull] string queueName, double score);
         void RemoveFromSet([NotNull] string key, [NotNull] string value);
 
         // List operations

--- a/src/Hangfire.Core/Storage/JobStorageConnection.cs
+++ b/src/Hangfire.Core/Storage/JobStorageConnection.cs
@@ -49,7 +49,10 @@ namespace Hangfire.Storage
 
         // Sets
         public abstract HashSet<string> GetAllItemsFromSet(string key);
+        public abstract HashSet<string> GetAllItemsFromSetQueue(string key, string queueName);
+
         public abstract string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore);
+        public abstract Dictionary<string, double> GetAllValuesWithScoresFromSetQueueWithinScoreRange(string key, string queueName, double fromScore, double toScore);
 
         public virtual long GetSetCount([NotNull] string key)
         {

--- a/src/Hangfire.Core/Storage/JobStorageTransaction.cs
+++ b/src/Hangfire.Core/Storage/JobStorageTransaction.cs
@@ -38,6 +38,9 @@ namespace Hangfire.Storage
         public abstract void DecrementCounter(string key, TimeSpan expireIn);
         public abstract void AddToSet(string key, string value);
         public abstract void AddToSet(string key, string value, double score);
+        public abstract void AddToSetQueue(string key, string value, string queueName);
+        public abstract void AddToSetQueue(string key, string value, string queueName, double score);
+
         public abstract void RemoveFromSet(string key, string value);
         public abstract void InsertToList(string key, string value);
         public abstract void RemoveFromList(string key, string value);

--- a/src/Hangfire.SqlServer/Entities/SqlSet.cs
+++ b/src/Hangfire.SqlServer/Entities/SqlSet.cs
@@ -1,0 +1,29 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2013-2014 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Hangfire.SqlServer.Entities
+{
+    internal class SqlSet
+    {
+        public int Id { get; set; }
+        public string Key { get; set; }
+        public double Score { get; set; }
+        public string Value { get; set; }
+        public DateTime? ExpireAt { get; set; }
+    }
+}

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CountersAggregator.cs" />
     <Compile Include="EnqueuedAndFetchedCountDto.cs" />
     <Compile Include="Entities\SqlHash.cs" />
+    <Compile Include="Entities\SqlSet.cs" />
     <Compile Include="ExpirationManager.cs" />
     <Compile Include="Entities\JobParameter.cs" />
     <Compile Include="Entities\SqlJob.cs" />

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -16,7 +16,7 @@
 
 SET NOCOUNT ON
 DECLARE @TARGET_SCHEMA_VERSION INT;
-SET @TARGET_SCHEMA_VERSION = 5;
+SET @TARGET_SCHEMA_VERSION = 6;
 
 PRINT 'Installing Hangfire SQL objects...';
 
@@ -380,13 +380,24 @@ BEGIN
 	SET @CURRENT_SCHEMA_VERSION = 5;
 END
 	
-/*IF @CURRENT_SCHEMA_VERSION = 5
+IF @CURRENT_SCHEMA_VERSION = 5
 BEGIN
 	PRINT 'Installing schema version 6';
 
-	-- Insert migration here
+	ALTER TABLE [$(HangFireSchema)].[Set]
+	ADD QueueName NVARCHAR(100) NULL;
 
 	SET @CURRENT_SCHEMA_VERSION = 6;
+END
+
+
+/*IF @CURRENT_SCHEMA_VERSION = 6
+BEGIN
+	PRINT 'Installing schema version 7';
+
+	-- Insert migration here
+
+	SET @CURRENT_SCHEMA_VERSION = 7;
 END*/
 
 UPDATE [$(HangFireSchema)].[Schema] SET [Version] = @CURRENT_SCHEMA_VERSION

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -233,6 +233,21 @@ when not matched then insert (JobId, Name, Value) values (Source.JobId, Source.N
             });
         }
 
+        public override HashSet<string> GetAllItemsFromSetQueue(string key, string queueName)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (queueName == null) throw new ArgumentNullException(nameof(queueName));
+
+            return _storage.UseConnection(connection =>
+            {
+                var result = connection.Query<string>(
+                    $@"select Value from [{_storage.SchemaName}].[Set] with (readcommittedlock) where [Key] = @key AND QueueName = @queueName",
+                    new { key, queueName });
+
+                return new HashSet<string>(result);
+            });
+        }
+
         public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
@@ -485,6 +500,27 @@ where [Key] = @key
 order by [Id] desc";
 
             return _storage.UseConnection(connection => connection.Query<string>(query, new { key = key }).ToList());
+        }
+
+        public override Dictionary<string, double> GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+            string key, 
+            string queueName, 
+            double fromScore, 
+            double toScore)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (queueName == null) throw new ArgumentNullException(nameof(queueName));
+            if (toScore < fromScore) throw new ArgumentException("The `toScore` value must be higher or equal to the `fromScore` value.");
+
+            return _storage.UseConnection(connection =>
+            {
+                var result = connection.Query<SqlSet>(
+                    $"select Value, Score from [{_storage.SchemaName}].[Set] with (readcommittedlock) where [Key] = @key and QueueName = @queueName and Score between @from and @to",
+                    new { key, queueName, from = fromScore, to = toScore })
+                    .ToDictionary(x => x.Value, x => x.Score);
+
+                return result.Count != 0 ? result : null;
+            });
         }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -26,7 +26,7 @@ namespace Hangfire.SqlServer
 {
     public static class SqlServerObjectsInstaller
     {
-        public static readonly int RequiredSchemaVersion = 5;
+        public static readonly int RequiredSchemaVersion = 6;
         private const int RetryAttempts = 3;
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(SqlServerStorage));
@@ -51,7 +51,7 @@ namespace Hangfire.SqlServer
                 typeof(SqlServerObjectsInstaller).GetTypeInfo().Assembly, 
                 "Hangfire.SqlServer.Install.sql");
 
-            script = script.Replace("SET @TARGET_SCHEMA_VERSION = 5;", "SET @TARGET_SCHEMA_VERSION = " + RequiredSchemaVersion + ";");
+            script = script.Replace("SET @TARGET_SCHEMA_VERSION = 6;", "SET @TARGET_SCHEMA_VERSION = " + RequiredSchemaVersion + ";");
 
             script = script.Replace("$(HangFireSchema)", !string.IsNullOrWhiteSpace(schema) ? schema : Constants.DefaultSchema);
 

--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -200,6 +200,27 @@ when not matched then insert ([Key], Value, Score) values (Source.[Key], Source.
                 transaction));
         }
 
+        public override void AddToSetQueue(string key, string value, string queueName)
+        {
+            AddToSetQueue(key, value, queueName, 0.0);
+        }
+
+        public override void AddToSetQueue(string key, string value, string queueName, double score)
+        {
+            string addSql =
+$@";merge [{_storage.SchemaName}].[Set] with (holdlock) as Target
+using (VALUES (@key, @value, @score, @queueName)) as Source ([Key], Value, Score, QueueName)
+on Target.[Key] = Source.[Key] and Target.Value = Source.Value
+when matched then update set Score = Source.Score, QueueName = Source.QueueName
+when not matched then insert ([Key], Value, Score, QueueName) values (Source.[Key], Source.Value, Source.Score, Source.QueueName);";
+
+            AcquireSetLock();
+            QueueCommand((connection, transaction) => connection.Execute(
+                addSql,
+                new { key, value, score, queueName },
+                transaction));
+        }
+
         public override void RemoveFromSet(string key, string value)
         {
             string query = $@"delete from [{_storage.SchemaName}].[Set] where [Key] = @key and Value = @value";

--- a/tests/Hangfire.Core.Tests/QueueAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/QueueAttributeFacts.cs
@@ -22,27 +22,5 @@ namespace Hangfire.Core.Tests
             var filter = new QueueAttribute("hello");
             Assert.Equal("hello", filter.Queue);
         }
-
-        [Fact]
-        public void OnStateElection_OverridesTheQueue_OfTheCandidateState()
-        {
-            var filter = new QueueAttribute("override");
-            filter.OnStateElection(_context.Object);
-
-            Assert.Equal("override", ((EnqueuedState)_context.Object.CandidateState).Queue);
-        }
-
-        [Fact]
-        public void OnStateElection_DoesNotDoAnything_IfStateIsNotEnqueuedState()
-        {
-            var filter = new QueueAttribute("override");
-            var context = new ElectStateContextMock
-            {
-                ApplyContext = { NewState = new Mock<IState>() }
-            };
-
-            // Does not throw
-            filter.OnStateElection(context.Object);
-        }
     }
 }

--- a/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
+++ b/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
@@ -75,17 +75,6 @@ namespace Hangfire.Core.Tests
 
             Assert.Equal("job", exception.ParamName);
         }
-
-        [Fact]
-        public void AddOrUpdate_ThrowsAnException_WhenQueueNameIsNull()
-        {
-            var manager = CreateManager();
-
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => manager.AddOrUpdate(_id, _job, Cron.Daily(), TimeZoneInfo.Local, null));
-
-            Assert.Equal("queue", exception.ParamName);
-        }
         
         [Fact]
         public void AddOrUpdate_ThrowsAnException_WhenCronExpressionIsNull()
@@ -143,24 +132,13 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
-        public void AddOrUpdate_ThrowsAnException_WhenQueueIsNull()
-        {
-            var manager = CreateManager();
-
-            var exception = Assert.Throws<ArgumentNullException>(
-                () => manager.AddOrUpdate(_id, _job, _cronExpression, TimeZoneInfo.Utc, null));
-
-            Assert.Equal("queue", exception.ParamName);
-        }
-
-        [Fact]
         public void AddOrUpdate_AddsAJob_ToTheRecurringJobsSet()
         {
             var manager = CreateManager();
 
             manager.AddOrUpdate(_id, _job, _cronExpression);
 
-            _transaction.Verify(x => x.AddToSet("recurring-jobs", _id));
+            _transaction.Verify(x => x.AddToSetQueue("recurring-jobs", _id, _job.QueueName));
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/RecurringJobOptionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/RecurringJobOptionsFacts.cs
@@ -13,7 +13,6 @@ namespace Hangfire.Core.Tests
             var options = new RecurringJobOptions();
 
             Assert.Equal(TimeZoneInfo.Utc, options.TimeZone);
-            Assert.Equal("default", options.QueueName);
         }
 
         [Fact]
@@ -22,25 +21,6 @@ namespace Hangfire.Core.Tests
             var options = new RecurringJobOptions();
 
             Assert.Throws<ArgumentNullException>(() => options.TimeZone = null);
-        }
-
-        [Fact]
-        public void SetQueueName_ThrowsAnException_WhenValueIsNull()
-        {
-            var options = new RecurringJobOptions();
-
-            Assert.Throws<ArgumentNullException>(() => options.QueueName = null);
-        }
-
-        [Fact]
-        public void SetQueueName_ThrowsAnException_WhenQueueNameHasInvalidFormat()
-        {
-            var options = new RecurringJobOptions();
-
-            var exception = Assert.Throws<ArgumentException>(
-                () => options.QueueName = "UPPER_CASE");
-
-            Assert.Equal("value", exception.ParamName);
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
@@ -63,6 +63,7 @@ namespace Hangfire.Core.Tests
 
             Assert.IsType<ScheduledState>(_context.Object.CandidateState);
             Assert.True(((ScheduledState)_context.Object.CandidateState).EnqueueAt > DateTime.UtcNow);
+            Assert.True(((ScheduledState)_context.Object.CandidateState).QueueName == "default");
             Assert.Contains("1 of 1", _context.Object.CandidateState.Reason);
 
             _connection.Verify(x => x.SetJobParameter(JobId, "RetryCount", "1"));
@@ -127,7 +128,7 @@ namespace Hangfire.Core.Tests
 
         private static AutomaticRetryAttribute CreateFilter()
         {
-            return new AutomaticRetryAttribute { Attempts = 1 };
+            return new AutomaticRetryAttribute() { Attempts = 1 };
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Hangfire.Server;
 using Hangfire.States;
@@ -19,6 +21,8 @@ namespace Hangfire.Core.Tests.Server
         private readonly BackgroundProcessContextMock _context;
         private readonly Mock<IWriteOnlyTransaction> _transaction;
         private readonly Mock<IDisposable> _distributedLock;
+        private readonly string[] _queues;
+        private readonly Dictionary<string, double> _jobSet;
 
         public DelayedJobSchedulerFacts()
         {
@@ -33,12 +37,16 @@ namespace Hangfire.Core.Tests.Server
             _connection.Setup(x => x.CreateWriteTransaction()).Returns(_transaction.Object);
 
             _distributedLock = new Mock<IDisposable>();
-            _connection
-                .Setup(x => x.AcquireDistributedLock("locks:schedulepoller", It.IsAny<TimeSpan>()))
-                .Returns(_distributedLock.Object);
 
-            _connection.Setup(x => x.GetFirstByLowestScoreFromSet(
-                "schedule", 0, It.Is<double>(time => time > 0))).Returns(JobId);
+            _jobSet = new Dictionary<string, double>()
+            {
+                { JobId, 1 }
+            };
+
+            _connection.Setup(x => x.GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+                "schedule", "default", 0, It.Is<double>(time => time > 0))).Returns(_jobSet);
+
+            _queues = new[] { EnqueuedState.DefaultQueue };
         }
 
         [Fact]
@@ -51,7 +59,16 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
-        public void Execute_MovesJobStateToEnqueued()
+        public void Ctor_ThrowsAnException_WhenQueuesIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new DelayedJobScheduler(Timeout.InfiniteTimeSpan, _stateChanger.Object, null));
+
+            Assert.Equal("queues", exception.ParamName);
+        }
+
+        [Fact]
+        public void Execute_MovesJobStateToEnqueued_InDefaultQueue()
         {
             var scheduler = CreateScheduler();
 
@@ -60,16 +77,51 @@ namespace Hangfire.Core.Tests.Server
             _stateChanger.Verify(x => x.ChangeState(It.Is<StateChangeContext>(ctx =>
                 ctx.BackgroundJobId == JobId &&
                 ctx.NewState is EnqueuedState &&
+                ((EnqueuedState)ctx.NewState).Queue == EnqueuedState.DefaultQueue &&
                 ctx.ExpectedStates.SequenceEqual(new[] { ScheduledState.StateName }))));
 
             _connection.Verify(x => x.Dispose());
         }
 
         [Fact]
+        public void Execute_MovesJobStateToEnqueued_InCustomQueue()
+        {
+            _connection.Setup(x => x.GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+                "schedule", "custom_queue", 0, It.Is<double>(time => time > 0))).Returns(_jobSet);
+            var scheduler = CreateScheduler("custom_queue");
+
+            scheduler.Execute(_context.Object);
+
+            _stateChanger.Verify(x => x.ChangeState(It.Is<StateChangeContext>(ctx =>
+                ctx.BackgroundJobId == JobId &&
+                ctx.NewState is EnqueuedState &&
+                ((EnqueuedState)ctx.NewState).Queue == "custom_queue" &&
+                ctx.ExpectedStates.SequenceEqual(new[] { ScheduledState.StateName }))));
+
+            _connection.Verify(x => x.Dispose());
+        }
+
+        [Fact]
+        public void Execute_DoesNotCallStateChanger_ForJobsNotInDesignatedQueues()
+        {
+            _connection.Setup(x => x.GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+                "schedule", "default", 0, It.Is<double>(time => time > 0))).Returns((Dictionary<string, double>) null);
+
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+
+            _stateChanger.Verify(
+                x => x.ChangeState(It.IsAny<StateChangeContext>()),
+                Times.Never);
+        }
+
+        [Fact]
         public void Execute_DoesNotCallStateChanger_IfThereAreNoJobsToEnqueue()
         {
-            _connection.Setup(x => x.GetFirstByLowestScoreFromSet(
-                "schedule", 0, It.Is<double>(time => time > 0))).Returns((string)null);
+            _connection.Setup(x => x.GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+                "schedule", It.IsAny<string>(), 0, It.Is<double>(time => time > 0))).Returns((Dictionary<string, double>)null);
+
             var scheduler = CreateScheduler();
 
 			scheduler.Execute(_context.Object);
@@ -105,9 +157,19 @@ namespace Hangfire.Core.Tests.Server
             _distributedLock.Verify(x => x.Dispose());
         }
 
-        private DelayedJobScheduler CreateScheduler()
+        private DelayedJobScheduler CreateScheduler(params string[] additionalQueues)
         {
-            return new DelayedJobScheduler(Timeout.InfiniteTimeSpan, _stateChanger.Object);
+            var queues = new List<string> { EnqueuedState.DefaultQueue };
+            queues.AddRange(additionalQueues);
+
+            foreach (string queueName in queues)
+            {
+                _connection
+                    .Setup(x => x.AcquireDistributedLock($"locks:schedulepoller:{ queueName }", It.IsAny<TimeSpan>()))
+                    .Returns(_distributedLock.Object);
+            }
+
+            return new DelayedJobScheduler(Timeout.InfiniteTimeSpan, _stateChanger.Object, queues.ToArray());
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
@@ -24,6 +24,7 @@ namespace Hangfire.Core.Tests.Server
         private readonly BackgroundProcessContextMock _context;
         private readonly Mock<IBackgroundJobFactory> _factory;
         private readonly BackgroundJobMock _backgroundJobMock;
+        private readonly string[] _queues;
 
         public RecurringJobSchedulerFacts()
         {
@@ -45,14 +46,12 @@ namespace Hangfire.Core.Tests.Server
             {
                 { "Cron", "* * * * *" },
                 { "Job", JobHelper.ToJson(InvocationData.Serialize(Job.FromExpression(() => Console.WriteLine()))) },
-                { "TimeZoneId", timeZone1.Id }
+                { "TimeZoneId", timeZone1.Id },
+                { "Queue", EnqueuedState.DefaultQueue }
             };
 
             _connection = new Mock<IStorageConnection>();
             _context.Storage.Setup(x => x.GetConnection()).Returns(_connection.Object);
-
-            _connection.Setup(x => x.GetAllItemsFromSet("recurring-jobs"))
-                .Returns(new HashSet<string> { RecurringJobId });
 
             _connection.Setup(x => x.GetAllEntriesFromHash($"recurring-job:{RecurringJobId}"))
                 .Returns(_recurringJob);
@@ -61,6 +60,8 @@ namespace Hangfire.Core.Tests.Server
 
             _factory = new Mock<IBackgroundJobFactory>();
             _factory.Setup(x => x.Create(It.IsAny<CreateContext>())).Returns(_backgroundJobMock.Object);
+
+            _queues = new string[] { EnqueuedState.DefaultQueue };
         }
 
         [Fact]
@@ -68,7 +69,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
 // ReSharper disable once AssignNullToNotNullAttribute
-                () => new RecurringJobScheduler(null, _instantFactory, _throttler.Object));
+                () => new RecurringJobScheduler(null, _instantFactory, _throttler.Object, _queues));
 
             Assert.Equal("factory", exception.ParamName);
         }
@@ -78,7 +79,7 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
 // ReSharper disable once AssignNullToNotNullAttribute
-                () => new RecurringJobScheduler(_factory.Object, null, _throttler.Object));
+                () => new RecurringJobScheduler(_factory.Object, null, _throttler.Object, _queues));
 
             Assert.Equal("instantFactory", exception.ParamName);
         }
@@ -88,9 +89,19 @@ namespace Hangfire.Core.Tests.Server
         {
             var exception = Assert.Throws<ArgumentNullException>(
 // ReSharper disable once AssignNullToNotNullAttribute
-                () => new RecurringJobScheduler(_factory.Object, _instantFactory, null));
+                () => new RecurringJobScheduler(_factory.Object, _instantFactory, null, _queues));
 
             Assert.Equal("throttler", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenQueuesIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                // ReSharper disable once AssignNullToNotNullAttribute
+                () => new RecurringJobScheduler(_factory.Object, _instantFactory, _throttler.Object, null));
+
+            Assert.Equal("queues", exception.ParamName);
         }
 
         [Fact]
@@ -106,13 +117,23 @@ namespace Hangfire.Core.Tests.Server
         [Fact]
         public void Execute_EnqueuesAJobToAGivenQueue_WhenItIsTimeToRunIt()
         {
-            _recurringJob["Queue"] = "critical";
-            var scheduler = CreateScheduler();
+            var scheduler = CreateScheduler("critical");
 
             scheduler.Execute(_context.Object);
 
             _factory.Verify(x => x.Create(
                 It.Is<CreateContext>(cc => ((EnqueuedState)cc.InitialState).Queue == "critical")));
+        }
+
+        [Fact]
+        public void Execute_DoesNotEnqueueAJobBelongingToAnotherQueue_WhenItIsTimeToRunIt()
+        {
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+            
+            _factory.Verify(x => x.Create(
+                It.Is<CreateContext>(cc => ((EnqueuedState)cc.InitialState).Queue == "bad_queue")), Times.Never());
         }
 
         [Fact]
@@ -314,12 +335,18 @@ namespace Hangfire.Core.Tests.Server
                 It.Is<DateTime>(time => time < nextExecution)));
         }
 
-        private RecurringJobScheduler CreateScheduler()
+        private RecurringJobScheduler CreateScheduler(params string[] additionalQueues)
         {
+            var queues = new List<string> { EnqueuedState.DefaultQueue };
+            queues.AddRange(additionalQueues);
+            
+            _connection.Setup(x => x.GetAllItemsFromSetQueue("recurring-jobs", It.IsIn<string>(queues)))
+                    .Returns(new HashSet<string> { RecurringJobId });
+
             return new RecurringJobScheduler(
                 _factory.Object,
                 _instantFactory,
-                _throttler.Object);
+                _throttler.Object, queues.ToArray());
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/States/ScheduledStateFacts.cs
+++ b/tests/Hangfire.Core.Tests/States/ScheduledStateFacts.cs
@@ -10,7 +10,7 @@ namespace Hangfire.Core.Tests.States
         [Fact]
         public void StateName_IsCorrect()
         {
-            var state = new ScheduledState(DateTime.UtcNow);
+            var state = new ScheduledState(DateTime.UtcNow, EnqueuedState.DefaultQueue);
             Assert.Equal(ScheduledState.StateName, state.Name);
         }
 
@@ -18,22 +18,29 @@ namespace Hangfire.Core.Tests.States
         public void Ctor_SetsTheCorrectData_WhenDateIsPassed()
         {
             var date = new DateTime(2012, 12, 12);
-            var state = new ScheduledState(date);
+            var state = new ScheduledState(date, EnqueuedState.DefaultQueue);
             Assert.Equal(date, state.EnqueueAt);
         }
 
         [Fact]
         public void Ctor_SetsTheCorrectDate_WhenTimeSpanIsPassed()
         {
-            var state = new ScheduledState(TimeSpan.FromDays(1));
+            var state = new ScheduledState(TimeSpan.FromDays(1), EnqueuedState.DefaultQueue);
             Assert.True(DateTime.UtcNow.AddDays(1).AddMinutes(-1) < state.EnqueueAt);
             Assert.True(state.EnqueueAt < DateTime.UtcNow.AddDays(1).AddMinutes(1));
         }
 
         [Fact]
+        public void Ctor_SetsTheCorrectQueue_WhenProvided()
+        {
+            var state = new ScheduledState(TimeSpan.FromDays(1), "queue_name");
+            Assert.True(state.QueueName == "queue_name");
+        }
+
+        [Fact]
         public void SerializeData_ReturnsCorrectData()
         {
-            var state = new ScheduledState(new DateTime(2012, 12, 12));
+            var state = new ScheduledState(new DateTime(2012, 12, 12), EnqueuedState.DefaultQueue);
 
             var data = state.SerializeData();
 
@@ -44,7 +51,7 @@ namespace Hangfire.Core.Tests.States
         [Fact]
         public void IsFinal_ReturnsFalse()
         {
-            var state = new ScheduledState(DateTime.UtcNow);
+            var state = new ScheduledState(DateTime.UtcNow, EnqueuedState.DefaultQueue);
 
             Assert.False(state.IsFinal);
         }
@@ -52,7 +59,7 @@ namespace Hangfire.Core.Tests.States
         [Fact]
         public void IgnoreExceptions_ReturnsFalse()
         {
-            var state = new ScheduledState(DateTime.UtcNow);
+            var state = new ScheduledState(DateTime.UtcNow, EnqueuedState.DefaultQueue);
             Assert.False(state.IgnoreJobLoadException);
         }
     }

--- a/tests/Hangfire.Core.Tests/States/ScheduledStateHandlerFacts.cs
+++ b/tests/Hangfire.Core.Tests/States/ScheduledStateHandlerFacts.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
@@ -20,7 +22,7 @@ namespace Hangfire.Core.Tests.States
             _context = new ApplyStateContextMock
             {
                 BackgroundJob = { Id = JobId },
-                NewStateObject = new ScheduledState(_enqueueAt)
+                NewStateObject = new ScheduledState(_enqueueAt, "new_queue")
             };
 
             _transaction = new Mock<IWriteOnlyTransaction>();
@@ -34,22 +36,28 @@ namespace Hangfire.Core.Tests.States
         }
 
         [Fact]
-        public void Apply_ShouldAddTheJob_ToTheScheduleSet_WithTheCorrectScore()
+        public void Apply_ShouldAddTheJob_ToTheScheduleSet_WithTheCorrectScore_AndInTheRightQueue()
         {
             var handler = new ScheduledState.Handler();
             handler.Apply(_context.Object, _transaction.Object);
 
             _transaction.Verify(x => x.AddToSet(
                 "schedule", JobId, JobHelper.ToTimestamp(_enqueueAt)));
+
+            _transaction.Verify(x => x.SetRangeInHash(
+                It.Is<string>(keyName => keyName == $"scheduled-job:{JobId}"),
+                It.Is<Dictionary<string, string>>(
+                    hash => hash.ContainsKey("Queue") && hash["Queue"] == "new_queue")));
         }
 
         [Fact]
-        public void Unapply_ShouldRemoveTheJob_FromTheScheduledSet()
+        public void Unapply_ShouldRemoveTheJob_FromTheScheduledSetAndHash()
         {
             var handler = new ScheduledState.Handler();
             handler.Unapply(_context.Object, _transaction.Object);
 
             _transaction.Verify(x => x.RemoveFromSet("schedule", JobId));
+            _transaction.Verify(x => x.RemoveHash($"scheduled-job:{JobId}"));
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -20,19 +20,21 @@ namespace Hangfire.Core.Tests.Storage
                 type.AssemblyQualifiedName,
                 methodInfo.Name,
                 JobHelper.ToJson(new [] { typeof(string) }),
-                JobHelper.ToJson(new [] { JobHelper.ToJson("Hello") }));
+                JobHelper.ToJson(new [] { JobHelper.ToJson("Hello") }),
+                "custom_queue");
 
             var job = serializedData.Deserialize();
 
             Assert.Equal(type, job.Type);
             Assert.Equal(methodInfo, job.Method);
             Assert.Equal("Hello", job.Args[0]);
+            Assert.Equal("custom_queue", job.QueueName);
         }
 
         [Fact]
         public void Deserialize_WrapsAnException_WithTheJobLoadException()
         {
-            var serializedData = new InvocationData(null, null, null, null);
+            var serializedData = new InvocationData(null, null, null, null, null);
 
             Assert.Throws<JobLoadException>(
                 () => serializedData.Deserialize());
@@ -65,6 +67,23 @@ namespace Hangfire.Core.Tests.Storage
         }
 
         [Fact]
+        public void Deserialize_ThrowsAnException_WhenQueueNameIsNull()
+        {
+            var type = typeof(InvocationDataFacts);
+            var methodInfo = type.GetMethod("Sample");
+
+            var serializedData = new InvocationData(
+                type.AssemblyQualifiedName,
+                methodInfo.Name,
+                JobHelper.ToJson(new[] { typeof(string) }),
+                JobHelper.ToJson(new[] { JobHelper.ToJson("Hello") }),
+                null);
+            
+            Assert.Throws<JobLoadException>(
+                () => serializedData.Deserialize());
+        }
+
+        [Fact]
         public void Serialize_CorrectlySerializesTheData()
         {
             var job = Job.FromExpression(() => Sample("Hello"));
@@ -75,6 +94,7 @@ namespace Hangfire.Core.Tests.Storage
             Assert.Equal("Sample", invocationData.Method);
             Assert.Equal(JobHelper.ToJson(new[] { typeof(string) }), invocationData.ParameterTypes);
             Assert.Equal(JobHelper.ToJson(new[] { "\"Hello\"" }), invocationData.Arguments);
+            Assert.Equal("custom_queue", invocationData.QueueName);
         }
 
         [Fact]
@@ -141,6 +161,7 @@ namespace Hangfire.Core.Tests.Storage
             Assert.IsType<JsonReaderException>(exception.InnerException);
         }
 
+        [Queue("custom_queue")]
         public static void Sample(string arg)
         {
         }

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Dapper;
 using Hangfire.Common;
 using Hangfire.Server;
+using Hangfire.States;
 using Hangfire.Storage;
 using Moq;
 using Xunit;
@@ -721,6 +722,72 @@ values (@key, 0.0, @value)";
         }
 
         [Fact, CleanDatabase]
+        public void GetAllItemsFromSetQueue_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+                Assert.Throws<ArgumentNullException>(() => connection.GetAllItemsFromSetQueue(null, "default")));
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSetQueue_ThrowsAnException_WhenQueueNameIsNull()
+        {
+            UseConnection(connection =>
+                Assert.Throws<ArgumentNullException>(() => connection.GetAllItemsFromSetQueue("some-set", null)));
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSetQueue_ReturnsEmptyCollection_WhenKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllItemsFromSetQueue("some-set", "default");
+
+                Assert.NotNull(result);
+                Assert.Equal(0, result.Count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSetQueue_ReturnsEmptyCollection_WhenQueueDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllItemsFromSetQueue("some-set", "default");
+
+                Assert.NotNull(result);
+                Assert.Equal(0, result.Count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSetQueue_ReturnsAllItems()
+        {
+            const string arrangeSql = @"
+insert into HangFire.[Set] ([Key], Score, Value, QueueName)
+values (@key, 0.0, @value, @queueName)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "some-set", value = "1", queueName = "my_queue" },
+                    new { key = "some-set", value = "2", queueName = "my_queue" },
+                    new { key = "another-set", value = "3", queueName = "my_queue" },
+                    new { key = "some-set", value = "4", queueName = "not_my_queue" }
+                });
+
+                // Act
+                var result = connection.GetAllItemsFromSetQueue("some-set", "my_queue");
+
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Contains("1", result);
+                Assert.Contains("2", result);
+            });
+        }
+
+        [Fact, CleanDatabase]
         public void SetRangeInHash_ThrowsAnException_WhenKeyIsNull()
         {
             UseConnection(connection =>
@@ -1327,6 +1394,74 @@ values (@key, @value, @expireAt, 0.0)";
                 // Assert
                 Assert.True(TimeSpan.FromMinutes(59) < result);
                 Assert.True(result < TimeSpan.FromMinutes(61));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllValuesWithScoresFromSetQueueWithinScoreRange_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetAllValuesWithScoresFromSetQueueWithinScoreRange(null, EnqueuedState.DefaultQueue, 0, 1));
+
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllValuesWithScoresFromSetQueueWithinScoreRange_ThrowsAnException_ToScoreIsLowerThanFromScore()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentException>(
+                () => connection.GetAllValuesWithScoresFromSetQueueWithinScoreRange("key", EnqueuedState.DefaultQueue, 0, -1)));
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllValuesWithScoresFromSetQueueWithinScoreRange_ThrowsAnException_WhenQueueNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetAllValuesWithScoresFromSetQueueWithinScoreRange("key", null, 0, 1));
+
+                Assert.Equal("queueName", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllValuesWithScoresFromSetQueueWithinScoreRange_ReturnsNull_WhenTheKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllValuesWithScoresFromSetQueueWithinScoreRange(
+                    "key", EnqueuedState.DefaultQueue, 0, 1);
+
+                Assert.Null(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllValuesWithScoresFromSetQueueWithinScoreRange_ReturnsTheValuesWithinTheScoreRange()
+        {
+            const string arrangeSql = @"
+insert into HangFire.[Set] ([Key], Score, Value, QueueName)
+values 
+('key', 1.0, '123', 'custom_queue'),
+('key', 1.0, '000', 'default'),
+('key', -1.0, '456', 'custom_queue'),
+('key', -5.0, '789', 'custom_queue'),
+('another-key', -2.0, '999', 'custom_queue')";
+
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql);
+
+                var result = connection.GetAllValuesWithScoresFromSetQueueWithinScoreRange("key", "custom_queue", -1.0, 3.0);
+
+                Assert.NotNull(result);
+                Assert.Equal(2, result.Count);
+                Assert.Equal(1.0, result["123"]);
+                Assert.Equal(-1.0, result["456"]);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -362,6 +362,106 @@ select scope_identity() as Id";
         }
 
         [Fact, CleanDatabase]
+        public void AddToSetQueue_AddsARecord_IfThereIsNo_SuchKeyAndValue()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x => x.AddToSetQueue("my-key", "my-value", "default"));
+
+                var record = sql.Query("select * from HangFire.[Set]").Single();
+
+                Assert.Equal("my-key", record.Key);
+                Assert.Equal("my-value", record.Value);
+                Assert.Equal(0.0, record.Score, 2);
+                Assert.Equal("default", record.QueueName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddToSetQueue_AddsARecord_WhenKeyIsExists_ButValuesAreDifferent()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x =>
+                {
+                    x.AddToSetQueue("my-key", "my-value", "default");
+                    x.AddToSetQueue("my-key", "another-value", "default");
+                });
+
+                var recordCount = sql.Query<int>("select count(*) from HangFire.[Set]").Single();
+
+                Assert.Equal(2, recordCount);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddToSetQueue_DoesNotAddARecord_WhenBothKeyAndValueAreExist()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x =>
+                {
+                    x.AddToSetQueue("my-key", "my-value", "default");
+                    x.AddToSetQueue("my-key", "my-value", "default");
+                });
+
+                var recordCount = sql.Query<int>("select count(*) from HangFire.[Set]").Single();
+
+                Assert.Equal(1, recordCount);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddToSetQueue_WithScore_AddsARecordWithScore_WhenBothKeyAndValueAreNotExist()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x => x.AddToSetQueue("my-key", "my-value", "default", 3.2));
+
+                var record = sql.Query("select * from HangFire.[Set]").Single();
+
+                Assert.Equal("my-key", record.Key);
+                Assert.Equal("my-value", record.Value);
+                Assert.Equal(3.2, record.Score, 3);
+                Assert.Equal("default", record.QueueName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddToSetQueue_WithScore_UpdatesAScore_WhenBothKeyAndValueAreExist()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x =>
+                {
+                    x.AddToSetQueue("my-key", "my-value", "default");
+                    x.AddToSetQueue("my-key", "my-value", "default", 3.2);
+                });
+
+                var record = sql.Query("select * from HangFire.[Set]").Single();
+
+                Assert.Equal(3.2, record.Score, 3);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddToSetQueue_WithScore_UpdatesAQueue_WhenBothKeyAndValueAreExist()
+        {
+            UseConnection(sql =>
+            {
+                Commit(sql, x =>
+                {
+                    x.AddToSetQueue("my-key", "my-value", "default");
+                    x.AddToSetQueue("my-key", "my-value", "not_default", 3.2);
+                });
+
+                var record = sql.Query("select * from HangFire.[Set]").Single();
+
+                Assert.Equal("not_default", record.QueueName);
+            });
+        }
+
+        [Fact, CleanDatabase]
         public void RemoveFromSet_RemovesARecord_WithGivenKeyAndValue()
         {
             UseConnection(sql =>


### PR DESCRIPTION
In working with this product in a distributed architecture, we have noticed our logs becomming inundated with job load exceptions from servers that are trying to schedule jobs when they do not have a reference to the assembly that contains the type that contains the job's logic.

This series of changes aims to isolate job scheduling such that servers only attempt to schedule or enqueue jobs that are assigned to a queue that the server is responsible for. Additionally, schedulers will now lock at the queue level which allows mutliple schedulers to run simultaneously so long as they are working from different queues.

None of these changes are breaking and can roll into any environment that is currently using the version that this change set was branched from. 