### PR TITLE
Catch DistributedLockTimeoutException in some background processes.

### DIFF
--- a/src/Hangfire.Core/Server/DelayedJobScheduler.cs
+++ b/src/Hangfire.Core/Server/DelayedJobScheduler.cs
@@ -156,12 +156,12 @@ namespace Hangfire.Server
                     // No more scheduled jobs pending.
                     return false;
                 }
-
+                
                 var appliedState = _stateChanger.ChangeState(new StateChangeContext(
                     context.Storage,
                     connection,
                     jobId,
-                    new EnqueuedState { Reason = $"Triggered by {ToString()}" },
+                    new EnqueuedState { Reason = $"Triggered by {ToString()}" }, 
                     ScheduledState.StateName));
 
                 if (appliedState == null)

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -119,52 +119,32 @@ namespace Hangfire.Server
 
             _throttler.Throttle(context.CancellationToken);
 
-            using (var connection = context.Storage.GetConnection())
+            UseConnectionDistributedLock(context.Storage, connection =>
             {
-                IDisposable distributedLock;
+                var recurringJobIds = connection.GetAllItemsFromSet("recurring-jobs");
 
-                try
+                foreach (var recurringJobId in recurringJobIds)
                 {
-                    distributedLock = connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout);
-                }
-                catch (DistributedLockTimeoutException)
-                {
-                    // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
-                    // It just means another Hangfire server did this work.
+                    var recurringJob = connection.GetAllEntriesFromHash(
+                        $"recurring-job:{recurringJobId}");
 
-                    _throttler.Delay(context.CancellationToken);
-                    return;
-                }
-
-                using (distributedLock)
-                {
-                    var recurringJobIds = connection.GetAllItemsFromSet("recurring-jobs");
-
-                    foreach (var recurringJobId in recurringJobIds)
+                    if (recurringJob == null)
                     {
-                        var recurringJob = connection.GetAllEntriesFromHash(
-                            $"recurring-job:{recurringJobId}");
-
-                        if (recurringJob == null)
-                        {
-                            continue;
-                        }
-
-                        try
-                        {
-                            TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob);
-                        }
-                        catch (JobLoadException ex)
-                        {
-                            Logger.WarnException(
-                                $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
-                                ex);
-                        }
+                        continue;
                     }
 
-                    _throttler.Delay(context.CancellationToken);
+                    try
+                    {
+                        TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob);
+                    }
+                    catch (JobLoadException ex)
+                    {
+                        Logger.WarnException(
+                            $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
+                            ex);
+                    }
                 }
-            }
+            });
 
             // The code above may be completed in less than a second. Default throttler use
             // the second resolution, and without an extra delay, CPU and DB bursts may happen.
@@ -253,6 +233,20 @@ namespace Hangfire.Server
                     ex);
             }
 
+        }
+
+        private void UseConnectionDistributedLock(JobStorage storage, Action<IStorageConnection> action)
+        {
+            using (var connection = storage.GetConnection())
+            {
+                connection.UseDistributedLock(
+                    "recurring-jobs:lock",
+                    LockTimeout,
+                    action,
+                    // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
+                    // It just means another Hangfire server did this work.
+                    throwTimeoutException: false);
+            }
         }
 
         private static DateTime GetLastInstant(IReadOnlyDictionary<string, string> recurringJob, DateTime nowInstant)

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -237,18 +237,23 @@ namespace Hangfire.Server
 
         private void UseConnectionDistributedLock(JobStorage storage, Action<IStorageConnection> action)
         {
+            var resource = "recurring-jobs:lock";
             try
             {
                 using (var connection = storage.GetConnection())
-                using (connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout))
+                using (connection.AcquireDistributedLock(resource, LockTimeout))
                 {
                     action(connection);
                 }
             }
-            catch (DistributedLockTimeoutException e) when (e.Resource == "recurring-jobs:lock")
+            catch (DistributedLockTimeoutException e) when (e.Resource == resource)
             {
                 // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
                 // It just means another Hangfire server did this work.
+                Logger.Log(
+                    LogLevel.Debug,
+                    () => $@"An exception was thrown during acquiring distributed lock the {resource} resource within {LockTimeout.TotalSeconds} seconds. The recurring jobs have not been handled this time.",
+                    e);
             }
         }
 

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -120,30 +120,49 @@ namespace Hangfire.Server
             _throttler.Throttle(context.CancellationToken);
 
             using (var connection = context.Storage.GetConnection())
-            using (connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout))
             {
-                var recurringJobIds = connection.GetAllItemsFromSet("recurring-jobs");
+                IDisposable distributedLock;
 
-                foreach (var recurringJobId in recurringJobIds)
+                try
                 {
-                    var recurringJob = connection.GetAllEntriesFromHash(
-                        $"recurring-job:{recurringJobId}");
+                    distributedLock = connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout);
+                }
+                catch (DistributedLockTimeoutException)
+                {
+                    // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
+                    // It just means another Hangfire server did this work.
 
-                    if (recurringJob == null)
+                    _throttler.Delay(context.CancellationToken);
+                    return;
+                }
+
+                using (distributedLock)
+                {
+                    var recurringJobIds = connection.GetAllItemsFromSet("recurring-jobs");
+
+                    foreach (var recurringJobId in recurringJobIds)
                     {
-                        continue;
+                        var recurringJob = connection.GetAllEntriesFromHash(
+                            $"recurring-job:{recurringJobId}");
+
+                        if (recurringJob == null)
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob);
+                        }
+                        catch (JobLoadException ex)
+                        {
+                            Logger.WarnException(
+                                $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
+                                ex);
+                        }
                     }
 
