### PR TITLE
Distributed lock timeout change/explaination

### DIFF
--- a/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
+++ b/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
@@ -26,7 +26,7 @@ namespace Hangfire
 
         public DisableConcurrentExecutionAttribute(int timeoutInSeconds)
         {
-            if (timeoutInSeconds < 0) throw new ArgumentException("Timeout argument value should be greater that zero.");
+            if (!(timeoutInSeconds >= 0)) throw new ArgumentException("Timeout argument cannot be negative.");
 
             _timeoutInSeconds = timeoutInSeconds;
         }

--- a/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
+++ b/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
@@ -24,7 +24,7 @@ namespace Hangfire
     {
         private readonly int _timeoutInSeconds;
 
-        public DisableConcurrentExecutionAttribute(int timeoutInSeconds)
+        public DisableConcurrentExecutionAttribute(int timeoutInSeconds = 0)
         {
             if (!(timeoutInSeconds >= 0)) throw new ArgumentException("Timeout argument cannot be negative.");
 


### PR DESCRIPTION
I might have gotten this wrong, please advice if there's any issues here but here's why I think this change might be reasonable.

Given that the `sp_getapplock` `@LockTimeout ` parameter depends on this value, it should be possible to specify zero, which implies that you don't want to wait to acquire the lock. It's also not clear from the documentation or code that this timeout refer to the maximum amount of time to wait to acquire the lock, it's not the length the lock is being held.

Thus, if you use this functionality to prevent concurrent execution of jobs then I think that the timeout should be optional and the default behavior should be fail fast. However, this can be debated.

A trivial wokring solution is to just do `[DisableConcurrentExecution(0)]` this is totally a vanity pull request.

See https://msdn.microsoft.com/en-us/library/ms189823.aspx?f=255&MSPPError=-2147217396 for documentation of `sp_getapplock`