### PR TITLE
Add callback method, to allow to open the database with an impersonat…

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -65,7 +65,7 @@ namespace Hangfire.SqlServer
 
             _connectionString = GetConnectionString(nameOrConnectionString);
             _options = options;
-            
+
             if (options.PrepareSchemaIfNecessary)
             {
                 using (var connection = CreateAndOpenConnection())
@@ -197,7 +197,7 @@ namespace Hangfire.SqlServer
                 return true;
             }, null);
         }
-        
+
         internal T UseTransaction<T>([InstantHandle] Func<DbConnection, DbTransaction, T> func, IsolationLevel? isolationLevel)
         {
 #if NETFULL
@@ -229,13 +229,18 @@ namespace Hangfire.SqlServer
 
         internal DbConnection CreateAndOpenConnection()
         {
+            SqlConnection connection = null;
+
             if (_existingConnection != null)
             {
                 return _existingConnection;
             }
 
-            var connection = new SqlConnection(_connectionString);
-            connection.Open();
+            using (_options.ImpersonationFunc?.Invoke())
+            {
+                connection = new SqlConnection(_connectionString);
+                connection.Open();
+            }
 
             return connection;
         }

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -89,5 +89,7 @@ namespace Hangfire.SqlServer
                 _schemaName = value;
             }
         }
+
+        public Func<IDisposable> ImpersonationFunc { get; set; }
     }
 }


### PR DESCRIPTION
Hi,

I added a callback function  to allow to open the database with an impersonated user. We needed this in an ASP.NET MVC Application to open the database with the user of the application pool.

In the Owin Startup class we set these callback with HostingEnvironment.Impersonate.

`
GlobalConfiguration.Configuration.UseSqlServerStorage(
    "<ConnectionName>",
    new SqlServerStorageOptions 
    { 
        QueuePollInterval = TimeSpan.FromSeconds(10),
        ImpersonationMethod = HostingEnvironment.Impersonate
    }
);`

We hope, you merge these changes!

Thanks a lot for your nice work.

Björn