### PR TITLE
Change the order of the AutomaticRetryAttribute filter

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -98,6 +98,7 @@ namespace Hangfire
             Attempts = DefaultRetryAttempts;
             LogEvents = true;
             OnAttemptsExceeded = AttemptsExceededAction.Fail;
+            Order = 100;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR increases the order of the `AutomaticRetryAttribute` filter to `100`, to be able to pay more attention to exceptions that are thrown just before an automatic retry. This change means the following:

1. It will allow to intercept transition to the `FailedState` before running `AutomaticRetryAttribute`'s logic, for example, to allow logging all the retries.
2. It will be performed *after* the `StatisticsHistory` filter that tracks number of failed jobs that's shown in the dashboard. 