### PR TITLE
Fix issue with configuration block not called on .NET Core + reuse services

### DIFF
--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardContext.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardContext.cs
@@ -17,6 +17,7 @@
 using System;
 using Hangfire.Annotations;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hangfire.Dashboard
 {
@@ -36,5 +37,15 @@ namespace Hangfire.Dashboard
         }
 
         public HttpContext HttpContext { get; }
+
+        public override IBackgroundJobClient GetBackgroundJobClient()
+        {
+            return HttpContext.RequestServices.GetService<IBackgroundJobClient>() ?? base.GetBackgroundJobClient();
+        }
+
+        public override IRecurringJobManager GetRecurringJobManager()
+        {
+            return HttpContext.RequestServices.GetService<IRecurringJobManager>() ?? base.GetRecurringJobManager();
+        }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardContext.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardContext.cs
@@ -38,5 +38,15 @@ namespace Hangfire.Dashboard
         
         public DashboardRequest Request { get; protected set; }
         public DashboardResponse Response { get; protected set; }
+
+        public virtual IBackgroundJobClient GetBackgroundJobClient()
+        {
+            return new BackgroundJobClient(Storage);
+        }
+
+        public virtual IRecurringJobManager GetRecurringJobManager()
+        {
+            return new RecurringJobManager(Storage);
+        }
     }
 }

--- a/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
@@ -152,7 +152,7 @@ namespace Hangfire.Dashboard
                 "/jobs/actions/requeue/(?<JobId>.+)",
                 context =>
                 {
-                    var client = new BackgroundJobClient(context.Storage);
+                    var client = context.GetBackgroundJobClient();
                     return client.ChangeState(context.UriMatch.Groups["JobId"].Value, CreateEnqueuedState());
                 });
 
@@ -160,7 +160,7 @@ namespace Hangfire.Dashboard
                 "/jobs/actions/delete/(?<JobId>.+)",
                 context =>
                 {
-                    var client = new BackgroundJobClient(context.Storage);
+                    var client = context.GetBackgroundJobClient();
                     return client.ChangeState(context.UriMatch.Groups["JobId"].Value, CreateDeletedState());
                 });
 

--- a/src/Hangfire.Core/Dashboard/RouteCollectionExtensions.cs
+++ b/src/Hangfire.Core/Dashboard/RouteCollectionExtensions.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Text.RegularExpressions;
 using Hangfire.Annotations;
+using System.ComponentModel;
 
 namespace Hangfire.Dashboard
 {
@@ -34,7 +35,7 @@ namespace Hangfire.Dashboard
             routes.Add(pathTemplate, new RazorPageDispatcher(pageFunc));
         }
 
-#if NETFULL
+#if NETFULL && OBSOLETE
         [Obsolete("Use the AddCommand(RouteCollection, string, Func<DashboardContext, bool>) overload instead. Will be removed in 2.0.0.")]
         public static void AddCommand(
             [NotNull] this RouteCollection routes, 
@@ -61,7 +62,7 @@ namespace Hangfire.Dashboard
             routes.Add(pathTemplate, new CommandDispatcher(command));
         }
 
-#if NETFULL
+#if NETFULL && OBSOLETE
         [Obsolete("Use the AddBatchCommand(RouteCollection, string, Func<DashboardContext, bool>) overload instead. Will be removed in 2.0.0.")]
         public static void AddBatchCommand(
             [NotNull] this RouteCollection routes, 
@@ -97,11 +98,27 @@ namespace Hangfire.Dashboard
 
             routes.AddBatchCommand(pathTemplate, (context, jobId) =>
             {
-                var client = new BackgroundJobClient(context.Storage);
+                var client = context.GetBackgroundJobClient();
                 command(client, jobId);
             });
         }
 
