### PR TITLE
Modify identity columns type to bigint in all tables.

### DIFF
--- a/src/Hangfire.SqlServer.Msmq/MsmqJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer.Msmq/MsmqJobQueueMonitoringApi.cs
@@ -41,9 +41,9 @@ namespace Hangfire.SqlServer.Msmq
             return _queues;
         }
 
-        public IEnumerable<int> GetEnqueuedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetEnqueuedJobIds(string queue, int @from, int perPage)
         {
-            var result = new List<int>();
+            var result = new List<long>();
 
             using (var messageQueue = new MessageQueue(String.Format(_pathPattern, queue)))
             {
@@ -58,7 +58,7 @@ namespace Hangfire.SqlServer.Msmq
                         var message = enumerator.Current;
                         if (message == null) continue;
 
-                        result.Add(int.Parse(message.Label));
+                        result.Add(long.Parse(message.Label));
                     }
 
                     if (current >= end) break;
@@ -70,9 +70,9 @@ namespace Hangfire.SqlServer.Msmq
             return result;
         }
 
-        public IEnumerable<int> GetFetchedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetFetchedJobIds(string queue, int @from, int perPage)
         {
-            return Enumerable.Empty<int>();
+            return Enumerable.Empty<long>();
         }
 
         public EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue)

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -380,14 +380,187 @@ BEGIN
 
 	SET @CURRENT_SCHEMA_VERSION = 5;
 END
-	
-/*IF @CURRENT_SCHEMA_VERSION = 5
+
+IF @CURRENT_SCHEMA_VERSION = 5
 BEGIN
 	PRINT 'Installing schema version 6';
 
-	-- Insert migration here
+	-- Modify [HangFire].[AggregatedCounter].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[AggregatedCounter] DROP CONSTRAINT [PK_HangFire_CounterAggregated];
+	PRINT 'Dropped constraint [PK_HangFire_CounterAggregated] to modify the [HangFire].[AggregatedCounter].[Id] column';
+
+	ALTER TABLE [HangFire].[AggregatedCounter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[AggregatedCounter].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[AggregatedCounter] ADD CONSTRAINT [PK_HangFire_CounterAggregated] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_CounterAggregated]';
+
+	-- Modify [HangFire].[Counter].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[Counter] DROP CONSTRAINT [PK_HangFire_Counter];
+	PRINT 'Dropped constraint [PK_HangFire_Counter] to modify the [HangFire].[Counter].[Id] column';
+
+	ALTER TABLE [HangFire].[Counter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[Counter].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[Counter] ADD CONSTRAINT [PK_HangFire_Counter] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Counter]';
+
+	-- Modify [HangFire].[Hash].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[Hash] DROP CONSTRAINT [PK_HangFire_Hash];
+	PRINT 'Dropped constraint [PK_HangFire_Hash] to modify the [HangFire].[Hash].[Id] column';
+
+	DROP INDEX [IX_HangFire_Hash_ExpireAt] ON [HangFire].[Hash];
+	PRINT 'Dropped index [IX_HangFire_Hash_ExpireAt] ] to modify the [HangFire].[Hash].[Id] column';
+
+	ALTER TABLE [HangFire].[Hash] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[Hash].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[Hash] ADD CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Hash]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Hash_ExpireAt] ON [HangFire].[Hash] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
+
+	-- Modify [HangFire].[Job].[Id] type to bigint
+	
+	ALTER TABLE [HangFire].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
+	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [HangFire].[JobParameter].[JobId] column';
+
+	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter];
+	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [HangFire].[JobParameter].[JobId] column';
+
+	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [JobId] bigint;
+	PRINT 'Modified [HangFire].[JobParameter].[JobId] type to bigint to modify [HangFire].[Job].[Id] type to bigint';
+	
+	ALTER TABLE [HangFire].[State] DROP CONSTRAINT [FK_HangFire_State_Job];
+	PRINT 'Dropped constraint [FK_HangFire_State_Job] to modify the [HangFire].[State].[JobId] column';
+
+	DROP INDEX [IX_HangFire_State_JobId] ON [HangFire].[State];
+	PRINT 'Dropped index [IX_HangFire_State_JobId] to modify the [HangFire].[State].[JobId] column';
+
+	ALTER TABLE [HangFire].[State] ALTER COLUMN [JobId] bigint;
+	PRINT 'Modified [HangFire].[State].[JobId] type to bigint to modify [HangFire].[Job].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[Job] DROP CONSTRAINT [PK_HangFire_Job];
+	PRINT 'Dropped constraint [PK_HangFire_Job] to modify the [HangFire].[Job].[Id] column';
+
+	DROP INDEX [IX_HangFire_Job_ExpireAt] ON [HangFire].[Job];
+	PRINT 'Dropped index [IX_HangFire_Job_ExpireAt] to modify the [HangFire].[Job].[Id] column';
+
+	ALTER TABLE [HangFire].[Job] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[Job].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[Job] ADD CONSTRAINT [PK_HangFire_Job] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Job_ExpireAt] ON [HangFire].[Job] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]';
+
+	ALTER TABLE [HangFire].[JobParameter] ADD CONSTRAINT [FK_HangFire_JobParameter_Job] FOREIGN KEY([JobId])
+		REFERENCES [HangFire].[Job] ([Id])
+		ON UPDATE CASCADE
+		ON DELETE CASCADE;
+	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter] (
+		[JobId] ASC,
+		[Name] ASC
+	);
+	PRINT 'Re-created index [IX_HangFire_JobParameter_JobIdAndName]';
+
+	ALTER TABLE [HangFire].[State] ADD CONSTRAINT [FK_HangFire_State_Job] FOREIGN KEY([JobId])
+		REFERENCES [HangFire].[Job] ([Id])
+		ON UPDATE CASCADE
+		ON DELETE CASCADE;
+	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_State_JobId] ON [HangFire].[State] ([JobId] ASC);
+	PRINT 'Re-created index [IX_HangFire_State_JobId]';
+
+	-- Modify [HangFire].[JobParameter].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[JobParameter] DROP CONSTRAINT [PK_HangFire_JobParameter];
+	PRINT 'Dropped constraint [PK_HangFire_JobParameter] to modify the [HangFire].[JobParameter].[Id] column';
+
+	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[JobParameter].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[JobParameter] ADD CONSTRAINT [PK_HangFire_JobParameter] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_JobParameter]';
+
+	-- Modify [HangFire].[JobQueue].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[JobQueue] DROP CONSTRAINT [PK_HangFire_JobQueue];
+	PRINT 'Dropped constraint [PK_HangFire_JobQueue] to modify the [HangFire].[JobQueue].[Id] column';
+
+	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[JobQueue].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[JobQueue] ADD CONSTRAINT [PK_HangFire_JobQueue] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_JobQueue]';
+
+	-- Modify [HangFire].[List].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[List] DROP CONSTRAINT [PK_HangFire_List];
+	PRINT 'Dropped constraint [PK_HangFire_List] to modify the [HangFire].[List].[Id] column';
+
+	DROP INDEX [IX_HangFire_List_ExpireAt] ON [HangFire].[List];
+	PRINT 'Dropped index [IX_HangFire_List_ExpireAt] to modify the [HangFire].[List].[Id] column';
+
+	ALTER TABLE [HangFire].[List] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[List].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[List] ADD CONSTRAINT [PK_HangFire_List] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_List]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_List_ExpireAt] ON [HangFire].[List] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
+
+	-- Modify [HangFire].[Set].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[Set] DROP CONSTRAINT [PK_HangFire_Set];
+	PRINT 'Dropped constraint [PK_HangFire_Set] to modify the [HangFire].[Set].[Id] column';
+
+	DROP INDEX [IX_HangFire_Set_ExpireAt] ON [HangFire].[Set];
+	PRINT 'Dropped index [IX_HangFire_Set_ExpireAt] to modify the [HangFire].[Set].[Id] column';
+
+	ALTER TABLE [HangFire].[Set] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[Set].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[Set] ADD CONSTRAINT [PK_HangFire_Set] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Set]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Set_ExpireAt] ON [HangFire].[Set] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
+
+	-- Modify [HangFire].[State].[Id] type to bigint
+
+	ALTER TABLE [HangFire].[State] DROP CONSTRAINT [PK_HangFire_State];
+	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [HangFire].[State].[Id] column';
+
+	ALTER TABLE [HangFire].[State] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [HangFire].[State].[Id] type to bigint';
+
+	ALTER TABLE [HangFire].[State] ADD CONSTRAINT [PK_HangFire_State] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_State]';
 
 	SET @CURRENT_SCHEMA_VERSION = 6;
+END	
+
+/*IF @CURRENT_SCHEMA_VERSION = 6
+BEGIN
+	PRINT 'Installing schema version 7';
+
+	-- Insert migration here
+
+	SET @CURRENT_SCHEMA_VERSION = 7;
 END*/
 
 UPDATE [HangFire].[Schema] SET [Version] = @CURRENT_SCHEMA_VERSION

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -433,7 +433,7 @@ BEGIN
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [HangFire].[JobParameter].[JobId] column';
 
 	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter];
