### PR TITLE
add support for generic methods where the generic types may not be in…

### DIFF
--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -353,7 +353,8 @@ namespace Hangfire.Common
                 // MethodInfo instance, based on the same method name and parameter types.
                 method = type.GetNonOpenMatchingMethod(
                     callExpression.Method.Name,
-                    callExpression.Method.GetParameters().Select(x => x.ParameterType).ToArray());
+                    callExpression.Method.GetParameters().Select(x => x.ParameterType).ToArray(),
+                    callExpression.Method.GetGenericArguments());
             }
 
             return new Job(

--- a/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/TypeExtensionsFacts.cs
@@ -225,6 +225,36 @@ namespace Hangfire.Core.Tests.Common
         }
 
         [Fact]
+        public void GetNonOpenMatchingMethod_HandlesMethodHasNonGenericParameters()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new[] { typeof(int), typeof(double) },
+                new[] { typeof(NonGenericClass.NestedNonGenericClass) });
+            Assert.Equal("GenericMethod", method.Name);
+            Assert.Equal(2, method.GetParameters().Length);
+            Assert.Equal(typeof(int), method.GetParameters()[0].ParameterType);
+            Assert.Equal(typeof(double), method.GetParameters()[1].ParameterType);
+        }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_HandlesMethodHasNoParametersOrTypes()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new Type[0]);
+            Assert.Null(method);
+        }
+
+        [Fact]
+        public void GetNonOpenMatchingMethod_HandlesMethodHasNoParameters()
+        {
+            var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
+                new Type[0], 
+                new[] { typeof(NonGenericClass.NestedNonGenericClass) });
+            Assert.Equal("GenericMethod", method.Name);
+            Assert.Equal(0, method.GetParameters().Length);
+        }
+
+        [Fact]
         public void GetNonOpenMatchingMethod_HandlesMethodHasGenericAndNonGenericParameters()
         {
             var method = TypeExtensions.GetNonOpenMatchingMethod(typeof(NonGenericClass), "GenericMethod",
@@ -341,6 +371,8 @@ namespace Hangfire.Core.Tests.Common
         public void GenericMethod<T>(T arg0, T arg1) { }
 
         public void GenericMethod<T>(int arg0, T arg1, double arg2) { }
+
+        public void GenericMethod<T>(int arg0, double arg1) { }
 
         public void GenericMethod<T>(Tuple<T, List<int>> arg) { }
 


### PR DESCRIPTION
… the method's argument list. Maintains backward compatibility with jobs already serialized before this change.

Addresses issue #893 