### PR TITLE
Wrap exceptions throwing during job disposal in JobPerformanceException			407adc9

### DIFF
--- a/src/Hangfire.Core/JobActivatorScope.cs
+++ b/src/Hangfire.Core/JobActivatorScope.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using Hangfire.Server;
 
 namespace Hangfire
 {
@@ -45,6 +46,12 @@ namespace Hangfire
             try
             {
                 DisposeScope();
+            }
+            catch (Exception ex)
+            {
+                throw new JobPerformanceException(
+                    "Job has been performed, but an exception occurred during disposal.",
+                    ex);
             }
             finally
             {

--- a/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
@@ -222,7 +222,7 @@ namespace Hangfire.Core.Tests.Server
             _context.BackgroundJob.Job = Job.FromExpression<BrokenDispose>(x => x.Method());
             var performer = CreatePerformer();
             
-            Assert.Throws<InvalidOperationException>(
+            Assert.Throws<JobPerformanceException>(
                 () => performer.Perform(_context.Object));
 
             Assert.True(_methodInvoked);


### PR DESCRIPTION
Disposable jobs are automatic disposed after an invocation. Any exception which was threw during disposing should be wrap in JobPerformanceException.