-	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [HangFire].[JobParameter].[JobId] column';
+	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName]. Unique index will be created instead.';
 
 	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [JobId] BIGINT;
 	PRINT 'Modified [HangFire].[JobParameter].[JobId] type to BIGINT to modify [HangFire].[Job].[Id] type to BIGINT';
@@ -469,11 +469,11 @@ BEGIN
 		ON DELETE CASCADE;
 	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
 
-	CREATE NONCLUSTERED INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter] (
+	CREATE UNIQUE NONCLUSTERED INDEX [UX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter] (
 		[JobId] ASC,
 		[Name] ASC
 	);
-	PRINT 'Re-created index [IX_HangFire_JobParameter_JobIdAndName]';
+	PRINT 'Created unique index [UX_HangFire_JobParameter_JobIdAndName]';
 
 	ALTER TABLE [HangFire].[State] ADD CONSTRAINT [FK_HangFire_State_Job] FOREIGN KEY([JobId])
 		REFERENCES [HangFire].[Job] ([Id])

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -17,7 +17,7 @@
 
 SET NOCOUNT ON
 DECLARE @TARGET_SCHEMA_VERSION INT;
-SET @TARGET_SCHEMA_VERSION = 5;
+SET @TARGET_SCHEMA_VERSION = 6;
 
 PRINT 'Installing Hangfire SQL objects...';
 
@@ -427,6 +427,8 @@ BEGIN
 
 	-- Modify [HangFire].[Job].[Id] type to bigint
 	
+	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [JobId] bigint;
+
 	ALTER TABLE [HangFire].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [HangFire].[JobParameter].[JobId] column';
 
@@ -541,6 +543,8 @@ BEGIN
 	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
 
 	-- Modify [HangFire].[State].[Id] type to bigint
+	ALTER TABLE [HangFire].[Job] ALTER COLUMN [StateId] bigint;
+	PRINT 'Modified [HangFire].[Job].[StateId] type to bigint to modify the [HangFire].[State].[Id] column';
 
 	ALTER TABLE [HangFire].[State] DROP CONSTRAINT [PK_HangFire_State];
 	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [HangFire].[State].[Id] column';
@@ -558,7 +562,7 @@ END
 BEGIN
 	PRINT 'Installing schema version 7';
 
-	-- Insert migration here
+	 Insert migration here
 
 	SET @CURRENT_SCHEMA_VERSION = 7;
 END*/

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -385,29 +385,29 @@ IF @CURRENT_SCHEMA_VERSION = 5
 BEGIN
 	PRINT 'Installing schema version 6';
 
-	-- Modify [HangFire].[AggregatedCounter].[Id] type to bigint
+	-- Modify [HangFire].[AggregatedCounter].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[AggregatedCounter] DROP CONSTRAINT [PK_HangFire_CounterAggregated];
 	PRINT 'Dropped constraint [PK_HangFire_CounterAggregated] to modify the [HangFire].[AggregatedCounter].[Id] column';
 
-	ALTER TABLE [HangFire].[AggregatedCounter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[AggregatedCounter].[Id] type to bigint';
+	ALTER TABLE [HangFire].[AggregatedCounter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[AggregatedCounter].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[AggregatedCounter] ADD CONSTRAINT [PK_HangFire_CounterAggregated] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_CounterAggregated]';
 
-	-- Modify [HangFire].[Counter].[Id] type to bigint
+	-- Modify [HangFire].[Counter].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[Counter] DROP CONSTRAINT [PK_HangFire_Counter];
 	PRINT 'Dropped constraint [PK_HangFire_Counter] to modify the [HangFire].[Counter].[Id] column';
 
-	ALTER TABLE [HangFire].[Counter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[Counter].[Id] type to bigint';
+	ALTER TABLE [HangFire].[Counter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[Counter].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[Counter] ADD CONSTRAINT [PK_HangFire_Counter] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Counter]';
 
-	-- Modify [HangFire].[Hash].[Id] type to bigint
+	-- Modify [HangFire].[Hash].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[Hash] DROP CONSTRAINT [PK_HangFire_Hash];
 	PRINT 'Dropped constraint [PK_HangFire_Hash] to modify the [HangFire].[Hash].[Id] column';
@@ -415,8 +415,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Hash_ExpireAt] ON [HangFire].[Hash];
 	PRINT 'Dropped index [IX_HangFire_Hash_ExpireAt] ] to modify the [HangFire].[Hash].[Id] column';
 
-	ALTER TABLE [HangFire].[Hash] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[Hash].[Id] type to bigint';
+	ALTER TABLE [HangFire].[Hash] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[Hash].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[Hash] ADD CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Hash]';
@@ -425,9 +425,9 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
 
-	-- Modify [HangFire].[Job].[Id] type to bigint
+	-- Modify [HangFire].[Job].[Id] type to BIGINT
 	
-	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [JobId] bigint;
+	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [JobId] BIGINT;
 
 	ALTER TABLE [HangFire].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [HangFire].[JobParameter].[JobId] column';
@@ -435,8 +435,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter];
 	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [HangFire].[JobParameter].[JobId] column';
 
-	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [JobId] bigint;
-	PRINT 'Modified [HangFire].[JobParameter].[JobId] type to bigint to modify [HangFire].[Job].[Id] type to bigint';
+	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [JobId] BIGINT;
+	PRINT 'Modified [HangFire].[JobParameter].[JobId] type to BIGINT to modify [HangFire].[Job].[Id] type to BIGINT';
 	
 	ALTER TABLE [HangFire].[State] DROP CONSTRAINT [FK_HangFire_State_Job];
 	PRINT 'Dropped constraint [FK_HangFire_State_Job] to modify the [HangFire].[State].[JobId] column';
@@ -444,8 +444,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_State_JobId] ON [HangFire].[State];
 	PRINT 'Dropped index [IX_HangFire_State_JobId] to modify the [HangFire].[State].[JobId] column';
 
-	ALTER TABLE [HangFire].[State] ALTER COLUMN [JobId] bigint;
-	PRINT 'Modified [HangFire].[State].[JobId] type to bigint to modify [HangFire].[Job].[Id] type to bigint';
+	ALTER TABLE [HangFire].[State] ALTER COLUMN [JobId] BIGINT;
+	PRINT 'Modified [HangFire].[State].[JobId] type to BIGINT to modify [HangFire].[Job].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[Job] DROP CONSTRAINT [PK_HangFire_Job];
 	PRINT 'Dropped constraint [PK_HangFire_Job] to modify the [HangFire].[Job].[Id] column';
@@ -453,8 +453,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Job_ExpireAt] ON [HangFire].[Job];
 	PRINT 'Dropped index [IX_HangFire_Job_ExpireAt] to modify the [HangFire].[Job].[Id] column';
 
-	ALTER TABLE [HangFire].[Job] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[Job].[Id] type to bigint';
+	ALTER TABLE [HangFire].[Job] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[Job].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[Job] ADD CONSTRAINT [PK_HangFire_Job] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Job]';
@@ -484,29 +484,29 @@ BEGIN
 	CREATE NONCLUSTERED INDEX [IX_HangFire_State_JobId] ON [HangFire].[State] ([JobId] ASC);
 	PRINT 'Re-created index [IX_HangFire_State_JobId]';
 
-	-- Modify [HangFire].[JobParameter].[Id] type to bigint
+	-- Modify [HangFire].[JobParameter].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[JobParameter] DROP CONSTRAINT [PK_HangFire_JobParameter];
 	PRINT 'Dropped constraint [PK_HangFire_JobParameter] to modify the [HangFire].[JobParameter].[Id] column';
 
-	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[JobParameter].[Id] type to bigint';
+	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[JobParameter].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[JobParameter] ADD CONSTRAINT [PK_HangFire_JobParameter] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_JobParameter]';
 
-	-- Modify [HangFire].[JobQueue].[Id] type to bigint
+	-- Modify [HangFire].[JobQueue].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[JobQueue] DROP CONSTRAINT [PK_HangFire_JobQueue];
 	PRINT 'Dropped constraint [PK_HangFire_JobQueue] to modify the [HangFire].[JobQueue].[Id] column';
 
-	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[JobQueue].[Id] type to bigint';
+	ALTER TABLE [HangFire].[JobQueue] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[JobQueue].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[JobQueue] ADD CONSTRAINT [PK_HangFire_JobQueue] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_JobQueue]';
 
