### PR TITLE
Support custom delays for automatic retries

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -147,7 +147,7 @@ namespace Hangfire
             {
                 if (value == null || value.Length == 0) throw new ArgumentNullException(nameof(value));
                 
-                if (value.Any(delay => delay < 0)) throw new ArgumentException(@"DelaysInSeconds value must be a string containing non-negative numbers separated by a comma.", nameof(value));
+                if (value.Any(delay => delay < 0)) throw new ArgumentException($@"{nameof(DelaysInSeconds)} value must be an array of non-negative numbers.", nameof(value));
 
                 lock (_lockObject) { _delaysInSeconds = value; }
             }
@@ -257,19 +257,7 @@ namespace Hangfire
             }
             else
             {
-                try
-                {
-                    delayInSeconds = _delayInSecondsByAttemptFunc(retryAttempt);
-                }
-                catch (Exception e)
-                {
-                    Logger.WarnException(
-                        $"DelayInSecondsByAttemptFunc function threw exception during retrying job '{context.BackgroundJob.Id}'. The delay was defined by the default function.",
-                        e);
-                    
-                    delayInSeconds = DefaultDelayInSecondsByAttemptFunc(retryAttempt);
-                }
-                
+                delayInSeconds = _delayInSecondsByAttemptFunc(retryAttempt);                
             }
 
             var delay = TimeSpan.FromSeconds(delayInSeconds);          

--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -146,7 +146,6 @@ namespace Hangfire
             set
             {
                 if (value == null || value.Length == 0) throw new ArgumentNullException(nameof(value));
-                
                 if (value.Any(delay => delay < 0)) throw new ArgumentException($@"{nameof(DelaysInSeconds)} value must be an array of non-negative numbers.", nameof(value));
 
                 lock (_lockObject) { _delaysInSeconds = value; }

--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -137,9 +137,9 @@ namespace Hangfire
         /// <summary>
         /// Gets or sets the delays between attempts.
         /// </summary>
-        /// <value>A string containing non-negative numbers separated by a comma.</value>
+        /// <value>An array of non-negative numbers.</value>
         /// <exception cref="ArgumentNullException">The value in a set operation is null.</exception>
-        /// <exception cref="ArgumentException">The value in a set operation can't be parsed as a list of numbers.</exception>
+        /// <exception cref="ArgumentException">The value contain one or more negative numbers.</exception>
         public int[] DelaysInSeconds
         {
             get { lock (_lockObject) { return _delaysInSeconds; } }

--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -268,10 +268,12 @@ namespace Hangfire
 
             // If attempt number is less than max attempts, we should
             // schedule the job to run again later.
-            context.CandidateState = new ScheduledState(delay)
-            {
-                Reason = $"Retry attempt {retryAttempt} of {Attempts}: {exceptionMessage}"
-            };
+            
+            var reason = $"Retry attempt {retryAttempt} of {Attempts}: {exceptionMessage}";
+
+            context.CandidateState = delay == TimeSpan.Zero
+                ? (IState)new EnqueuedState { Reason = reason }
+                : new ScheduledState(delay) { Reason = reason };
 
             if (LogEvents)
             {

--- a/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
@@ -84,23 +84,13 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
-        public void DelaysInSeconds_ParsesOneValueCorrectly()
+        public void DelaysInSeconds_SetsValueCorrectly()
         {
-            var filter = new AutomaticRetryAttribute { DelaysInSeconds = new[] { 5 } };
+            var filter = new AutomaticRetryAttribute { DelaysInSeconds = new[] { 5, 8 } };
 
-            Assert.Equal(1, filter.DelaysInSeconds.Length);
+            Assert.Equal(2, filter.DelaysInSeconds.Length);
             Assert.Equal(5, filter.DelaysInSeconds[0]);
-        }
-
-        [Fact]
-        public void DelaysInSeconds_ParsesListOfValuesCorrectly()
-        {
-            var filter = new AutomaticRetryAttribute { DelaysInSeconds = new[] { 1, 3, 8 } };
-
-            Assert.Equal(3, filter.DelaysInSeconds.Length);
-            Assert.Equal(1, filter.DelaysInSeconds[0]);
-            Assert.Equal(3, filter.DelaysInSeconds[1]);
-            Assert.Equal(8, filter.DelaysInSeconds[2]);
+            Assert.Equal(8, filter.DelaysInSeconds[1]);
         }
 
         [Fact]
@@ -132,6 +122,20 @@ namespace Hangfire.Core.Tests
             var thrownExcetption = Assert.Throws<Exception>(() => filter.OnStateElection(_context.Object));
 
             Assert.Equal(exception, thrownExcetption);
+        }
+
+        [Fact]
+        public void OnStateElection_UsesDelaysInSeconds_WhenBothDelaysInSecondsAndDelayInSecondsByAttemptFuncAreSpecified()
+        {
+            var filter = new AutomaticRetryAttribute
+            {
+                DelayInSecondsByAttemptFunc = attempt => 1,
+                DelaysInSeconds = new[] { 0 }
+            };
+
+            filter.OnStateElection(_context.Object);
+
+            Assert.IsType<EnqueuedState>(_context.Object.CandidateState);
         }
 
         [Fact]

--- a/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/RetryAttributeFacts.cs
@@ -115,19 +115,21 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
-        public void OnStateElection_UsesDefaultFunc_WhenDelayInSecondsByAttemptFuncThrowsException()
+        public void OnStateElection_ThrowsAnException_WhenDelayInSecondsByAttemptFuncThrowsAnException()
         {
+            var exception = new Exception();
+            
             var filter = new AutomaticRetryAttribute
             {
                 DelayInSecondsByAttemptFunc = attempt =>
                 {
-                    throw new Exception();
+                    throw exception;
                 }
             };
             
-            filter.OnStateElection(_context.Object);
+            var thrownExcetption = Assert.Throws<Exception>(() => filter.OnStateElection(_context.Object));
 
-            Assert.IsType<ScheduledState>(_context.Object.CandidateState);
+            Assert.Equal(exception, thrownExcetption);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds ability to specify custom delays for retries via `AutomaticRetryAttribute`. 

**Specify custom delays by an integer array**. 

You can set a delay for a job:
```csharp
// All delays are the same and equal 10 seconds.
[AutomaticRetry(DelaysInSeconds = new [] { 10 })]
public void SomeJob() { ... }

// First delay is 1 second, second delay is 5 seconds, other delays are 10 seconds.
[AutomaticRetry(DelaysInSeconds = new [] { 1, 5, 10 })]
public void SomeJob() { ... }
```

Also it's possible set a delay for all jobs:
```csharp
GlobalJobFilters.Filters.Add(new AutomaticRetryAttribute { DelaysInSeconds = new { 1,5,100 }});
```
**Specify custom delay by a function.**

If you want to use complex algorithm to define a delay by a attempt you should set `AutomaticRetryAttribute.DelayInSecondsByAttemptFunc` property:

```csharp
// Delays will be 1, 4, 9 seconds and so on.
var func = attempt => attempt * attempt;
GlobalJobFilters.Filters.Add(new AutomaticRetryAttribute { DelayInSecondsByAttemptFunc = func});
```

**Behaviour**

If you specifty both `DelaysInSeconds` and `DelayInSecondsByAttemptFunc` then only `DelaysInSeconds` will be used.

If given `DelayInSecondsByAttemptFunc` throws excecption then the default function will be used.

