### PR TITLE
Move creating job scope from CoreBackgroundJobPerformer to Worker

### DIFF
--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -55,8 +55,7 @@ namespace Hangfire
                 x.GetRequiredService<IJobFilterProvider>()));
 
             services.TryAddSingleton<IBackgroundJobPerformer>(x => new BackgroundJobPerformer(
-                x.GetRequiredService<IJobFilterProvider>(),
-                x.GetRequiredService<JobActivator>()));
+                x.GetRequiredService<IJobFilterProvider>()));
 
             services.TryAddSingleton<IBackgroundJobClient>(x => new BackgroundJobClient(
                 x.GetRequiredService<JobStorage>(),

--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -131,12 +131,12 @@ namespace Hangfire
             var filterProvider = _options.FilterProvider ?? JobFilterProviders.Providers;
 
             var factory = new BackgroundJobFactory(filterProvider);
-            var performer = new BackgroundJobPerformer(filterProvider, _options.Activator ?? JobActivator.Current);
+            var performer = new BackgroundJobPerformer(filterProvider);
             var stateChanger = new BackgroundJobStateChanger(filterProvider);
             
             for (var i = 0; i < _options.WorkerCount; i++)
             {
-                processes.Add(new Worker(_options.Queues, performer, stateChanger));
+                processes.Add(new Worker(_options.Queues, performer, stateChanger, _options.Activator ?? JobActivator.Current));
             }
             
             processes.Add(new DelayedJobScheduler(_options.SchedulePollingInterval, stateChanger));

--- a/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
@@ -33,19 +33,12 @@ namespace Hangfire.Server
         }
 
         public BackgroundJobPerformer([NotNull] IJobFilterProvider filterProvider)
-            : this(filterProvider, JobActivator.Current)
-        {
-        }
-
-        public BackgroundJobPerformer(
-            [NotNull] IJobFilterProvider filterProvider,
-            [NotNull] JobActivator activator)
-            : this(filterProvider, new CoreBackgroundJobPerformer(activator))
+            : this(filterProvider, new CoreBackgroundJobPerformer())
         {
         }
 
         internal BackgroundJobPerformer(
-            [NotNull] IJobFilterProvider filterProvider, 
+            [NotNull] IJobFilterProvider filterProvider,
             [NotNull] IBackgroundJobPerformer innerPerformer)
         {
             if (filterProvider == null) throw new ArgumentNullException(nameof(filterProvider));


### PR DESCRIPTION
Currently I'm working on [Orchard CMS](http://www.orchardproject.net/) module for Hangfire. All hangfire interfaces/classes provide proper level for integration except activator scope creation.

The problem is when hangfire filters are executing, job scope already disposed. For example I want to create one IServerExceptionFilter for all tasks and properly handle exceptions including transaction. Orchard exception filter for hangfire that rollback transaction for any exception can looks like
```csharp
namespace Orchard.Hangfire {
    using Hangfire.Server;
    using Orchard.Data;

    public class TransactionFilter : IServerExceptionFilter {
        public void OnServerException(ServerExceptionContext filterContext) {
            var transaction = filterContext.Resolve(typeof(ITransactionManager)) as ITransactionManager;
            transaction.Cancel();
        }
    }
}
```
Or it can be useful to resolve some services in IServerFilter.OnPerforming/OnPerformed hangfire filter todo some operations not only related to hangfire logic but for our application also. For example send email notification when job successfully completed using our internal services resolved via scope. 

I propose move job scope creating from CoreBackgroundJobPerformer to Worker and extend PerformContext class by Resolve method. This pull request only as a starting point for discussion. Please note this changes already tested on our live servers and successfully working for a couple of months.

My changes break backward compatibility and tests and pull request didn't  provide fixes for tests.

As I know new hangfire version 2.0 will have a list of backward compatibility issues. I think a proper way to discuss and implement such changes in scope for new version. But I also can update this PR to be backward compatible with current 1.6.10 version.

I'm open for any discussion.