-	-- Modify [HangFire].[List].[Id] type to bigint
+	-- Modify [HangFire].[List].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[List] DROP CONSTRAINT [PK_HangFire_List];
 	PRINT 'Dropped constraint [PK_HangFire_List] to modify the [HangFire].[List].[Id] column';
@@ -514,8 +514,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_List_ExpireAt] ON [HangFire].[List];
 	PRINT 'Dropped index [IX_HangFire_List_ExpireAt] to modify the [HangFire].[List].[Id] column';
 
-	ALTER TABLE [HangFire].[List] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[List].[Id] type to bigint';
+	ALTER TABLE [HangFire].[List] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[List].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[List] ADD CONSTRAINT [PK_HangFire_List] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_List]';
@@ -524,7 +524,7 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
 
-	-- Modify [HangFire].[Set].[Id] type to bigint
+	-- Modify [HangFire].[Set].[Id] type to BIGINT
 
 	ALTER TABLE [HangFire].[Set] DROP CONSTRAINT [PK_HangFire_Set];
 	PRINT 'Dropped constraint [PK_HangFire_Set] to modify the [HangFire].[Set].[Id] column';
@@ -532,8 +532,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Set_ExpireAt] ON [HangFire].[Set];
 	PRINT 'Dropped index [IX_HangFire_Set_ExpireAt] to modify the [HangFire].[Set].[Id] column';
 
-	ALTER TABLE [HangFire].[Set] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[Set].[Id] type to bigint';
+	ALTER TABLE [HangFire].[Set] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[Set].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[Set] ADD CONSTRAINT [PK_HangFire_Set] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Set]';
@@ -542,15 +542,16 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
 
-	-- Modify [HangFire].[State].[Id] type to bigint
-	ALTER TABLE [HangFire].[Job] ALTER COLUMN [StateId] bigint;
-	PRINT 'Modified [HangFire].[Job].[StateId] type to bigint to modify the [HangFire].[State].[Id] column';
+	-- Modify [HangFire].[State].[Id] type to BIGINT
+
+	ALTER TABLE [HangFire].[Job] ALTER COLUMN [StateId] BIGINT;
+	PRINT 'Modified [HangFire].[Job].[StateId] type to BIGINT to modify the [HangFire].[State].[Id] column';
 
 	ALTER TABLE [HangFire].[State] DROP CONSTRAINT [PK_HangFire_State];
 	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [HangFire].[State].[Id] column';
 
-	ALTER TABLE [HangFire].[State] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [HangFire].[State].[Id] type to bigint';
+	ALTER TABLE [HangFire].[State] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [HangFire].[State].[Id] type to BIGINT';
 
 	ALTER TABLE [HangFire].[State] ADD CONSTRAINT [PK_HangFire_State] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_State]';

--- a/src/Hangfire.SqlServer/DefaultInstall.sql
+++ b/src/Hangfire.SqlServer/DefaultInstall.sql
@@ -422,8 +422,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Hash]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Hash_ExpireAt] ON [HangFire].[Hash] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [HangFire].[Job].[Id] type to BIGINT
 	
@@ -433,7 +434,7 @@ BEGIN
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [HangFire].[JobParameter].[JobId] column';
 
 	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [HangFire].[JobParameter];
-	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName]. Unique index will be created instead.';
+	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName]. Unique index will be created instead';
 
 	ALTER TABLE [HangFire].[JobParameter] ALTER COLUMN [JobId] BIGINT;
 	PRINT 'Modified [HangFire].[JobParameter].[JobId] type to BIGINT to modify [HangFire].[Job].[Id] type to BIGINT';
@@ -460,8 +461,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Job]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Job_ExpireAt] ON [HangFire].[Job] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	ALTER TABLE [HangFire].[JobParameter] ADD CONSTRAINT [FK_HangFire_JobParameter_Job] FOREIGN KEY([JobId])
 		REFERENCES [HangFire].[Job] ([Id])
@@ -521,8 +523,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_List]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_List_ExpireAt] ON [HangFire].[List] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [HangFire].[Set].[Id] type to BIGINT
 
@@ -539,8 +542,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Set]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Set_ExpireAt] ON [HangFire].[Set] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [HangFire].[State].[Id] type to BIGINT
 

--- a/src/Hangfire.SqlServer/EnqueuedAndFetchedCountDto.cs
+++ b/src/Hangfire.SqlServer/EnqueuedAndFetchedCountDto.cs
@@ -18,10 +18,8 @@ namespace Hangfire.SqlServer
 {
     public class EnqueuedAndFetchedCountDto
     {
-        // TODO: Change return type to `long` to support `bigint` type.
         public int? EnqueuedCount { get; set; }
 
-        // TODO: Change return type to `long` to support `bigint` type.
         public int? FetchedCount { get; set; }
     }
 }

--- a/src/Hangfire.SqlServer/IPersistentJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/IPersistentJobQueueMonitoringApi.cs
@@ -22,11 +22,9 @@ namespace Hangfire.SqlServer
     {
         IEnumerable<string> GetQueues();
 
-        // TODO: Change return type to `IEnumerable<long>` to support `bigint` type.
-        IEnumerable<int> GetEnqueuedJobIds(string queue, int from, int perPage);
+        IEnumerable<long> GetEnqueuedJobIds(string queue, int from, int perPage);
 
-        // TODO: Change return type to `IEnumerable<long>` to support `bigint` type.
-        IEnumerable<int> GetFetchedJobIds(string queue, int from, int perPage);
+        IEnumerable<long> GetFetchedJobIds(string queue, int from, int perPage);
 
         EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue);
     }

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -384,29 +384,29 @@ IF @CURRENT_SCHEMA_VERSION = 5
 BEGIN
 	PRINT 'Installing schema version 6';
 
-	-- Modify [$(HangFireSchema)].[AggregatedCounter].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[AggregatedCounter].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] DROP CONSTRAINT [PK_HangFire_CounterAggregated];
 	PRINT 'Dropped constraint [PK_HangFire_CounterAggregated] to modify the [$(HangFireSchema)].[AggregatedCounter].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[AggregatedCounter].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[AggregatedCounter].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] ADD CONSTRAINT [PK_HangFire_CounterAggregated] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_CounterAggregated]';
 
-	-- Modify [$(HangFireSchema)].[Counter].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[Counter].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[Counter] DROP CONSTRAINT [PK_HangFire_Counter];
 	PRINT 'Dropped constraint [PK_HangFire_Counter] to modify the [$(HangFireSchema)].[Counter].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[Counter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[Counter].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[Counter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[Counter].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[Counter] ADD CONSTRAINT [PK_HangFire_Counter] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Counter]';
 
-	-- Modify [$(HangFireSchema)].[Hash].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[Hash].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[Hash] DROP CONSTRAINT [PK_HangFire_Hash];
 	PRINT 'Dropped constraint [PK_HangFire_Hash] to modify the [$(HangFireSchema)].[Hash].[Id] column';
@@ -414,8 +414,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Hash_ExpireAt] ON [$(HangFireSchema)].[Hash];
 	PRINT 'Dropped index [IX_HangFire_Hash_ExpireAt] ] to modify the [$(HangFireSchema)].[Hash].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[Hash] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[Hash].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[Hash] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[Hash].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[Hash] ADD CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Hash]';
@@ -424,9 +424,9 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
 
-	-- Modify [$(HangFireSchema)].[Job].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[Job].[Id] type to BIGINT
 	
-	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [JobId] bigint;
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [JobId] BIGINT;
 
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
@@ -434,8 +434,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter];
 	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
 
-	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [JobId] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[JobId] type to bigint to modify [$(HangFireSchema)].[Job].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [JobId] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[JobId] type to BIGINT to modify [$(HangFireSchema)].[Job].[Id] type to BIGINT';
 	
 	ALTER TABLE [$(HangFireSchema)].[State] DROP CONSTRAINT [FK_HangFire_State_Job];
 	PRINT 'Dropped constraint [FK_HangFire_State_Job] to modify the [$(HangFireSchema)].[State].[JobId] column';
@@ -443,8 +443,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_State_JobId] ON [$(HangFireSchema)].[State];
 	PRINT 'Dropped index [IX_HangFire_State_JobId] to modify the [$(HangFireSchema)].[State].[JobId] column';
 
-	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [JobId] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[State].[JobId] type to bigint to modify [$(HangFireSchema)].[Job].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [JobId] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[State].[JobId] type to BIGINT to modify [$(HangFireSchema)].[Job].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[Job] DROP CONSTRAINT [PK_HangFire_Job];
 	PRINT 'Dropped constraint [PK_HangFire_Job] to modify the [$(HangFireSchema)].[Job].[Id] column';
