### PR TITLE
Change order of the QueueAttribute state filter

### DIFF
--- a/src/Hangfire.Core/QueueAttribute.cs
+++ b/src/Hangfire.Core/QueueAttribute.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Hangfire.Common;
 using Hangfire.States;
 
@@ -54,6 +55,7 @@ namespace Hangfire
         public QueueAttribute(string queue)
         {
             Queue = queue;
+            Order = Int32.MaxValue;
         }
 
         /// <summary>


### PR DESCRIPTION
It's better to make it run as an apply state filter, but this is a breaking change. This filter always should be called last, especially if previous filters are suspected in changing candidate state to the enqueued one, to not to ignore the queue setting. 

This behavior leads to bug, when continuation is created when antecedent job is already finished, and our continuation is enqueued to the `default` queue, regardless of the specified one. Steps to reproduce:

```csharp
[Queue("critical")]
public static void MyJob() {}

var antecedent = BackgroundJob.Enqueue(() => MyJob()); // critical queue
Thread.Sleep(60000); // Waiting for antecedent job to be succeeded
BackgroundJob.ContinueWith(antecedent, () => MyJob()); // default queue, wrong
```

If continuation is created before antecedent background job is finished (try to remove the `Thread.Sleep` statement, or start server after these lines), continuation is enqueued to the right queue (`critical` in this case).