### PR TITLE
Change `AutomaticRetryAttribute` filter Order to 20

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -98,6 +98,7 @@ namespace Hangfire
             Attempts = DefaultRetryAttempts;
             LogEvents = true;
             OnAttemptsExceeded = AttemptsExceededAction.Fail;
+            Order = 20;
         }
 
         /// <summary>


### PR DESCRIPTION
This change will allow to add elect state filters that are able intercept the `FailedState` transition before the `AutomaticRetryAttribute` filter. For example, to set custom notifications about retries, provide custom automatic retry logic, etc. Currently this isn't possible without clearing the global filters, because `AutomaticRetryAttribute` has the lowest possible order.