@@ -452,8 +452,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Job_ExpireAt] ON [$(HangFireSchema)].[Job];
 	PRINT 'Dropped index [IX_HangFire_Job_ExpireAt] to modify the [$(HangFireSchema)].[Job].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[Job].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[Job].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[Job] ADD CONSTRAINT [PK_HangFire_Job] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Job]';
@@ -483,29 +483,29 @@ BEGIN
 	CREATE NONCLUSTERED INDEX [IX_HangFire_State_JobId] ON [$(HangFireSchema)].[State] ([JobId] ASC);
 	PRINT 'Re-created index [IX_HangFire_State_JobId]';
 
-	-- Modify [$(HangFireSchema)].[JobParameter].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[JobParameter].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] DROP CONSTRAINT [PK_HangFire_JobParameter];
 	PRINT 'Dropped constraint [PK_HangFire_JobParameter] to modify the [$(HangFireSchema)].[JobParameter].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] ADD CONSTRAINT [PK_HangFire_JobParameter] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_JobParameter]';
 
-	-- Modify [$(HangFireSchema)].[JobQueue].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[JobQueue].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[JobQueue] DROP CONSTRAINT [PK_HangFire_JobQueue];
 	PRINT 'Dropped constraint [PK_HangFire_JobQueue] to modify the [$(HangFireSchema)].[JobQueue].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[JobQueue].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[JobQueue].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[JobQueue] ADD CONSTRAINT [PK_HangFire_JobQueue] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_JobQueue]';
 
-	-- Modify [$(HangFireSchema)].[List].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[List].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[List] DROP CONSTRAINT [PK_HangFire_List];
 	PRINT 'Dropped constraint [PK_HangFire_List] to modify the [$(HangFireSchema)].[List].[Id] column';
@@ -513,8 +513,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_List_ExpireAt] ON [$(HangFireSchema)].[List];
 	PRINT 'Dropped index [IX_HangFire_List_ExpireAt] to modify the [$(HangFireSchema)].[List].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[List] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[List].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[List] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[List].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[List] ADD CONSTRAINT [PK_HangFire_List] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_List]';
@@ -523,7 +523,7 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
 
-	-- Modify [$(HangFireSchema)].[Set].[Id] type to bigint
+	-- Modify [$(HangFireSchema)].[Set].[Id] type to BIGINT
 
 	ALTER TABLE [$(HangFireSchema)].[Set] DROP CONSTRAINT [PK_HangFire_Set];
 	PRINT 'Dropped constraint [PK_HangFire_Set] to modify the [$(HangFireSchema)].[Set].[Id] column';
@@ -531,8 +531,8 @@ BEGIN
 	DROP INDEX [IX_HangFire_Set_ExpireAt] ON [$(HangFireSchema)].[Set];
 	PRINT 'Dropped index [IX_HangFire_Set_ExpireAt] to modify the [$(HangFireSchema)].[Set].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[Set] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[Set].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[Set] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[Set].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[Set] ADD CONSTRAINT [PK_HangFire_Set] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_Set]';
@@ -541,15 +541,16 @@ BEGIN
 	INCLUDE ([Id]);
 	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
 
-	-- Modify [$(HangFireSchema)].[State].[Id] type to bigint
-	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [StateId] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[Job].[StateId] type to bigint to modify the [$(HangFireSchema)].[State].[Id] column';
+	-- Modify [$(HangFireSchema)].[State].[Id] type to BIGINT
+
+	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [StateId] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[Job].[StateId] type to BIGINT to modify the [$(HangFireSchema)].[State].[Id] column';
 
 	ALTER TABLE [$(HangFireSchema)].[State] DROP CONSTRAINT [PK_HangFire_State];
 	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [$(HangFireSchema)].[State].[Id] column';
 
-	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [Id] bigint;
-	PRINT 'Modified [$(HangFireSchema)].[State].[Id] type to bigint';
+	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [Id] BIGINT;
+	PRINT 'Modified [$(HangFireSchema)].[State].[Id] type to BIGINT';
 
 	ALTER TABLE [$(HangFireSchema)].[State] ADD CONSTRAINT [PK_HangFire_State] PRIMARY KEY CLUSTERED ([Id] ASC);
 	PRINT 'Re-created constraint [PK_HangFire_State]';

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -421,8 +421,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Hash]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Hash_ExpireAt] ON [$(HangFireSchema)].[Hash] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [$(HangFireSchema)].[Job].[Id] type to BIGINT
 	
@@ -459,8 +460,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Job]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Job_ExpireAt] ON [$(HangFireSchema)].[Job] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] ADD CONSTRAINT [FK_HangFire_JobParameter_Job] FOREIGN KEY([JobId])
 		REFERENCES [$(HangFireSchema)].[Job] ([Id])
@@ -520,8 +522,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_List]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_List_ExpireAt] ON [$(HangFireSchema)].[List] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [$(HangFireSchema)].[Set].[Id] type to BIGINT
 
@@ -538,8 +541,9 @@ BEGIN
 	PRINT 'Re-created constraint [PK_HangFire_Set]';
 
 	CREATE NONCLUSTERED INDEX [IX_HangFire_Set_ExpireAt] ON [$(HangFireSchema)].[Set] ([ExpireAt])
-	INCLUDE ([Id]);
-	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
+	INCLUDE ([Id])
+	WHERE [ExpireAt] IS NOT NULL;
+	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]. Made the index only for rows with non-null ExpireAt value';
 
 	-- Modify [$(HangFireSchema)].[State].[Id] type to BIGINT
 

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -432,7 +432,7 @@ BEGIN
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
 
 	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter];
-	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
+	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName]. Unique index will be created instead';
 
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [JobId] BIGINT;
 	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[JobId] type to BIGINT to modify [$(HangFireSchema)].[Job].[Id] type to BIGINT';
@@ -468,11 +468,11 @@ BEGIN
 		ON DELETE CASCADE;
 	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
 
