### PR TITLE
Add Async Overloads of Jobs Creation's Methods

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.9-build-0{build}
+version: 1.6.10-build-0{build}
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.10-build-0{build}
+version: 1.6.11-build-0{build}
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.7-build-0{build}
+version: 1.6.8-build-0{build}
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.8-build-0{build}
+version: 1.6.9-build-0{build}
 
 os: Visual Studio 2015
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
   round: down
   status:
     changes: false
-    patch: true
+    patch: false
     project: true
 parsers:
   gcov:

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes>http://hangfire.io/blog/
     
 1.6.11
-• Fixed – `NullReferenceException` in dashboard when `owinContext.Auth.User` is `null`.
+• Fixed – `NullReferenceException` in dashboard when OWIN's or ASP.NET Core's `User` is `null`.
 • Fixed – Regression related to missing CSS and JS resources in dashboard appeared in 1.6.10.
     
 1.6.10

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,6 +14,12 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.10
+• Fixed – Duplicate job continuations aren't added anymore, when outer transaction has failed.
+• Fixed – Existing duplicate continuations don't lead to `ArgumentException`: the same key already added.
+• Fixed – Replace inline script, because it may violate the Content Security Policy (by @Beczka).
+• Fixed – Don't skip records in RecurringJobsPage (by @reaction1989).
+    
 1.6.8
 • Fixed – `Cron.MonthInterval` now returns correct CRON expression.
 • Fixed – Throw `NotSupportedException` early, when arguments contain delegate or expression.

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,6 +14,10 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.11
+• Fixed – `NullReferenceException` in dashboard when `owinContext.Auth.User` is `null`.
+• Fixed – Regression related to missing CSS and JS resources in dashboard appeared in 1.6.10.
+    
 1.6.10
 • Fixed – Duplicate job continuations aren't added anymore, when outer transaction has failed.
 • Fixed – Existing duplicate continuations don't lead to `ArgumentException`: the same key already added.

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -14,6 +14,15 @@
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.8
+• Fixed – `Cron.MonthInterval` now returns correct CRON expression.
+• Fixed – Throw `NotSupportedException` early, when arguments contain delegate or expression.
+• Fixed – Connection and distributed lock kept longer than necessary in `RecurringJobScheduler`.
+• Fixed – Use local date/times everywhere in Dashboard UI.
+• Fixed – Call chart update only when it exists in Dashboard UI to prevent JavaScript errors.
+• Fixed – Scheduled column title is now displaying correctly in Dashboard UI.
+• Fixed – Typo "Nexts jobs" should be "Next jobs" in Dashboard UI (by @danielabbatt).
+    
 1.6.7
 • Fixed – ArgumentException when using complex arguments in generic methods like "IList&lt;T&gt;" (by @aidmsu).
 • Fixed – Generic arrays like "T[]" aren't supported in background job arguments (by @aidmsu).

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -14,6 +14,9 @@
     <tags>Hangfire SqlServer SqlAzure LocalDB</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.8
+• Fixed – Use `long` where possible instead of `int` for background job identifiers, full support will be in 1.7.0.
+    
 1.6.7
 • Fixed – Validation added to avoid "An invalid application lock time-out" exceptions (by t0mburton).
     

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -14,6 +14,9 @@
     <tags>Hangfire SqlServer SqlAzure LocalDB</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.9
