### PR TITLE
Reduce serialization size

### DIFF
--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -67,7 +67,7 @@ namespace Hangfire
                 var recurringJob = new Dictionary<string, string>();
                 var invocationData = InvocationData.Serialize(job);
 
-                recurringJob["Job"] = JobHelper.ToJson(invocationData);
+                recurringJob["Job"] = invocationData.Serialize();
                 recurringJob["Cron"] = cronExpression;
                 recurringJob["TimeZoneId"] = options.TimeZone.Id;
                 recurringJob["Queue"] = options.QueueName;
@@ -103,7 +103,7 @@ namespace Hangfire
                     return;
                 }
                 
-                var job = JobHelper.FromJson<InvocationData>(hash["Job"]).Deserialize();
+                var job = InvocationData.Deserialize(hash["Job"]).Deserialize();
                 var state = new EnqueuedState { Reason = "Triggered using recurring job manager" };
 
                 if (hash.ContainsKey("Queue"))

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -159,7 +159,7 @@ namespace Hangfire.Server
             string recurringJobId, 
             IReadOnlyDictionary<string, string> recurringJob)
         {
-            var serializedJob = JobHelper.FromJson<InvocationData>(recurringJob["Job"]);
+            var serializedJob = InvocationData.Deserialize(recurringJob["Job"]);
             var job = serializedJob.Deserialize();
             var cron = recurringJob["Cron"];
             var cronSchedule = CrontabSchedule.Parse(cron);

--- a/src/Hangfire.Core/States/AwaitingState.cs
+++ b/src/Hangfire.Core/States/AwaitingState.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization.Formatters;
 using Hangfire.Annotations;
 using Hangfire.Common;
 using Hangfire.Storage;
@@ -127,6 +128,7 @@ namespace Hangfire.States
         /// <summary>
         /// Gets the expiration time of a background job continuation.
         /// </summary>
+        [JsonIgnore]
         public TimeSpan Expiration { get; }
 
         /// <inheritdoc />
@@ -135,6 +137,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -146,6 +149,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => false;
 
         /// <inheritdoc />
@@ -155,6 +159,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />
@@ -199,8 +204,15 @@ namespace Hangfire.States
             return new Dictionary<string, string>
             {
                 { "ParentId", ParentId },
-                { "NextState", JsonConvert.SerializeObject(NextState, Formatting.None, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects }) },
-                { "Options", Options.ToString("G") },
+                {
+                    "NextState", JsonConvert.SerializeObject(NextState, new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.Objects,
+                        TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
+                        DefaultValueHandling = DefaultValueHandling.Ignore
+                    })
+                },
+                { "Options", Options.ToString("D") },
                 { "Expiration", Expiration.ToString() }
             };
         }

--- a/src/Hangfire.Core/States/EnqueuedState.cs
+++ b/src/Hangfire.Core/States/EnqueuedState.cs
@@ -16,10 +16,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Hangfire.Annotations;
 using Hangfire.Common;
 using Hangfire.Storage;