-	CREATE NONCLUSTERED INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter] (
+	CREATE UNIQUE NONCLUSTERED INDEX [UX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter] (
 		[JobId] ASC,
 		[Name] ASC
 	);
-	PRINT 'Re-created index [IX_HangFire_JobParameter_JobIdAndName]';
+	PRINT 'Created unique index [UX_HangFire_JobParameter_JobIdAndName]';
 
 	ALTER TABLE [$(HangFireSchema)].[State] ADD CONSTRAINT [FK_HangFire_State_Job] FOREIGN KEY([JobId])
 		REFERENCES [$(HangFireSchema)].[Job] ([Id])

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -16,7 +16,7 @@
 
 SET NOCOUNT ON
 DECLARE @TARGET_SCHEMA_VERSION INT;
-SET @TARGET_SCHEMA_VERSION = 5;
+SET @TARGET_SCHEMA_VERSION = 6;
 
 PRINT 'Installing Hangfire SQL objects...';
 
@@ -426,6 +426,8 @@ BEGIN
 
 	-- Modify [$(HangFireSchema)].[Job].[Id] type to bigint
 	
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [JobId] bigint;
+
 	ALTER TABLE [$(HangFireSchema)].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
 	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
 
@@ -540,6 +542,8 @@ BEGIN
 	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
 
 	-- Modify [$(HangFireSchema)].[State].[Id] type to bigint
+	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [StateId] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[Job].[StateId] type to bigint to modify the [$(HangFireSchema)].[State].[Id] column';
 
 	ALTER TABLE [$(HangFireSchema)].[State] DROP CONSTRAINT [PK_HangFire_State];
 	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [$(HangFireSchema)].[State].[Id] column';
@@ -557,7 +561,7 @@ END
 BEGIN
 	PRINT 'Installing schema version 7';
 
-	-- Insert migration here
+	 Insert migration here
 
 	SET @CURRENT_SCHEMA_VERSION = 7;
 END*/

--- a/src/Hangfire.SqlServer/Install.sql
+++ b/src/Hangfire.SqlServer/Install.sql
@@ -379,14 +379,187 @@ BEGIN
 
 	SET @CURRENT_SCHEMA_VERSION = 5;
 END
-	
-/*IF @CURRENT_SCHEMA_VERSION = 5
+
+IF @CURRENT_SCHEMA_VERSION = 5
 BEGIN
 	PRINT 'Installing schema version 6';
 
-	-- Insert migration here
+	-- Modify [$(HangFireSchema)].[AggregatedCounter].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] DROP CONSTRAINT [PK_HangFire_CounterAggregated];
+	PRINT 'Dropped constraint [PK_HangFire_CounterAggregated] to modify the [$(HangFireSchema)].[AggregatedCounter].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[AggregatedCounter].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[AggregatedCounter] ADD CONSTRAINT [PK_HangFire_CounterAggregated] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_CounterAggregated]';
+
+	-- Modify [$(HangFireSchema)].[Counter].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[Counter] DROP CONSTRAINT [PK_HangFire_Counter];
+	PRINT 'Dropped constraint [PK_HangFire_Counter] to modify the [$(HangFireSchema)].[Counter].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[Counter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[Counter].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[Counter] ADD CONSTRAINT [PK_HangFire_Counter] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Counter]';
+
+	-- Modify [$(HangFireSchema)].[Hash].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[Hash] DROP CONSTRAINT [PK_HangFire_Hash];
+	PRINT 'Dropped constraint [PK_HangFire_Hash] to modify the [$(HangFireSchema)].[Hash].[Id] column';
+
+	DROP INDEX [IX_HangFire_Hash_ExpireAt] ON [$(HangFireSchema)].[Hash];
+	PRINT 'Dropped index [IX_HangFire_Hash_ExpireAt] ] to modify the [$(HangFireSchema)].[Hash].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[Hash] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[Hash].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[Hash] ADD CONSTRAINT [PK_HangFire_Hash] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Hash]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Hash_ExpireAt] ON [$(HangFireSchema)].[Hash] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Hash_ExpireAt]';
+
+	-- Modify [$(HangFireSchema)].[Job].[Id] type to bigint
+	
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] DROP CONSTRAINT [FK_HangFire_JobParameter_Job];
+	PRINT 'Dropped constraint [FK_HangFire_JobParameter_Job] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
+
+	DROP INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter];
+	PRINT 'Dropped index [IX_HangFire_JobParameter_JobIdAndName] to modify the [$(HangFireSchema)].[JobParameter].[JobId] column';
+
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [JobId] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[JobId] type to bigint to modify [$(HangFireSchema)].[Job].[Id] type to bigint';
+	
+	ALTER TABLE [$(HangFireSchema)].[State] DROP CONSTRAINT [FK_HangFire_State_Job];
+	PRINT 'Dropped constraint [FK_HangFire_State_Job] to modify the [$(HangFireSchema)].[State].[JobId] column';
+
+	DROP INDEX [IX_HangFire_State_JobId] ON [$(HangFireSchema)].[State];
+	PRINT 'Dropped index [IX_HangFire_State_JobId] to modify the [$(HangFireSchema)].[State].[JobId] column';
+
+	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [JobId] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[State].[JobId] type to bigint to modify [$(HangFireSchema)].[Job].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[Job] DROP CONSTRAINT [PK_HangFire_Job];
+	PRINT 'Dropped constraint [PK_HangFire_Job] to modify the [$(HangFireSchema)].[Job].[Id] column';
+
+	DROP INDEX [IX_HangFire_Job_ExpireAt] ON [$(HangFireSchema)].[Job];
+	PRINT 'Dropped index [IX_HangFire_Job_ExpireAt] to modify the [$(HangFireSchema)].[Job].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[Job] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[Job].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[Job] ADD CONSTRAINT [PK_HangFire_Job] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Job_ExpireAt] ON [$(HangFireSchema)].[Job] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Job_ExpireAt]';
+
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ADD CONSTRAINT [FK_HangFire_JobParameter_Job] FOREIGN KEY([JobId])
+		REFERENCES [$(HangFireSchema)].[Job] ([Id])
+		ON UPDATE CASCADE
+		ON DELETE CASCADE;
+	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_JobParameter_JobIdAndName] ON [$(HangFireSchema)].[JobParameter] (
+		[JobId] ASC,
+		[Name] ASC
+	);
+	PRINT 'Re-created index [IX_HangFire_JobParameter_JobIdAndName]';
+
+	ALTER TABLE [$(HangFireSchema)].[State] ADD CONSTRAINT [FK_HangFire_State_Job] FOREIGN KEY([JobId])
+		REFERENCES [$(HangFireSchema)].[Job] ([Id])
+		ON UPDATE CASCADE
+		ON DELETE CASCADE;
+	PRINT 'Re-created constraint [FK_HangFire_JobParameter_Job]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_State_JobId] ON [$(HangFireSchema)].[State] ([JobId] ASC);
+	PRINT 'Re-created index [IX_HangFire_State_JobId]';
+
+	-- Modify [$(HangFireSchema)].[JobParameter].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] DROP CONSTRAINT [PK_HangFire_JobParameter];
+	PRINT 'Dropped constraint [PK_HangFire_JobParameter] to modify the [$(HangFireSchema)].[JobParameter].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[JobParameter].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[JobParameter] ADD CONSTRAINT [PK_HangFire_JobParameter] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_JobParameter]';
+
+	-- Modify [$(HangFireSchema)].[JobQueue].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] DROP CONSTRAINT [PK_HangFire_JobQueue];
+	PRINT 'Dropped constraint [PK_HangFire_JobQueue] to modify the [$(HangFireSchema)].[JobQueue].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[JobQueue].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[JobQueue] ADD CONSTRAINT [PK_HangFire_JobQueue] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_JobQueue]';
+
+	-- Modify [$(HangFireSchema)].[List].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[List] DROP CONSTRAINT [PK_HangFire_List];
+	PRINT 'Dropped constraint [PK_HangFire_List] to modify the [$(HangFireSchema)].[List].[Id] column';
+
+	DROP INDEX [IX_HangFire_List_ExpireAt] ON [$(HangFireSchema)].[List];
+	PRINT 'Dropped index [IX_HangFire_List_ExpireAt] to modify the [$(HangFireSchema)].[List].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[List] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[List].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[List] ADD CONSTRAINT [PK_HangFire_List] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_List]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_List_ExpireAt] ON [$(HangFireSchema)].[List] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_List_ExpireAt]';
+
+	-- Modify [$(HangFireSchema)].[Set].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[Set] DROP CONSTRAINT [PK_HangFire_Set];
+	PRINT 'Dropped constraint [PK_HangFire_Set] to modify the [$(HangFireSchema)].[Set].[Id] column';
+
+	DROP INDEX [IX_HangFire_Set_ExpireAt] ON [$(HangFireSchema)].[Set];
+	PRINT 'Dropped index [IX_HangFire_Set_ExpireAt] to modify the [$(HangFireSchema)].[Set].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[Set] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[Set].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[Set] ADD CONSTRAINT [PK_HangFire_Set] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_Set]';
+
+	CREATE NONCLUSTERED INDEX [IX_HangFire_Set_ExpireAt] ON [$(HangFireSchema)].[Set] ([ExpireAt])
+	INCLUDE ([Id]);
+	PRINT 'Re-created index [IX_HangFire_Set_ExpireAt]';
+
+	-- Modify [$(HangFireSchema)].[State].[Id] type to bigint
+
+	ALTER TABLE [$(HangFireSchema)].[State] DROP CONSTRAINT [PK_HangFire_State];
+	PRINT 'Dropped constraint [PK_HangFire_State] to modify the [$(HangFireSchema)].[State].[Id] column';
+
+	ALTER TABLE [$(HangFireSchema)].[State] ALTER COLUMN [Id] bigint;
+	PRINT 'Modified [$(HangFireSchema)].[State].[Id] type to bigint';
+
+	ALTER TABLE [$(HangFireSchema)].[State] ADD CONSTRAINT [PK_HangFire_State] PRIMARY KEY CLUSTERED ([Id] ASC);
+	PRINT 'Re-created constraint [PK_HangFire_State]';
 
 	SET @CURRENT_SCHEMA_VERSION = 6;
+END	
+
+/*IF @CURRENT_SCHEMA_VERSION = 6
+BEGIN
+	PRINT 'Installing schema version 7';
+
+	-- Insert migration here
+
+	SET @CURRENT_SCHEMA_VERSION = 7;
 END*/
 
 UPDATE [$(HangFireSchema)].[Schema] SET [Version] = @CURRENT_SCHEMA_VERSION

--- a/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
@@ -67,7 +67,7 @@ namespace Hangfire.SqlServer
             }  
         }
 
-        public IEnumerable<int> GetEnqueuedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetEnqueuedJobIds(string queue, int @from, int perPage)
         {
             string sqlQuery =
 $@"select r.JobId from (
@@ -79,20 +79,19 @@ where r.row_num between @start and @end";
 
             return UseTransaction((connection, transaction) =>
             {
-                // TODO: Remove cast to `int` to support `bigint`.
                 return connection.Query<JobIdDto>(
                     sqlQuery,
                     new { queue = queue, start = from + 1, end = @from + perPage },
                     transaction)
                     .ToList()
-                    .Select(x => (int)x.JobId)
+                    .Select(x => x.JobId)
                     .ToList();
             });
         }
 
