### PR TITLE
Use local time on Dashboard

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -70,9 +70,12 @@
         });
 
         if (xSettings) {
-            this._xAxis = new Rickshaw.Graph.Axis.Time($.extend({ graph: graph }, xSettings));
+            this._xAxis = new Rickshaw.Graph.Axis.Time($.extend({
+              graph: graph,
+              timeFixture: new Rickshaw.Fixtures.Time.Local()
+            }, xSettings));
         }
-
+        
         if (ySettings) {
             this._yAxis = new Rickshaw.Graph.Axis.Y($.extend({
                 graph: graph,
@@ -297,6 +300,16 @@
                         var time = moment(timestamp, 'X');
                         $this.prop('title', time.format('llll'))
                             .attr('data-container', 'body');
+                    }
+                });
+
+                $('*[data-moment-local]').each(function () {
+                    var $this = $(this);
+                    var timestamp = $this.data('moment-local');
+
+                    if (timestamp) {
+                        var time = moment(timestamp, 'X');
+                        $this.html(time.format('l LTS'));
                     }
                 });
             };

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.Designer.cs
@@ -685,7 +685,7 @@ namespace Hangfire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Time: {0} GMT.
+        ///   Looks up a localized string similar to Time:.
         /// </summary>
         public static string LayoutPage_Footer_Time {
             get {

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.es.resx
@@ -287,7 +287,7 @@
     <value>Generado: {0}ms</value>
   </data>
   <data name="LayoutPage_Footer_Time" xml:space="preserve">
-    <value>Hora: {0} GMT</value>
+    <value>Hora:</value>
   </data>
   <data name="Paginator_Next" xml:space="preserve">
     <value>Siguiente</value>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
@@ -290,7 +290,7 @@
     <value>Generated: {0}ms</value>
   </data>
   <data name="LayoutPage_Footer_Time" xml:space="preserve">
-    <value>Time: {0} GMT</value>
+    <value>Time:</value>
   </data>
   <data name="Paginator_Next" xml:space="preserve">
     <value>Next</value>

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.zh.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.zh.resx
@@ -288,7 +288,7 @@
     <value>耗时: {0}ms</value>
   </data>
   <data name="LayoutPage_Footer_Time" xml:space="preserve">
-    <value>时间: {0} GMT</value>
+    <value>时间:</value>
   </data>
   <data name="Paginator_Next" xml:space="preserve">
     <value>下一步</value>

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -154,6 +154,11 @@ namespace Hangfire.Dashboard
             return Raw($"<span data-moment-title=\"{JobHelper.ToTimestamp(time)}\">{value}</span>");
         }
 
+        public NonEscapedString LocalTime(DateTime value)
+        {
+            return Raw($"<span data-moment-local=\"{JobHelper.ToTimestamp(value)}\">{value}</span>");
+        }
+
         public string ToHumanDuration(TimeSpan? duration, bool displaySign = true)
         {
             if (duration == null) return null;

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -62,7 +62,7 @@
                         </a>
                     </li>
                     <li>@Storage</li>
-                    <li>@String.Format(Strings.LayoutPage_Footer_Time, DateTime.UtcNow)</li>
+                    <li>@Strings.LayoutPage_Footer_Time @Html.LocalTime(DateTime.UtcNow)</li>
                     <li>@String.Format(Strings.LayoutPage_Footer_Generatedms, GenerationTime.Elapsed.TotalMilliseconds.ToString("N"))</li>
                 </ul>
             </div>

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
@@ -237,7 +237,17 @@ WriteLiteral("</li>\r\n                    <li>");
 
             
             #line 65 "..\..\Dashboard\Pages\LayoutPage.cshtml"
-                   Write(String.Format(Strings.LayoutPage_Footer_Time, DateTime.UtcNow));
+                   Write(Strings.LayoutPage_Footer_Time);
+
+            
+            #line default
+            #line hidden
+WriteLiteral(" ");
+
+
+            
+            #line 65 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                                                   Write(Html.LocalTime(DateTime.UtcNow));
 
             
             #line default


### PR DESCRIPTION
Local time is used everywhere including a footer and x-axis of History graph

Fix #702 