+• Fixed – `TimeoutException` on large arguments or large batches via `SqlServerOptions.CommandTimeout`.
+
 1.6.8
 • Fixed – Use `long` where possible instead of `int` for background job identifiers, full support will be in 1.7.0.
     

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -19,6 +19,11 @@
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.9
+
+Hangfire.SqlServer
+• Fixed – `TimeoutException` on large arguments or large batches via `SqlServerOptions.CommandTimeout`.
+
 1.6.8
 
 Hangfire.Core

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -19,6 +19,14 @@
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.10
+
+Hangfire.Core
+• Fixed – Duplicate job continuations aren't added anymore, when outer transaction has failed.
+• Fixed – Existing duplicate continuations don't lead to `ArgumentException`: the same key already added.
+• Fixed – Replace inline script, because it may violate the Content Security Policy (by @Beczka).
+• Fixed – Don't skip records in RecurringJobsPage (by @reaction1989).
+    
 1.6.9
 
 Hangfire.SqlServer

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -19,6 +19,12 @@
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.11
+
+Hangfire.Core
+• Fixed – `NullReferenceException` in dashboard when `owinContext.Auth.User` is `null`.
+• Fixed – Regression related to missing CSS and JS resources in dashboard appeared in 1.6.10.
+    
 1.6.10
 
 Hangfire.Core

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -22,7 +22,7 @@
 1.6.11
 
 Hangfire.Core
-• Fixed – `NullReferenceException` in dashboard when `owinContext.Auth.User` is `null`.
+• Fixed – `NullReferenceException` in dashboard when OWIN's or ASP.NET Core's `User` is `null`.
 • Fixed – Regression related to missing CSS and JS resources in dashboard appeared in 1.6.10.
     
 1.6.10

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -19,6 +19,20 @@
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.8
+
+Hangfire.Core
+• Fixed – `Cron.MonthInterval` now returns correct CRON expression.
+• Fixed – Throw `NotSupportedException` early, when arguments contain delegate or expression.
+• Fixed – Connection and distributed lock kept longer than necessary in `RecurringJobScheduler`.
+• Fixed – Use local date/times everywhere in Dashboard UI.
+• Fixed – Call chart update only when it exists in Dashboard UI to prevent JavaScript errors.
+• Fixed – Scheduled column title is now displaying correctly in Dashboard UI.
+• Fixed – Typo "Nexts jobs" should be "Next jobs" in Dashboard UI (by @danielabbatt).
+
+Hangfire.SqlServer
+• Fixed – Use `long` where possible instead of `int` for background job identifiers, full support will be in 1.7.0.
+    
 1.6.7
 
 Hangfire.Core