-        public IEnumerable<int> GetFetchedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetFetchedJobIds(string queue, int @from, int perPage)
         {
-            return Enumerable.Empty<int>();
+            return Enumerable.Empty<long>();
         }
 
         public EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue)

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -211,9 +211,8 @@ namespace Hangfire.SqlServer
                 var enqueuedJobIds = tuple.Monitoring.GetEnqueuedJobIds(tuple.Queue, 0, 5);
                 var counters = tuple.Monitoring.GetEnqueuedAndFetchedCount(tuple.Queue);
 
-                // TODO: Remove the Select method call to support `bigint`.
                 var firstJobs = UseConnection(connection => 
-                    EnqueuedJobs(connection, enqueuedJobIds.Select(x => (long)x).ToArray()));
+                    EnqueuedJobs(connection, enqueuedJobIds.ToArray()));
 
                 result.Add(new QueueWithTopEnqueuedJobsDto
                 {
@@ -241,8 +240,7 @@ namespace Hangfire.SqlServer
             var queueApi = GetQueueApi(queue);
             var fetchedJobIds = queueApi.GetFetchedJobIds(queue, from, perPage);
 
-            // TODO: Remove the Select method call to support `bigint`.
-            return UseConnection(connection => FetchedJobs(connection, fetchedJobIds.Select(x => (long)x).ToArray()));
+            return UseConnection(connection => FetchedJobs(connection, fetchedJobIds.ToArray()));
         }
 
         public IDictionary<DateTime, long> HourlySucceededJobs()

--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -26,7 +26,7 @@ namespace Hangfire.SqlServer
 {
     public static class SqlServerObjectsInstaller
     {
-        public static readonly int RequiredSchemaVersion = 5;
+        public static readonly int RequiredSchemaVersion = 6;
         private const int RetryAttempts = 3;
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(SqlServerStorage));
@@ -51,7 +51,7 @@ namespace Hangfire.SqlServer
                 typeof(SqlServerObjectsInstaller).GetTypeInfo().Assembly, 
                 "Hangfire.SqlServer.Install.sql");
 
-            script = script.Replace("SET @TARGET_SCHEMA_VERSION = 5;", "SET @TARGET_SCHEMA_VERSION = " + RequiredSchemaVersion + ";");
+            script = script.Replace("SET @TARGET_SCHEMA_VERSION = 6;", "SET @TARGET_SCHEMA_VERSION = " + RequiredSchemaVersion + ";");
 
             script = script.Replace("$(HangFireSchema)", !string.IsNullOrWhiteSpace(schema) ? schema : Constants.DefaultSchema);
 

--- a/tests/Hangfire.SqlServer.Msmq.Tests/MsmqJobQueueMonitoringApiFacts.cs
+++ b/tests/Hangfire.SqlServer.Msmq.Tests/MsmqJobQueueMonitoringApiFacts.cs
@@ -85,6 +85,19 @@ namespace Hangfire.SqlServer.Msmq.Tests
             Assert.Equal(5, result[1]);
         }
 
+        [Fact, CleanMsmqQueue("my-queue")]
+        public void GetEnqueuedJobIds_ReturnsCorrectResult_WhenJobIdIsLongValue()
+        {
+            MsmqUtils.EnqueueJobId("my-queue", (int.MaxValue + 1L).ToString());
+
+            var api = CreateMonitoringApi();
+
+            var result = api.GetEnqueuedJobIds("my-queue", 0, 1).ToArray();
+
+            Assert.Equal(1, result.Length);
+            Assert.Equal(int.MaxValue + 1L, result[0]);
+        }
+
         private static MsmqJobQueueMonitoringApi CreateMonitoringApi()
         {
             return new MsmqJobQueueMonitoringApi(PathPattern, Queues);

--- a/tests/Hangfire.SqlServer.Tests/CountersAggregatorFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/CountersAggregatorFacts.cs
@@ -49,13 +49,13 @@ values ('key', 1, @expireAt)";
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
 
-                connection.Query($"DBCC CHECKIDENT('HangFire.AggregatedCounter', RESEED, {int.MaxValue});");
+                connection.Query($"DBCC CHECKIDENT('HangFire.AggregatedCounter', RESEED, {int.MaxValue + 1L});");
 
                 // Act
                 aggregator.Execute(cts.Token);
 
                 // Assert
-                Assert.Equal(int.MaxValue + 1L, connection.Query<long>(@"select Id from HangFire.AggregatedCounter").Single());
+                Assert.True(int.MaxValue < connection.Query<long>(@"select Id from HangFire.AggregatedCounter").Single());
             }
         }
 

--- a/tests/Hangfire.SqlServer.Tests/CountersAggregatorFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/CountersAggregatorFacts.cs
@@ -33,6 +33,32 @@ values ('key', 1, @expireAt)";
             }
         }
 
+        [Fact, CleanDatabase]
+        public void CountersAggregator_HandlesAggregatorIdCanExceedInt32Max()
+        {
+            const string createSql = @"
+insert into HangFire.Counter ([Key], [Value], ExpireAt) 
+values ('key', 1, @expireAt)";
+
+            using (var connection = CreateConnection())
+            {
+                // Arrange
+                connection.Execute(createSql, new { expireAt = DateTime.UtcNow.AddHours(1) });
+
+                var aggregator = CreateAggregator(connection);
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                connection.Query($"DBCC CHECKIDENT('HangFire.AggregatedCounter', RESEED, {int.MaxValue});");
+
+                // Act
+                aggregator.Execute(cts.Token);
+
+                // Assert
+                Assert.Equal(int.MaxValue + 1L, connection.Query<long>(@"select Id from HangFire.AggregatedCounter").Single());
+            }
+        }
+
         private static SqlConnection CreateConnection()
         {
             return ConnectionUtils.CreateConnection();

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -1401,7 +1401,7 @@ update HangFire.Job set StateId = @stateId;";
             UseConnections((sql, connection) =>
             {
                 // Arrange
-                sql.Query($"DBCC CHECKIDENT('HangFire.Job', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.Job', RESEED, {int.MaxValue + 1L});");
 
                 // Act
                 var createdAt = new DateTime(2012, 12, 12);
@@ -1412,7 +1412,7 @@ update HangFire.Job set StateId = @stateId;";
                     TimeSpan.FromDays(1));
 
                 // Assert
-                Assert.Equal((int.MaxValue + 1L).ToString(), jobId);
+                Assert.True(int.MaxValue < long.Parse(jobId));
             });
         }
 
@@ -1453,7 +1453,7 @@ select scope_identity() as Id";
                 // Arrange
                 var job = sql.Query(arrangeSql).Single();
                 string jobId = job.Id.ToString();
-                sql.Query($"DBCC CHECKIDENT('HangFire.JobParameter', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.JobParameter', RESEED, {int.MaxValue + 1L});");
 
                 // Act
                 connection.SetJobParameter(jobId, "Name", "Value");
@@ -1463,7 +1463,7 @@ select scope_identity() as Id";
                     new { id = jobId, name = "Name" }).Single();
 
                 // Assert
-                Assert.Equal(int.MaxValue + 1L, parameter.Id);
+                Assert.True(int.MaxValue < parameter.Id);
             });
         }
 
@@ -1502,7 +1502,7 @@ values (@id, @jobId, @name, @value)";
             UseConnections((sql, connection) =>
             {
                 // Arrange
-                sql.Query($"DBCC CHECKIDENT('HangFire.Hash', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.Hash', RESEED, {int.MaxValue + 1L});");
 
                 // Act
                 connection.SetRangeInHash("some-hash", new Dictionary<string, string>
@@ -1515,7 +1515,7 @@ values (@id, @jobId, @name, @value)";
                     new { key = "some-hash" }).Single();
 
                 // Assert
-                Assert.Equal(int.MaxValue + 1L, result.Id);
+                Assert.True(int.MaxValue < result.Id);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -200,7 +200,7 @@ select scope_identity() as Id";
                         arguments = "['Arguments']"
                     }).Single();
 
-                var result = connection.GetJobData(((int)jobId.Id).ToString());
+                var result = connection.GetJobData(((long)jobId.Id).ToString());
 
                 Assert.NotNull(result);
                 Assert.NotNull(result.Job);
@@ -236,13 +236,13 @@ select scope_identity() as Id";
             const string arrangeSql = @"
 insert into HangFire.Job (InvocationData, Arguments, StateName, CreatedAt)
 values ('', '', '', getutcdate());
-declare @JobId int;
+declare @JobId bigint;
 set @JobId = scope_identity();
 insert into HangFire.State (JobId, Name, CreatedAt)
 values (@JobId, 'old-state', getutcdate());
 insert into HangFire.State (JobId, Name, Reason, Data, CreatedAt)
 values (@JobId, @name, @reason, @data, getutcdate());