+        public static void AddRecurringBatchCommand(
+            this RouteCollection routes,
+            string pathTemplate,
+            [NotNull] Action<IRecurringJobManager, string> command)
+        {
+            if (command == null) throw new ArgumentNullException(nameof(command));
+
+            routes.AddBatchCommand(pathTemplate, (context, jobId) =>
+            {
+                var manager = context.GetRecurringJobManager();
+                command(manager, jobId);
+            });
+        }
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("For binary compatibility only. Use overload with Action<IRecurringJobManager, string> instead.")]
         public static void AddRecurringBatchCommand(
             this RouteCollection routes,
             string pathTemplate,

--- a/src/Hangfire.Core/Dashboard/RouteCollectionExtensions.cs
+++ b/src/Hangfire.Core/Dashboard/RouteCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Hangfire.Dashboard
             routes.Add(pathTemplate, new RazorPageDispatcher(pageFunc));
         }
 
-#if NETFULL && OBSOLETE
+#if NETFULL
         [Obsolete("Use the AddCommand(RouteCollection, string, Func<DashboardContext, bool>) overload instead. Will be removed in 2.0.0.")]
         public static void AddCommand(
             [NotNull] this RouteCollection routes, 
@@ -62,7 +62,7 @@ namespace Hangfire.Dashboard
             routes.Add(pathTemplate, new CommandDispatcher(command));
         }
 
-#if NETFULL && OBSOLETE
+#if NETFULL
         [Obsolete("Use the AddBatchCommand(RouteCollection, string, Func<DashboardContext, bool>) overload instead. Will be removed in 2.0.0.")]
         public static void AddBatchCommand(
             [NotNull] this RouteCollection routes, 


### PR DESCRIPTION
On .NET Core the typical initialization of Hangfire is supposed to look like this:
```c#
services.AddHangfire(options => 
{
    options.UseSqlServerStorage("connection string");
    // other things, like options.UseConsole();
});
```
and it seems to work (most of the time).

However, in some cases one might want to move storage initialization away from configuration block, and place it directry into IoC container:
```c#
services.AddSingleton<JobStorage>(serviceProvider =>
{
    var config = serviceProvider.GetRequiredService<IOptions<DatabaseConfiguration>>().Value;
    return new SqlServerStorage(config.ConnectionString, config.Options);
});

services.AddHangfire(options => 
{
    // other things
}
```
And there's a very valid reason for that: you can use a standard `IOptions<T>` (or any other) service for retrieving configuration parameters however you like, which is not possible inside Hangfire's configuration block since `IServiceProvider` is not exposed (and exposing it will likely be a breaking change).

After that, however, the jobs start failing with a `MissingMethodException`: "No parameterless constructor defined for this object". After some investigation, I've found out that Hangfire was now using `SimpleJobActivator` instead of `AspNetCoreJobActivator`, which obviously cannot inject services into constructor. Not only that, it also completely ignored its own configuration block!

After looking into the code, it turned out that initialization of default logger and activator, as well as invocation of the configuration block, was done in the factory method of a JobStorage service. And since the whole service is now replaced, nothing was initialized at all.

It also appears that BackgroundJobServer and Dashboard are using theirs own hard-coded instances of `IBackgroundJobPerformer` & co., even though they are exposed as services, and it should be possible to replace them with a different implementation.

The purpose of this PR is to address all these issues:
- It gets rid of the messy static field that holds the initialization flag.
- It guarantees that the configuration block will be called, even if you would eventually replace all the underlying services. It also guarantees that configuration block will be called in client-only scenarios, given that you're using `IBackgroundJobClient` / `IRecurringJobManager` instances instead of theirs static counterparts. _Who would want to use static wrappers on .NET Core anyway?_
- Background server and Dashboard now also make use of `IBackgroundJobFactory`, `IBackgroundJobStateChanger` and `IBackgroundJobPerformer` IoC services, which were previously used solely by clients. This also eliminates the probable difference between job filters used by client and server counterparts.
- And it all seems like non-breaking changes.

Uhh, I'm tired of writing this text more than from making the PR itself… :)