-                    try
-                    {
-                        TryScheduleJob(context.Storage, connection, recurringJobId, recurringJob);
-                    }
-                    catch (JobLoadException ex)
-                    {
-                        Logger.WarnException(
-                            $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
-                            ex);
-                    }
+                    _throttler.Delay(context.CancellationToken);
                 }
             }
 

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -237,15 +237,18 @@ namespace Hangfire.Server
 
         private void UseConnectionDistributedLock(JobStorage storage, Action<IStorageConnection> action)
         {
-            using (var connection = storage.GetConnection())
+            try
             {
-                connection.UseDistributedLock(
-                    "recurring-jobs:lock",
-                    LockTimeout,
-                    action,
-                    // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
-                    // It just means another Hangfire server did this work.
-                    throwTimeoutException: false);
+                using (var connection = storage.GetConnection())
+                using (connection.AcquireDistributedLock("recurring-jobs:lock", LockTimeout))
+                {
+                    action(connection);
+                }
+            }
+            catch (DistributedLockTimeoutException e) when (e.Resource == "recurring-jobs:lock")
+            {
+                // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
+                // It just means another Hangfire server did this work.
             }
         }
 

--- a/src/Hangfire.Core/Storage/DistributedLockTimeoutException.cs
+++ b/src/Hangfire.Core/Storage/DistributedLockTimeoutException.cs
@@ -9,6 +9,9 @@ namespace Hangfire.Storage
                 $"Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the '{resource}' resource."
                 )
         {
+            Resource = resource;
         }
+
+        public string Resource { get; }
     }
 }

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -36,52 +36,6 @@ namespace Hangfire.Storage
                 timeout);
         }
 
-        public static T UseDistributedLock<T>(
-           [NotNull] this IStorageConnection connection,
-           string resource,
-           TimeSpan timeout,
-           Func<IStorageConnection, T> action,
-           bool throwTimeoutException
-           )
-        {
-            if (connection == null) throw new ArgumentNullException(nameof(connection));
-
-            try
-            {
-                using (connection.AcquireDistributedLock(resource, timeout))
-                {
-                    return action(connection);
-                }
-            }
-            catch (DistributedLockTimeoutException e) when (e.Resource == resource)
-            {
-                if (throwTimeoutException) throw;
-
-                return default(T);
-            }
-        }
-
-        public static void UseDistributedLock(
-          [NotNull] this IStorageConnection connection,
-          string resource,
-          TimeSpan timeout,
-          Action<IStorageConnection> action,
-          bool throwTimeoutException
-          )
-        {
-            UseDistributedLock(
-                connection,
-                resource,
-                timeout,
-                storageConnection =>
-                {
-                    action(storageConnection);
-                    return true;
-                },
-                throwTimeoutException
-            );
-        }
-
         public static long GetRecurringJobCount([NotNull] this JobStorageConnection connection)
         {
             if (connection == null) throw new ArgumentNullException(nameof(connection));

--- a/src/Hangfire.SqlServer/ExpirationManager.cs
+++ b/src/Hangfire.SqlServer/ExpirationManager.cs
@@ -115,6 +115,11 @@ namespace Hangfire.SqlServer
             {
                 // DistributedLockTimeoutException here doesn't mean that outdated records weren't removed.
                 // It just means another Hangfire server did this work.
+                Logger.Log(
+                    LogLevel.Debug,
+                    () => $@"An exception was thrown during acquiring distributed lock on the {DistributedLockKey} resource within {DefaultLockTimeout.TotalSeconds} seconds. Outdated records were not removed.
+It will be retried in {_checkInterval.TotalSeconds} seconds.",
+                    e);
             }
         }
 

--- a/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/DelayedJobSchedulerFacts.cs
@@ -105,6 +105,18 @@ namespace Hangfire.Core.Tests.Server
             _distributedLock.Verify(x => x.Dispose());
         }
 
+        [Fact]
+        public void Execute_DoesNotThrowDistributedLockTimeoutException()
+        {
+            _connection
+                .Setup(x => x.AcquireDistributedLock("locks:schedulepoller", It.IsAny<TimeSpan>()))
+                .Throws(new DistributedLockTimeoutException("locks:schedulepoller"));
+
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+        }
+
         private DelayedJobScheduler CreateScheduler()
         {
             return new DelayedJobScheduler(Timeout.InfiniteTimeSpan, _stateChanger.Object);

--- a/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/RecurringJobSchedulerFacts.cs
@@ -308,6 +308,18 @@ namespace Hangfire.Core.Tests.Server
                     == JobHelper.SerializeDateTime(_nowInstant))));
         }
 
+        [Fact]
+        public void Execute_DoesNotThrowDistributedLockTimeoutException()
+        {
+            _connection
+                .Setup(x => x.AcquireDistributedLock("recurring-jobs:lock", It.IsAny<TimeSpan>()))
+                .Throws(new DistributedLockTimeoutException("recurring-jobs:lock"));
+
+            var scheduler = CreateScheduler();
+
+            scheduler.Execute(_context.Object);
+        }
+
         private RecurringJobScheduler CreateScheduler(DateTime? lastExecution = null)
         {
             var scheduler = new RecurringJobScheduler(


### PR DESCRIPTION
Catch `DistributedLockTimeoutException` exceptions in `RecurringJobScheduler`, `DelayedJobScheduler`, `ExpirationManager` background processes.

If `DistributedLockTimeoutException` is thrown during running of these processes it doesn't mean that work  wasn't done. It just mean another Hangfire server did the work. Thus we should catch this exception.

In case of a large set of Hangfire servers it will make easier to read logs because they won't contain many records about `DistributedLockTimeoutException`.