-declare @StateId int;
+declare @StateId bigint;
 set @StateId = scope_identity();
 update HangFire.Job set StateId = @StateId;
 select @JobId as Id;";
@@ -254,11 +254,12 @@ select @JobId as Id;";
                     { "Key", "Value" }
                 };
 
-                var jobId = (int)sql.Query(
+                var jobId = (long)sql.Query(
                     arrangeSql,
                     new { name = "Name", reason = "Reason", @data = JobHelper.ToJson(data) }).Single().Id;
 
                 var result = connection.GetStateData(jobId.ToString());
+
                 Assert.NotNull(result);
 
                 Assert.Equal("Name", result.Name);
@@ -273,13 +274,13 @@ select @JobId as Id;";
             const string arrangeSql = @"
 insert into HangFire.Job (InvocationData, Arguments, StateName, CreatedAt)
 values ('', '', '', getutcdate());
-declare @JobId int;
+declare @JobId bigint;
 set @JobId = scope_identity();
 insert into HangFire.State (JobId, Name, CreatedAt)
 values (@JobId, 'old-state', getutcdate());
 insert into HangFire.State (JobId, Name, Reason, Data, CreatedAt)
 values (@JobId, @name, @reason, @data, getutcdate());
-declare @StateId int;
+declare @StateId bigint;
 set @StateId = scope_identity();
 update HangFire.Job set StateId = @StateId;
 select @JobId as Id;";
@@ -291,7 +292,7 @@ select @JobId as Id;";
                     { "key", "Value" }
                 };
 
-                var jobId = (int)sql.Query(
+                var jobId = (long)sql.Query(
                     arrangeSql,
                     new { name = "Name", reason = "Reason", @data = JobHelper.ToJson(data) }).Single().Id;
 
@@ -321,7 +322,7 @@ select scope_identity() as Id";
                         arguments = "['Arguments']"
                     }).Single();
 
-                var result = connection.GetJobData(((int)jobId.Id).ToString());
+                var result = connection.GetJobData(((long)jobId.Id).ToString());
 
                 Assert.NotNull(result.LoadException);
             });