+using Newtonsoft.Json;
 
 namespace Hangfire.States
 {
@@ -138,6 +140,7 @@ namespace Hangfire.States
         /// The value specified for a set operation is not a valid queue name.
         /// </exception>
         [NotNull]
+        [DefaultValue(DefaultQueue)]
         public string Queue
         {
             get { return _queue; }
@@ -159,6 +162,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -170,6 +174,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => false;
 
         /// <inheritdoc />
@@ -179,6 +184,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />

--- a/src/Hangfire.Core/States/FailedState.cs
+++ b/src/Hangfire.Core/States/FailedState.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Hangfire.Common;
+using Newtonsoft.Json;
 
 namespace Hangfire.States
 {
@@ -97,6 +98,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -108,6 +110,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => false;
 
         /// <inheritdoc />
@@ -117,6 +120,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />

--- a/src/Hangfire.Core/States/ProcessingState.cs
+++ b/src/Hangfire.Core/States/ProcessingState.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using Hangfire.Common;
 using Hangfire.Server;
+using Newtonsoft.Json;
 
 namespace Hangfire.States
 {
@@ -71,6 +72,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -82,6 +84,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => false;
 
         /// <inheritdoc />
@@ -91,6 +94,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />

--- a/src/Hangfire.Core/States/ScheduledState.cs
+++ b/src/Hangfire.Core/States/ScheduledState.cs
@@ -102,6 +102,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -113,6 +114,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => false;
 
         /// <inheritdoc />
@@ -122,6 +124,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />

--- a/src/Hangfire.Core/States/SucceededState.cs
+++ b/src/Hangfire.Core/States/SucceededState.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Hangfire.Common;
 using Hangfire.Storage;
+using Newtonsoft.Json;
 
 namespace Hangfire.States
 {
@@ -85,6 +86,7 @@ namespace Hangfire.States
         /// Please see the remarks section of the <see cref="IState.Name">IState.Name</see>
         /// article for the details.
         /// </remarks>
+        [JsonIgnore]
         public string Name => StateName;
 
         /// <inheritdoc />
@@ -96,6 +98,7 @@ namespace Hangfire.States
         /// Please refer to the <see cref="IState.IsFinal">IState.IsFinal</see> documentation
         /// for the details.
         /// </remarks>
+        [JsonIgnore]
         public bool IsFinal => true;
 
         /// <inheritdoc />
@@ -105,6 +108,7 @@ namespace Hangfire.States
         /// <see cref="IState.IgnoreJobLoadException">IState.IgnoreJobLoadException</see>
         /// article.
         /// </remarks>
+        [JsonIgnore]
         public bool IgnoreJobLoadException => false;
 
         /// <inheritdoc />

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -30,6 +30,7 @@ namespace Hangfire.Storage
 {
     public class InvocationData
     {
+        private const string EmptyArray = "[]";
         private static readonly string[] SystemAssemblyNames = { "mscorlib", "System.Private.CoreLib" };
 
         public InvocationData(
@@ -91,16 +92,23 @@ namespace Hangfire.Storage
 
             var invocationDataValues = JobHelper.FromJson<string[]>(serializedInvocationData);
 
-            return new InvocationData(
-                invocationDataValues[0],
-                invocationDataValues[1],
-                invocationDataValues[2],
-                invocationDataValues[3]);
+            var valuesCount = invocationDataValues.Length;
+            
+            var type = invocationDataValues[0];
+            var method = invocationDataValues[1];
+            var parameterTypes = valuesCount > 2 ? invocationDataValues[2] : EmptyArray;
+            var arguments = valuesCount > 2 ? invocationDataValues[3] : EmptyArray;
+
+            return new InvocationData(type, method, parameterTypes, arguments);
         }
 
         public string Serialize()
         {
-            return JobHelper.ToJson(new[] { Type, Method, ParameterTypes, Arguments});
+            var values = ParameterTypes == EmptyArray
+                ? new[] { Type, Method }
+                : new[] { Type, Method, ParameterTypes, Arguments };
+            
+            return JobHelper.ToJson(values);
         }
 
         internal static string[] SerializeArguments(IReadOnlyCollection<object> arguments)

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -82,7 +82,7 @@ namespace Hangfire.Storage
 
                 try
                 {
-                    var invocationData = JobHelper.FromJson<InvocationData>(hash["Job"]);
+                    var invocationData = InvocationData.Deserialize(hash["Job"]);
                     dto.Job = invocationData.Deserialize();
                 }
                 catch (JobLoadException ex)

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -90,7 +90,7 @@ values (@invocationData, @arguments, @createdAt, @expireAt)";
                     createJobSql,
                     new
                     {
-                        invocationData = JobHelper.ToJson(invocationData),
+                        invocationData = invocationData.Serialize(),
                         arguments = invocationData.Arguments,
                         createdAt = createdAt,
                         expireAt = createdAt.Add(expireIn)
@@ -137,7 +137,7 @@ $@"select InvocationData, StateName, Arguments, CreatedAt from [{_storage.Schema
                 if (jobData == null) return null;
 
                 // TODO: conversion exception could be thrown.
-                var invocationData = JobHelper.FromJson<InvocationData>(jobData.InvocationData);
+                var invocationData = InvocationData.Deserialize(jobData.InvocationData);
                 invocationData.Arguments = jobData.Arguments;
 
                 Job job = null;

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -478,7 +478,7 @@ where j.Id in @jobIds";
 
         private static Job DeserializeJob(string invocationData, string arguments)
         {
-            var data = JobHelper.FromJson<InvocationData>(invocationData);
+            var data = InvocationData.Deserialize(invocationData);
             data.Arguments = arguments;
 
             try

--- a/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/InvocationDataFacts.cs
@@ -10,6 +10,9 @@ namespace Hangfire.Core.Tests.Storage
 {
     public class InvocationDataFacts
     {
+        private const string NamespaceName = "Hangfire.Core.Tests.Storage";
+        private const string AssemblyName = "Hangfire.Core.Tests";
+
         [Fact]
         public void Deserialize_CorrectlyDeserializes_AllTheData()
         {
@@ -65,16 +68,42 @@ namespace Hangfire.Core.Tests.Storage
         }
 
         [Fact]
-        public void Serialize_CorrectlySerializesTheData()
+        public void Serialize_CorrectlySerializesInvocationDataToString()
         {
-            var job = Job.FromExpression(() => Sample("Hello"));
+            var type = $"{NamespaceName}.InvocationDataFacts, {AssemblyName}";
+            var method = "Sample";
+            var parameterTypes = "[\"System.String\"]";
+            var args = "[\"\\\"Hello\\\"\"]";
 
-            var invocationData = InvocationData.Serialize(job);
+            var expectedParameterTypes = "[\\\"System.String\\\"]";
+            var expectedArgs = "[\\\"\\\\\\\"Hello\\\\\\\"\\\"]";
 
-            Assert.Equal(typeof(InvocationDataFacts).AssemblyQualifiedName, invocationData.Type);
-            Assert.Equal("Sample", invocationData.Method);
-            Assert.Equal(JobHelper.ToJson(new[] { typeof(string) }), invocationData.ParameterTypes);
-            Assert.Equal(JobHelper.ToJson(new[] { "\"Hello\"" }), invocationData.Arguments);
+            var invocationData = new InvocationData(type, method, parameterTypes, args);
+
+            Assert.Equal($"[\"{type}\",\"{method}\",\"{expectedParameterTypes}\",\"{expectedArgs}\"]", invocationData.Serialize());
+        }
+
+        [Theory]
+
+        // Previous serialization format.
+        [InlineData("{\"$type\":\"Hangfire.Storage.InvocationData, Hangfire.Core\",\"Type\":\"Hangfire.Core.Tests.Storage.InvocationDataFacts, Hangfire.Core.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"Method\":\"Sample\",\"ParameterTypes\":\"{\\\"$type\\\":\\\"System.Type[], mscorlib\\\",\\\"$values\\\":[\\\"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\\\"]}\",\"Arguments\":\"{\\\"$type\\\":\\\"System.String[], mscorlib\\\",\\\"$values\\\":[\\\"\\\\\\\"Hello\\\\\\\"\\\"]}\"}")]
+        [InlineData("{\"Type\":\"Hangfire.Core.Tests.Storage.InvocationDataFacts, Hangfire.Core.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"Method\":\"Sample\",\"ParameterTypes\":\"{\\\"$type\\\":\\\"System.Type[], mscorlib\\\",\\\"$values\\\":[\\\"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\\\"]}\",\"Arguments\":\"{\\\"$type\\\":\\\"System.String[], mscorlib\\\",\\\"$values\\\":[\\\"\\\\\\\"Hello\\\\\\\"\\\"]}\"}")]
+        [InlineData("{\"$type\":\"Hangfire.Storage.InvocationData, Hangfire.Core\",\"Type\":\"Hangfire.Core.Tests.Storage.InvocationDataFacts, Hangfire.Core.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"Method\":\"Sample\",\"ParameterTypes\":\"[\\\"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\\\"]\",\"Arguments\":\"[\\\"\\\\\\\"Hello\\\\\\\"\\\"]\"}")]
+        [InlineData("{\"Type\":\"Hangfire.Core.Tests.Storage.InvocationDataFacts, Hangfire.Core.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\",\"Method\":\"Sample\",\"ParameterTypes\":\"[\\\"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\\\"]\",\"Arguments\":\"[\\\"\\\\\\\"Hello\\\\\\\"\\\"]\"}")]
+
+        // New serialization format.
+        [InlineData("[\"Hangfire.Core.Tests.Storage.InvocationDataFacts, Hangfire.Core.Tests\",\"Sample\",\"[\\\"System.String\\\"]\",\"[\\\"\\\\\\\"Hello\\\\\\\"\\\"]\"]")]
+        public void Deserialize_DeserializesCorrectlyStringToInvocationData(string invocationData)
+        {
+            var serializedData = InvocationData.Deserialize(invocationData);
+
+            var job = serializedData.Deserialize();
+
+            Assert.False(job.Type.GetTypeInfo().ContainsGenericParameters);
+            Assert.Equal("Sample", job.Method.Name);
+            Assert.Equal(typeof(string), job.Method.GetParameters()[0].ParameterType);
+            Assert.Equal(1, job.Args.Count);
+            Assert.Equal("Hello", job.Args[0]);
         }
 
         [Fact]
@@ -141,6 +170,57 @@ namespace Hangfire.Core.Tests.Storage
             Assert.IsType<JsonReaderException>(exception.InnerException);
         }
 
+        [Theory]
+        [MemberData(nameof(MemberData))]
+        public void Serialize_CorrectlySerializesJobToInvocationData(Job job, string className, string parameterTypes, string serializedArgs, bool isGlobalNameSpace)
+        {
+            var prefix = isGlobalNameSpace ? "" : $"{NamespaceName}.";
+
+            var methodName = job.Method.Name;
+            var invocationData = InvocationData.Serialize(job);
+
+            Assert.Equal($"{prefix}{className}, {AssemblyName}", invocationData.Type);
+            Assert.Equal(methodName, invocationData.Method);
+            Assert.Equal(parameterTypes, invocationData.ParameterTypes);
+            Assert.Equal(serializedArgs, invocationData.Arguments);
+        }
+
+        public static IEnumerable<object[]> MemberData
+        {
+            get
+            {
+                return new []
+                {
+                    new object[] { Job.FromExpression(() => Sample("str1")), "InvocationDataFacts", "[\"System.String\"]", "[\"\\\"str1\\\"\"]", false },
+                    new object[] { Job.FromExpression(() => ListMethod(new string[0])), nameof(InvocationDataFacts), "[\"System.Collections.Generic.IList`1[[System.String]]\"]", "[\"[]\"]", false },
+
+                    new object[] { Job.FromExpression(() => GenericMethod(1)), "InvocationDataFacts", "[\"System.Int32\"]", "[\"1\"]", false },
+                    new object[] { Job.FromExpression(() => GenericMethod(new InvocationDataFacts())), "InvocationDataFacts", $"[\"{NamespaceName}.InvocationDataFacts, {AssemblyName}\"]", "[\"{}\"]", false },
+                    new object[] { Job.FromExpression(() => GenericMethod(new GlobalType())), "InvocationDataFacts", $"[\"GlobalType, {AssemblyName}\"]", "[\"{}\"]", false },
+                    new object[] { Job.FromExpression(() => OtherGenericMethod(1, new List<int>())), "InvocationDataFacts", "[\"System.Int32\",\"System.Collections.Generic.List`1[[System.Int32]]\"]", "[\"1\",\"[]\"]", false },
+
+                    new object[] { Job.FromExpression<NestedType>(x => x.Method()), "InvocationDataFacts+NestedType", "[]", "[]", false },
+                    new object[] { Job.FromExpression<NestedType>(x => x.NestedGenericMethod(1)), "InvocationDataFacts+NestedType", "[\"System.Int32\"]", "[\"1\"]", false },
+
+                    new object[] { Job.FromExpression<GenericType<int>>(x => x.Method()), "InvocationDataFacts+GenericType`1[[System.Int32]]", "[]", "[]", false },
+                    new object[] { Job.FromExpression<GenericType<GlobalType>>(x => x.Method()), "InvocationDataFacts+GenericType`1[[GlobalType, Hangfire.Core.Tests]]", "[]", "[]", false },
+                    new object[] { Job.FromExpression<GenericType<InvocationDataFacts>>(x => x.Method()), $"InvocationDataFacts+GenericType`1[[{NamespaceName}.InvocationDataFacts, {AssemblyName}]]", "[]", "[]", false },
+                    new object[] { Job.FromExpression<GenericType<int>>(x => x.Method(1, 1)), "InvocationDataFacts+GenericType`1[[System.Int32]]", "[\"System.Int32\",\"System.Int32\"]", "[\"1\",\"1\"]", false },
+                    new object[] { Job.FromExpression<GenericType<int>.NestedGenericType<string>>(x => x.Method(1, "1")), "InvocationDataFacts+GenericType`1+NestedGenericType`1[[System.Int32],[System.String]]", "[\"System.Int32\",\"System.String\"]", "[\"1\",\"\\\"1\\\"\"]", false },
+
+                    new object[] { Job.FromExpression<GlobalType>(x => x.Method()), "GlobalType", "[]", "[]", true},
+                    new object[] { Job.FromExpression<GlobalType>(x => x.GenericMethod(1)), "GlobalType", "[\"System.Int32\"]", "[\"1\"]", true},
+                    new object[] { Job.FromExpression<GlobalType.NestedType>(x => x.NestedMethod()), "GlobalType+NestedType", "[]", "[]", true},
+                    new object[] { Job.FromExpression<GlobalType.NestedGenericType<long>>(x => x.NestedGenericMethod(1, 1)), "GlobalType+NestedGenericType`1[[System.Int64]]", "[\"System.Int64\",\"System.Int32\"]", "[\"1\",\"1\"]", true},
+
+                    new object[] { Job.FromExpression<GlobalGenericType<int>>(x => x.Method()), "GlobalGenericType`1[[System.Int32]]", "[]", "[]", true},
+                    new object[] { Job.FromExpression<GlobalGenericType<object>>(x => x.GenericMethod(1)), "GlobalGenericType`1[[System.Object]]", "[\"System.Int32\"]", "[\"1\"]", true},
+                    new object[] { Job.FromExpression<GlobalGenericType<int>.NestedType>(x => x.Method()), "GlobalGenericType`1+NestedType[[System.Int32]]", "[]", "[]", true},
+                    new object[] { Job.FromExpression<GlobalGenericType<long>.NestedGenericType<int>>(x => x.Method(1, 1)), "GlobalGenericType`1+NestedGenericType`1[[System.Int64],[System.Int32]]", "[\"System.Int64\",\"System.Int32\"]", "[\"1\",\"1\"]", true},
+                };
+            }
+        }
+
         public static void Sample(string arg)
         {
         }
@@ -149,10 +229,36 @@ namespace Hangfire.Core.Tests.Storage
         {
         }
 
-        public class GenericType<T1>
+        public static void GenericMethod<T>(T arg)
+        {
+        }
+
+        public static void OtherGenericMethod<T1,T2>(T1 arg1, T2 arg2)
+        {
+        }
+
+        public class NestedType
         {
             public void Method() { }
-            public void Method<T2>(T1 arg1, T2 arg2) { }
+            public void NestedGenericMethod<T>(T arg1) { }
+        }
+
+        public class GenericType<T1>
+        {
+            public void Method()
+            {
+            }
+
+            public void Method<T2>(T1 arg1, T2 arg2)
+            {
+            }
+
+            public class NestedGenericType<T2>
+            {
+                public void Method(T1 arg1, T2 arg2)
+                {
+                }
+            }
         }
 
         public interface IParent
@@ -163,5 +269,39 @@ namespace Hangfire.Core.Tests.Storage
         public interface IChild : IParent
         {
         }
+
+    }
+
+}
+
+public class GlobalType
+{
+    public void Method() {}
+    public void GenericMethod<T>(T arg) {}
+
+    public class NestedType
+    {
+        public void NestedMethod() { }
+    }
+
+    public class NestedGenericType<T>
+    {
+        public void NestedGenericMethod<T1>(T arg1, T1 arg2) { }
+    }
+}
+
+public class GlobalGenericType<T>
+{
+    public void Method() { }
+    public void GenericMethod<T1>(T1 arg) { }
+
+    public class NestedType
+    {
+        public void Method() { }
+    }
+
+    public class NestedGenericType<T1>
+    {
+        public void Method(T arg1, T1 arg2) { }
     }
 }

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -141,7 +141,7 @@ namespace Hangfire.SqlServer.Tests
                 Assert.Equal(null, (int?) sqlJob.StateId);
                 Assert.Equal(null, (string) sqlJob.StateName);
 
-                var invocationData = JobHelper.FromJson<InvocationData>((string)sqlJob.InvocationData);
+                var invocationData = InvocationData.Deserialize((string)sqlJob.InvocationData);
                 invocationData.Arguments = sqlJob.Arguments;
 
                 var job = invocationData.Deserialize();


### PR DESCRIPTION
This PR fixes #816.

Serialization is cumbersome in some places. I propose the following changes:

### Job serialization
- Do not save redundant assembly's information: Version, Culture, PublicKeyToken;
- Do not save assembly names for system types: "mscorlib" for .NET Full Framework and "System.Private.Core" for .NET Core
- Serialize InvocationData as properties array instead of json object;

**Example:**

Consider the following code
```
BackgroundJob.Enque(() => Console.WriteLine("Hello!"));
```
Current serialization of InvocationData looks like this:
```
"{\"Type\":\"System.Console, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\",\"Method\":\"WriteLine\",\"ParameterTypes\":\"[\\\"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\\\"]\",\"Arguments\":\"[\\\"\\\\\\\"Hello!\\\\\\\"\\\"]\"}")]
```
New format serialization looks like this:
```
["System.Console","WriteLine","[\"System.String\"]","[\"\\\\\"Hello!\\\\\"\"]"]
```
### State serialization
- Mark some state properties (like `IsFinal`, `IgnoreJobLoadException`) by `JsonIgnore` attribute.
- Do not save the default values when `AwaitingState.NextState` property is serialized.
- Sarialize `AwatingState.Options` as integer instead of string.

**Example:**

Current `AwatingState` serialization format:
```
{"ParentId":"1","NextState":"{\"$type\":\"Hangfire.States.EnqueuedState, Hangfire.Core\",\"Queue\":\"default\",\"EnqueuedAt\":\"2017-05-19T10:59:23.0050945Z\",\"Name\":\"Enqueued\",\"Reason\":null,\"IsFinal\":false,\"IgnoreJobLoadException\":false}","Options":"OnlyOnSucceededState","Expiration":"365.00:00:00"}
```
New format:
```
{"ParentId":"1","NextState":"{\"$type\":\"Hangfire.States.EnqueuedState, Hangfire.Core\",\"EnqueuedAt\":\"2017-05-19T10:59:23.0050945Z\"}","Options":1,"Expiration":"365.00:00:00"}
```

