### PR TITLE
Catch DistributedLockTimeoutException in some background processes.

### DIFF
--- a/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
@@ -105,6 +105,18 @@ namespace Hangfire.Core.Tests.Server
             _distributedLock.Verify(x => x.Dispose());
         }
 
+        [Fact]
+        public void Execute_DoesNotThrowDistributedLockTimeoutException()
+        {
+            _connection
+                .Setup(x => x.AcquireDistributedLock("locks:schedulepoller", It.IsAny<TimeSpan>()))
+                .Throws(new DistributedLockTimeoutException("locks:schedulepoller"));
+
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+        }
+
         private DelayedJobScheduler CreateScheduler()
         {
             return new DelayedJobScheduler(Timeout.InfiniteTimeSpan, _stateChanger.Object);

--- a/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
@@ -314,6 +314,18 @@ namespace Hangfire.Core.Tests.Server
                 It.Is<DateTime>(time => time < nextExecution)));
         }
 
+        [Fact]
+        public void Execute_DoesNotThrowDistributedLockTimeoutException()
+        {
+            _connection
+                .Setup(x => x.AcquireDistributedLock("recurring-jobs:lock", It.IsAny<TimeSpan>()))
+                .Throws(new DistributedLockTimeoutException("recurring-jobs:lock"));
+
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+        }
+
         private RecurringJobScheduler CreateScheduler()
         {
             return new RecurringJobScheduler(


### PR DESCRIPTION
Catch `DistributedLockTimeoutException` exceptions in `RecurringJobScheduler`, `DelayedJobScheduler`, `ExpirationManager` background processes.

If `DistributedLockTimeoutException` is thrown during running of these processes it doesn't mean that work  wasn't done. It just mean another Hangfire server did the work. Thus we should catch this exception.

In case of a large set of Hangfire servers it will make easier to read logs because they won't contain many records about `DistributedLockTimeoutException`.