@@ -459,7 +460,7 @@ select scope_identity() as Id";
         public void GetParameter_ReturnsParameterValue_WhenJobExists()
         {
             const string arrangeSql = @"
-declare @id int
+declare @id bigint
 insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
 values ('', '', getutcdate())
 set @id = scope_identity()
@@ -469,7 +470,7 @@ select @id";
 
             UseConnections((sql, connection) =>
             {
-                var id = sql.Query<int>(
+                var id = sql.Query<long>(
                     arrangeSql,
                     new { name = "name", value = "value" }).Single();
 
@@ -1327,6 +1328,194 @@ values (@key, @value, @expireAt, 0.0)";
                 // Assert
                 Assert.True(TimeSpan.FromMinutes(59) < result);
                 Assert.True(result < TimeSpan.FromMinutes(61));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetJobData_ReturnsResult_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON;
+insert into HangFire.Job (Id, InvocationData, Arguments, StateName, CreatedAt)
+values (@jobId, @invocationData, '[''Arguments'']', 'Succeeded', getutcdate());";
+
+            UseConnections((sql, connection) =>
+            {
+                var job = Job.FromExpression(() => SampleMethod("hello"));
+
+                sql.Query(
+                    arrangeSql,
+                    new
+                    {
+                        jobId = int.MaxValue + 1L,
+                        invocationData = JobHelper.ToJson(InvocationData.Serialize(job)),
+                    });
+
+                var result = connection.GetJobData((int.MaxValue + 1L).ToString());
+
+                Assert.NotNull(result);
+                Assert.NotNull(result.Job);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetStateData_ReturnsCorrectData_WhenJobIdAndStateIdAreLongValues()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, StateName, CreatedAt)
+values (@jobId, '', '', '', getutcdate());
+insert into HangFire.State (JobId, Name, CreatedAt)
+values (@jobId, 'old-state', getutcdate());
+SET IDENTITY_INSERT HangFire.Job OFF
+SET IDENTITY_INSERT HangFire.State ON
+insert into HangFire.State (Id, JobId, Name, Data, CreatedAt)
+values (@stateId, @jobId, 'Name', @data, getutcdate());
+update HangFire.Job set StateId = @stateId;";
+
+            UseConnections((sql, connection) =>
+            {
+                var data = new Dictionary<string, string>
+                {
+                    { "Key", "Value" }
+                };
+
+                sql.Query(
+                    arrangeSql,
+                    new
+                    {
+                        jobId = int.MaxValue + 1L,
+                        stateId = int.MaxValue + 1L,
+                        data = JobHelper.ToJson(data)
+                    });
+
+                var result = connection.GetStateData((int.MaxValue + 1L).ToString());
+
+                Assert.NotNull(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void CreateExpiredJob_HandlesJobIdCanExceedInt32Max()
+        {
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Query($"DBCC CHECKIDENT('HangFire.Job', RESEED, {int.MaxValue});");
+
+                // Act
+                var createdAt = new DateTime(2012, 12, 12);
+                var jobId = connection.CreateExpiredJob(
+                    Job.FromExpression(() => SampleMethod("Hello")),
+                    new Dictionary<string, string>(),
+                    createdAt,
+                    TimeSpan.FromDays(1));
+
+                // Assert
+                Assert.Equal((int.MaxValue + 1L).ToString(), jobId);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void SetJobParameter_CreatesNewParameter_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt)
+values (@jobId, '', '', getutcdate())";
+
+            UseConnections((sql, connection) =>
+            {
+                sql.Query(
+                    arrangeSql,
+                    new { jobId =  int.MaxValue + 1L});
+
+                connection.SetJobParameter((int.MaxValue + 1L).ToString(), "Name", "Value");
+
+                var parameter = sql.Query(
+                    "select * from HangFire.JobParameter where JobId = @id and Name = @name",
+                    new { id = int.MaxValue + 1L, name = "Name" }).Single();
+
+                Assert.NotNull(parameter);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void SetJobParameter_HandlesJobParameterIdCanExceedInt32Max()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values ('', '', getutcdate())
+select scope_identity() as Id";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                var job = sql.Query(arrangeSql).Single();
+                string jobId = job.Id.ToString();
+                sql.Query($"DBCC CHECKIDENT('HangFire.JobParameter', RESEED, {int.MaxValue});");
+
+                // Act
+                connection.SetJobParameter(jobId, "Name", "Value");
+
+                var parameter = sql.Query(
+                    "select * from HangFire.JobParameter where JobId = @id and Name = @name",
+                    new { id = jobId, name = "Name" }).Single();
+
+                // Assert
+                Assert.Equal(int.MaxValue + 1L, parameter.Id);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetJobParameter_ReturnsParameterValue_WhenJobIdAndJobParameterIdAreLongValues()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt)
+values (@jobId, '', '', getutcdate())
+SET IDENTITY_INSERT HangFire.Job OFF
+SET IDENTITY_INSERT HangFire.JobParameter ON
+insert into HangFire.JobParameter (Id, JobId, Name, Value)
+values (@id, @jobId, @name, @value)";
+
+            UseConnections((sql, connection) =>
+            {
+                sql.Query(
+                    arrangeSql, 
+                    new
+                    { 
+                        id = int.MaxValue + 1L,
+                        jobId = int.MaxValue + 1L,
+                        name = "name", value = "value"
+                    });
+
+                var value = connection.GetJobParameter((int.MaxValue + 1L).ToString(), "name");
+
+                Assert.Equal("value", value);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void SetRangeInHash_HandlesHashIdCanExceedInt32Max()
+        {
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Query($"DBCC CHECKIDENT('HangFire.Hash', RESEED, {int.MaxValue});");
+
+                // Act
+                connection.SetRangeInHash("some-hash", new Dictionary<string, string>
+                {
+                    { "Key", "Value" }
+                });
+
+                var result = sql.Query(
+                    "select * from HangFire.Hash where [Key] = @key",
+                    new { key = "some-hash" }).Single();
+
+                // Assert
+                Assert.Equal(int.MaxValue + 1L, result.Id);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -336,12 +336,12 @@ values (scope_identity(), @queue)";
             UseConnection(connection =>
             {
                 var queue = CreateJobQueue(connection);
-                connection.Query($"DBCC CHECKIDENT('HangFire.JobQueue', RESEED, {int.MaxValue});");
+                connection.Query($"DBCC CHECKIDENT('HangFire.JobQueue', RESEED, {int.MaxValue + 1L});");
 
                 queue.Enqueue(connection, "default", "1");
 
                 var record = connection.Query("select * from HangFire.JobQueue").Single();
-                Assert.Equal(int.MaxValue + 1L, record.Id);
+                Assert.True(int.MaxValue  < record.Id);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -115,6 +115,33 @@ select scope_identity() as Id;";
         }
 
         [Fact, CleanDatabase]
+        public void Dequeue_FetchesAJob_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+insert into HangFire.JobQueue (JobId, Queue)
+values (@jobId, @queue);
+select scope_identity() as Id;";
+
+            // Arrange
+            UseConnection(connection =>
+            {
+                // ReSharper disable once UnusedVariable
+                var id = (int)connection.Query(
+                    arrangeSql,
+                    new { jobId = int.MaxValue + 1L, queue = "default" }).Single().Id;
+                var queue = CreateJobQueue(connection);
+
+                // Act
+                var payload = (SqlServerFetchedJob)queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
+
+                // Assert
+                Assert.Equal((int.MaxValue + 1L).ToString(), payload.JobId);
+            });
+        }
+
+        [Fact, CleanDatabase]
         public void Dequeue_ShouldDeleteAJob()
         {
             const string arrangeSql = @"
@@ -286,6 +313,35 @@ values (scope_identity(), @queue)";
                 Assert.Equal("1", record.JobId.ToString());
                 Assert.Equal("default", record.Queue);
                 Assert.Null(record.FetchedAt);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Enqueue_AddsAJob_WhenIdIsLongValue()
+        {
+            UseConnection(connection =>
+            {
+                var queue = CreateJobQueue(connection);
+                
+                queue.Enqueue(connection, "default", (int.MaxValue + 1L).ToString());
+
+                var record = connection.Query("select * from HangFire.JobQueue").Single();
+                Assert.Equal((int.MaxValue + 1L).ToString(), record.JobId.ToString());
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Enqueue_HandlesJobQueueIdCanExceedIntMax()
+        {
+            UseConnection(connection =>
+            {
+                var queue = CreateJobQueue(connection);
+                connection.Query($"DBCC CHECKIDENT('HangFire.JobQueue', RESEED, {int.MaxValue});");
+
+                queue.Enqueue(connection, "default", "1");
+
+                var record = connection.Query("select * from HangFire.JobQueue").Single();
+                Assert.Equal(int.MaxValue + 1L, record.Id);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -967,13 +967,13 @@ values (@key, @expireAt)";
         {
             UseConnection(sql =>
             {
-                sql.Query($"DBCC CHECKIDENT('HangFire.Counter', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.Counter', RESEED, {int.MaxValue + 1L});");
 
                 Commit(sql, x => x.IncrementCounter("my-key"));
 
                 var record = sql.Query("select * from HangFire.Counter").Single();
 
-                Assert.Equal(int.MaxValue + 1L, record.Id);
+                Assert.True(int.MaxValue < record.Id);
             });
         }
 
@@ -982,13 +982,13 @@ values (@key, @expireAt)";
         {
             UseConnection(sql =>
             {
-                sql.Query($"DBCC CHECKIDENT('HangFire.List', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.List', RESEED, {int.MaxValue + 1L});");
 
                 Commit(sql, x => x.InsertToList("my-key", "my-value"));
 
                 var record = sql.Query("select * from HangFire.List").Single();
 
-                Assert.Equal(int.MaxValue + 1L, record.Id);
+                Assert.True(int.MaxValue < record.Id);
             });
         }
 
@@ -997,13 +997,13 @@ values (@key, @expireAt)";
         {
             UseConnection(sql =>
             {
-                sql.Query($"DBCC CHECKIDENT('HangFire.Set', RESEED, {int.MaxValue});");
+                sql.Query($"DBCC CHECKIDENT('HangFire.Set', RESEED, {int.MaxValue + 1L});");
                 var items = new List<string> { "1" };
 
                 Commit(sql, x => x.AddRangeToSet("my-set", items));
 
                 var record = sql.Query(@"select * from HangFire.[Set] where [Key] = N'my-set'").Single();
-                Assert.Equal(int.MaxValue + 1L, record.Id);
+                Assert.True(int.MaxValue < record.Id);
             });
         }
 

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -962,6 +962,144 @@ values (@key, @expireAt)";
             });
         }
 
+        [Fact, CleanDatabase]
+        public void IncrementCounter_AddsRecordToCounterTable_WhenIdExceedLongValue()
+        {
+            UseConnection(sql =>
+            {
+                sql.Query($"DBCC CHECKIDENT('HangFire.Counter', RESEED, {int.MaxValue});");
+
+                Commit(sql, x => x.IncrementCounter("my-key"));
+
+                var record = sql.Query("select * from HangFire.Counter").Single();
+
+                Assert.Equal(int.MaxValue + 1L, record.Id);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void InsertToList_HandlesListIdCanExceedInt32Max()
+        {
+            UseConnection(sql =>
+            {
+                sql.Query($"DBCC CHECKIDENT('HangFire.List', RESEED, {int.MaxValue});");
+
+                Commit(sql, x => x.InsertToList("my-key", "my-value"));
+
+                var record = sql.Query("select * from HangFire.List").Single();
+
+                Assert.Equal(int.MaxValue + 1L, record.Id);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddRangeToSet_HandlesSetIdCanExceedInt32Max()
+        {
+            UseConnection(sql =>
+            {
+                sql.Query($"DBCC CHECKIDENT('HangFire.Set', RESEED, {int.MaxValue});");
+                var items = new List<string> { "1" };
+
+                Commit(sql, x => x.AddRangeToSet("my-set", items));
+
+                var record = sql.Query(@"select * from HangFire.[Set] where [Key] = N'my-set'").Single();
+                Assert.Equal(int.MaxValue + 1L, record.Id);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void ExpireJob_SetsJobExpirationData_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt)
+values (@jobId, '', '', getutcdate())";
+
+            UseConnection(sql =>
+            {
+                sql.Query(
+                    arrangeSql,
+                    new { jobId = int.MaxValue + 1L });
+
+                Commit(sql, x => x.ExpireJob((int.MaxValue + 1L).ToString(), TimeSpan.FromDays(1)));
+
+                var job = GetTestJob(sql, (int.MaxValue + 1L).ToString());
+                Assert.True(DateTime.UtcNow.AddMinutes(-1) < job.ExpireAt && job.ExpireAt <= DateTime.UtcNow.AddDays(1));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void PersistJob_ClearsTheJobExpirationData_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt, ExpireAt)
+values (@jobId, '', '', getutcdate(), getutcdate())";
+
+            UseConnection(sql =>
+            {
+                sql.Query(
+                    arrangeSql,
+                    new { jobId = int.MaxValue + 1L });
+
+                Commit(sql, x => x.PersistJob((int.MaxValue + 1L).ToString()));
+
+                var job = GetTestJob(sql, (int.MaxValue + 1L).ToString());
+                Assert.Null(job.ExpireAt);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void SetJobState_WorksCorrect_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt)
+values (@jobId, '', '', getutcdate())";
+
+            UseConnection(sql =>
+            {
+                sql.Query(
+                    arrangeSql,
+                    new { jobId = int.MaxValue + 1L });
+
+                var state = new Mock<IState>();
+                state.Setup(x => x.Name).Returns("State");
+
+                Commit(sql, x => x.SetJobState((int.MaxValue + 1L).ToString(), state.Object));
+                var job = GetTestJob(sql, (int.MaxValue + 1L).ToString());
+
+                var jobState = sql.Query("select * from HangFire.State").Single();
+                Assert.Equal(int.MaxValue + 1L, jobState.JobId);
+                Assert.Equal(job.StateId, jobState.Id);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void AddJobState_AddsAState_WhenJobIdIsLongValue()
+        {
+            const string arrangeSql = @"
+SET IDENTITY_INSERT HangFire.Job ON
+insert into HangFire.Job (Id, InvocationData, Arguments, CreatedAt)
+values (@jobId, '', '', getutcdate())";
+
+            UseConnection(sql =>
+            {
+                sql.Query(
+                   arrangeSql,
+                   new { jobId = int.MaxValue + 1L });
+
+                var state = new Mock<IState>();
+                state.Setup(x => x.Name).Returns("State");
+
+                Commit(sql, x => x.AddJobState((int.MaxValue + 1L).ToString(), state.Object));
+
+                var jobState = sql.Query("select * from HangFire.State").Single();
+
+                Assert.Equal(int.MaxValue + 1L, jobState.JobId);
+            });
+        }
+
         private static void UseConnection(Action<SqlConnection> action)
         {
             using (var connection = ConnectionUtils.CreateConnection())


### PR DESCRIPTION
Identity columns in all tables have *int* type. Now there will be error if rows count exceed int.Max value.

This PR solves this problem by setting *bigint* type for identity columns in all tables.

Fix #749 

I also added in this PR sql migration:
* Make IX_HangFire_JobParameter_JobIdAndName index unique.