--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardMiddleware.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardMiddleware.cs
@@ -61,7 +61,9 @@ namespace Hangfire.Dashboard
             {
                 if (!filter.Authorize(context))
                 {
-                    httpContext.Response.StatusCode = httpContext.User.Identity.IsAuthenticated
+                    var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated;
+
+                    httpContext.Response.StatusCode = isAuthenticated == true
                         ? (int) HttpStatusCode.Forbidden
                         : (int) HttpStatusCode.Unauthorized;
 

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -1,4 +1,10 @@
 (function (hangfire) {
+    hangfire.config = {
+        pollInterval: $("#hangfireConfig").data("pollinterval"),
+        pollUrl: $("#hangfireConfig").data("pollurl"),
+        locale: document.documentElement.lang
+    };
+
     hangfire.Metrics = (function() {
         function Metrics() {
             this._metrics = {};

--- a/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
@@ -49,13 +49,13 @@ namespace Hangfire.Dashboard
             
             #region Embedded static content
 
-            Routes.Add("/js[0-9]{3}", new CombinedResourceDispatcher(
+            Routes.Add("/js[0-9]+", new CombinedResourceDispatcher(
                 "application/javascript",
                 GetExecutingAssembly(),
                 GetContentFolderNamespace("js"),
                 Javascripts));
 
-            Routes.Add("/css[0-9]{3}", new CombinedResourceDispatcher(
+            Routes.Add("/css[0-9]+", new CombinedResourceDispatcher(
                 "text/css",
                 GetExecutingAssembly(),
                 GetContentFolderNamespace("css"),

--- a/src/Hangfire.Core/Dashboard/Owin/MiddlewareExtensions.cs
+++ b/src/Hangfire.Core/Dashboard/Owin/MiddlewareExtensions.cs
@@ -104,7 +104,9 @@ namespace Hangfire.Dashboard
 
         private static Task Unauthorized(IOwinContext owinContext)
         {
-            owinContext.Response.StatusCode = owinContext.Authentication.User.Identity.IsAuthenticated
+            var isAuthenticated = owinContext.Authentication?.User?.Identity?.IsAuthenticated;
+
+            owinContext.Response.StatusCode = isAuthenticated == true
                 ? (int)HttpStatusCode.Forbidden
                 : (int)HttpStatusCode.Unauthorized;
 

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -68,15 +68,11 @@
             </div>
         </div>
         
-        <script>
-            (function (hangFire) {
-                hangFire.config = {
-                    pollInterval: @StatsPollingInterval,
-                    pollUrl: '@(Url.To("/stats"))',
-                    locale: '@CultureInfo.CurrentUICulture'
-                };
-            })(window.Hangfire = window.Hangfire || {});
-        </script>
+        <div id="hangfireConfig"
+             data-pollinterval="@StatsPollingInterval"
+             data-pollurl="@(Url.To("/stats"))">
+        </div>
+
         <script src="@Url.To($"/js{version.Major}{version.Minor}{version.Build}")"></script>
     </body>
 </html>

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.generated.cs
@@ -263,43 +263,31 @@ WriteLiteral("</li>\r\n                    <li>");
             #line default
             #line hidden
 WriteLiteral("</li>\r\n                </ul>\r\n            </div>\r\n        </div>\r\n        \r\n     " +
-"   <script>\r\n            (function (hangFire) {\r\n                hangFire.config" +
-" = {\r\n                    pollInterval: ");
+"   <div id=\"hangfireConfig\"\r\n             data-pollinterval=\"");
 
 
             
-            #line 74 "..\..\Dashboard\Pages\LayoutPage.cshtml"
-                             Write(StatsPollingInterval);
-
-            
-            #line default
-            #line hidden
-WriteLiteral(",\r\n                    pollUrl: \'");
-
-
-            
-            #line 75 "..\..\Dashboard\Pages\LayoutPage.cshtml"
-                          Write(Url.To("/stats"));
+            #line 72 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                           Write(StatsPollingInterval);
 
             
             #line default
             #line hidden
-WriteLiteral("\',\r\n                    locale: \'");
+WriteLiteral("\"\r\n             data-pollurl=\"");
+
+
+            
+            #line 73 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                       Write(Url.To("/stats"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n        </div>\r\n\r\n        <script src=\"");
 
 
             
             #line 76 "..\..\Dashboard\Pages\LayoutPage.cshtml"
-                        Write(CultureInfo.CurrentUICulture);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\'\r\n                };\r\n            })(window.Hangfire = window.Hangfire || {});\r\n" +
-"        </script>\r\n        <script src=\"");
-
-
-            
-            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                 Write(Url.To($"/js{version.Major}{version.Minor}{version.Build}"));
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
@@ -23,7 +23,7 @@
 	    if (storageConnection != null)
 	    {
 	        pager = new Pager(from, perPage, storageConnection.GetRecurringJobCount());
-	        recurringJobs = storageConnection.GetRecurringJobs(pager.FromRecord, pager.FromRecord + pager.RecordsPerPage - 1);
+	        recurringJobs = storageConnection.GetRecurringJobs(pager.FromRecord, pager.FromRecord + pager.RecordsPerPage);
 	    }
 	    else
 	    {

--- a/src/Hangfire.SqlServer/CountersAggregator.cs
+++ b/src/Hangfire.SqlServer/CountersAggregator.cs
@@ -57,7 +57,8 @@ namespace Hangfire.SqlServer
                 {
                     removedCount = connection.Execute(
                         GetAggregationQuery(_storage),
-                        new { now = DateTime.UtcNow, count = NumberOfRecordsInSinglePass });
+                        new { now = DateTime.UtcNow, count = NumberOfRecordsInSinglePass },
+                        commandTimeout: 0);
                 });
 
                 if (removedCount >= NumberOfRecordsInSinglePass)

--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -74,7 +74,8 @@ where Queue in @queues";
                     fetchedJob = connection.Query<FetchedJob>(
                         fetchJobSqlTemplate,
                         new { queues = queues },
-                        transaction).SingleOrDefault();
+                        transaction,
+                        commandTimeout: _storage.CommandTimeout).SingleOrDefault();
 
                     if (fetchedJob != null)
                     {
@@ -117,7 +118,7 @@ $@"insert into [{_storage.SchemaName}].JobQueue (JobId, Queue) values (@jobId, @
 #if !NETFULL
                 , transaction
 #endif
-                );
+                , commandTimeout: _storage.CommandTimeout);
         }
 
         [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
@@ -56,7 +56,7 @@ namespace Hangfire.SqlServer
                 {
                     var result = UseTransaction((connection, transaction) =>
                     {
-                        return connection.Query(sqlQuery, transaction: transaction).Select(x => (string) x.Queue).ToList();
+                        return connection.Query(sqlQuery, transaction: transaction, commandTimeout: _storage.CommandTimeout).Select(x => (string) x.Queue).ToList();
                     });
 
                     _queuesCache = result;
@@ -83,7 +83,8 @@ where r.row_num between @start and @end";
                 return connection.Query<JobIdDto>(
                     sqlQuery,
                     new { queue = queue, start = from + 1, end = @from + perPage },
-                    transaction)
+                    transaction,
+                    commandTimeout: _storage.CommandTimeout)
                     .ToList()
                     .Select(x => (int)x.JobId)
                     .ToList();
@@ -102,7 +103,7 @@ select count(Id) from [{_storage.SchemaName}].JobQueue with (nolock) where [Queu
 
             return UseTransaction((connection, transaction) =>
             {
-                var result = connection.ExecuteScalar<int>(sqlQuery, new { queue = queue }, transaction);
+                var result = connection.ExecuteScalar<int>(sqlQuery, new { queue = queue }, transaction, commandTimeout: _storage.CommandTimeout);
 
                 return new EnqueuedAndFetchedCountDto
                 {

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -122,7 +122,7 @@ namespace Hangfire.SqlServer
             return UseConnection<IList<ServerDto>>(connection =>
             {
                 var servers = connection.Query<Entities.Server>(
-                    $@"select * from [{_storage.SchemaName}].Server with (nolock)")
+                    $@"select * from [{_storage.SchemaName}].Server with (nolock)", commandTimeout: _storage.CommandTimeout)
                     .ToList();
 
                 var result = new List<ServerDto>();
@@ -266,7 +266,7 @@ select * from [{_storage.SchemaName}].Job with (nolock) where Id = @id
 select * from [{_storage.SchemaName}].JobParameter with (nolock) where JobId = @id
 select * from [{_storage.SchemaName}].State with (nolock) where JobId = @id order by Id desc";
 
-                using (var multi = connection.QueryMultiple(sql, new { id = jobId }))
+                using (var multi = connection.QueryMultiple(sql, new { id = jobId }, commandTimeout: _storage.CommandTimeout))
                 {
                     var job = multi.Read<SqlJob>().SingleOrDefault();
                     if (job == null) return null;
@@ -336,7 +336,7 @@ select count(*) from [{0}].[Set] with (nolock) where [Key] = N'recurring-jobs';
             var statistics = UseConnection(connection =>
             {
                 var stats = new StatisticsDto();
-                using (var multi = connection.QueryMultiple(sql))
+                using (var multi = connection.QueryMultiple(sql, commandTimeout: _storage.CommandTimeout))
                 {
                     stats.Enqueued = multi.ReadSingle<int>();
                     stats.Failed = multi.ReadSingle<int>();
@@ -400,7 +400,8 @@ where [Key] in @keys";
 
             var valuesMap = connection.Query(
                 sqlQuery,
-                new { keys = keyMaps.Keys })
+                new { keys = keyMaps.Keys },
+                commandTimeout: _storage.CommandTimeout)
                 .ToDictionary(x => (string)x.Key, x => (long)x.Count);
 
             foreach (var key in keyMaps.Keys)
@@ -441,7 +442,8 @@ where j.Id in @jobIds";
 
             var jobs = connection.Query<SqlJob>(
                 enqueuedJobsSql,
-                new { jobIds = jobIds })
+                new { jobIds = jobIds },
+                commandTimeout: _storage.CommandTimeout)
                 .ToDictionary(x => x.Id, x => x);
 
             var sortedSqlJobs = jobIds
@@ -468,7 +470,8 @@ where j.Id in @jobIds";
 
             var count = connection.ExecuteScalar<int>(
                  sqlQuery,
-                 new { state = stateName, limit = _jobListLimit });
+                 new { state = stateName, limit = _jobListLimit },
+                 commandTimeout: _storage.CommandTimeout);
 
             return count;
         }
@@ -511,7 +514,8 @@ order by j.Id desc";
 
             var jobs = connection.Query<SqlJob>(
                         jobsSql,
-                        new { stateName = stateName, start = @from + 1, end = @from + count })
+                        new { stateName = stateName, start = @from + 1, end = @from + count },
+                        commandTimeout: _storage.CommandTimeout)
                         .ToList();
 
             return DeserializeJobs(jobs, selector);
@@ -555,7 +559,8 @@ where j.Id in @jobIds";
 
             var jobs = connection.Query<SqlJob>(
                 fetchedJobsSql,
-                new { jobIds = jobIds })
+                new { jobIds = jobIds },
+                commandTimeout: _storage.CommandTimeout)
                 .ToList();
 
             var result = new List<KeyValuePair<string, FetchedJobDto>>(jobs.Count);

--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -60,7 +60,7 @@ namespace Hangfire.SqlServer
             {
                 try
                 {
-                    connection.Execute(script);
+                    connection.Execute(script, commandTimeout: 0);
                     break;
                 }
                 catch (DbException ex)
@@ -76,7 +76,7 @@ namespace Hangfire.SqlServer
                 }
             }
 #else
-            connection.Execute(script);
+            connection.Execute(script, commandTimeout: 0);
 #endif
 
             Log.Info("Hangfire SQL objects installed.");

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -96,6 +96,7 @@ namespace Hangfire.SqlServer
         public virtual PersistentJobQueueProviderCollection QueueProviders { get; private set; }
 
         internal string SchemaName => _options.SchemaName;
+        internal int? CommandTimeout => _options.CommandTimeout.HasValue ? (int)_options.CommandTimeout.Value.TotalSeconds : (int?)null;
 
         public override IMonitoringApi GetMonitoringApi()
         {

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -75,6 +75,7 @@ namespace Hangfire.SqlServer
 
         public int? DashboardJobListLimit { get; set; }
         public TimeSpan TransactionTimeout { get; set; }
+        public TimeSpan? CommandTimeout { get; set; }
 
         public string SchemaName
         {

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.8")]
+[assembly: AssemblyVersion("1.6.9")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.9")]
+[assembly: AssemblyVersion("1.6.10")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.10")]
+[assembly: AssemblyVersion("1.6.11")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.7")]
+[assembly: AssemblyVersion("1.6.8")]


### PR DESCRIPTION
As I understood, "The control is returned to a caller just after Hangfire serializes the given information and saves it to the storage."

I suggest to return the control to the caller earlier (i.e. no blocking of threads)  by supporting the async/await pattern by overloading the jobs creation's methods (also modify the implementation to call the Async version of data access methods which will finally save the job to the storage), example:

`await BackgroundJob.EnqueueAsync(() => SomeCalss.DoWork());`

Is is possible to see this methods soon ?