### PR TITLE
Fix number of displayed Records in RecurringJobsPage

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
@@ -23,7 +23,7 @@
 	    if (storageConnection != null)
 	    {
 	        pager = new Pager(from, perPage, storageConnection.GetRecurringJobCount());
-	        recurringJobs = storageConnection.GetRecurringJobs(pager.FromRecord, pager.FromRecord + pager.RecordsPerPage - 1);
+	        recurringJobs = storageConnection.GetRecurringJobs(pager.FromRecord, pager.FromRecord + pager.RecordsPerPage);
 	    }
 	    else
 	    {


### PR DESCRIPTION
The RecurringJobsPage only displayed 9 instead of 10 items.