### PR TITLE
AspNetCoreJobActivatorScope Resolve using ActivatorUtilities.GetServiceOrCreateInstance

### DIFF
--- a/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
+++ b/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
@@ -32,7 +32,7 @@ namespace Hangfire.AspNetCore
 
         public override object Resolve(Type type)
         {
-            return _serviceScope.ServiceProvider.GetRequiredService(type);
+            return ActivatorUtilities.GetServiceOrCreateInstance(_serviceScope.ServiceProvider, type);
         }
 
         public override void DisposeScope()


### PR DESCRIPTION
Use ActivatorUtilities.GetServiceOrCreateInstance instead of ServiceProvider.GetRequiredService, this allows creating instances of notification handlers without requiring them to be registered in DoI. Otherwise GetRequiredService would throw an error if a service isn't registered. This allow the handler to be created and still apply constructor injection to the handler.