### PR TITLE
Fix Scheduled column title

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml
@@ -63,7 +63,7 @@
                                 <th class="min-width">@Strings.Common_Id</th>
                                 <th>@Strings.ScheduledJobsPage_Table_Enqueue</th>
                                 <th>@Strings.Common_Job</th>
-                                <th class="align-right">ScheduledJobsPage_Table_Scheduled</th>
+                                <th class="align-right">@Strings.ScheduledJobsPage_Table_Scheduled</th>
                             </tr>
                         </thead>
                         @foreach (var job in scheduledJobs)

--- a/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.generated.cs
@@ -246,9 +246,17 @@ WriteLiteral("</th>\r\n                                <th>");
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                                <th class=\"align-right\">ScheduledJobsPage_" +
-"Table_Scheduled</th>\r\n                            </tr>\r\n                       " +
-" </thead>\r\n");
+WriteLiteral("</th>\r\n                                <th class=\"align-right\">");
+
+
+            
+            #line 66 "..\..\Dashboard\Pages\ScheduledJobsPage.cshtml"
+                                                   Write(Strings.ScheduledJobsPage_Table_Scheduled);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("</th>\r\n                            </tr>\r\n                        </thead>\r\n");
 
 
             


### PR DESCRIPTION
Use for Scheduled column title localized value from Strings.resx instead of string 'ScheduledJobsPage_Table_Scheduled'.