### PR TITLE
Change calculation for AutomaticRetryAttribute.cs SecondsToDelay

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -249,9 +249,8 @@ namespace Hangfire
         // delayed_job uses the same basic formula
         private static int SecondsToDelay(long retryCount)
         {
-            var random = new Random();
             return (int)Math.Round(
-                Math.Pow(retryCount - 1, 4) + 15 + random.Next(30) * retryCount);
+                Math.Pow(retryCount - 1, 4) + 43 * retryCount);
         }
     }
 }


### PR DESCRIPTION
The current implementation of SecondsToDelay uses "15 + random.Next(30)" which will generate potential collisions between subsequent requests made within the 30 seconds of each other - so this can lead to higher spikes of retry in a pathological scenario.

For example, if you have 26 failing items (A to Z) which occur at time T, (T + 1), ... , (T + 25) it is possible that all 26 would be scheduled for a retry at the same time in the future because item A may have a random value of 25, B a random value of 24, C a random value of 23 etc etc (unlikely but possible).

Obviously if you have a lot of items retrying at exactly the same time the retry load will be the same in the future with a constant factor but it will be predictable.

But with a random element in play you could end up with randomly much higher retry processing spikes.

My suggestion would be to simplify and use a constant prime number such as "43" and this way the retries will be more deterministic and not produce potentially higher spikes of work.

Note: This solution also eliminates the need to allocate and dispose a new PRNG with each retry attempt.