### PR TITLE
Hangfire.SqlServer: check limits before inserting data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Usage
 
 This is an incomplete list of features; to see all of them, check the [official site](http://hangfire.io) and the [documentation](http://docs.hangfire.io).
 
-[**Fire-and-forget tasks**](http://docs.hangfire.io/en/latest/users-guide/background-methods/calling-methods-in-background.html)
+[**Fire-and-forget tasks**](http://docs.hangfire.io/en/latest/background-methods/calling-methods-in-background.html)
 
 Dedicated worker pool threads execute queued background jobs as soon as possible, shortening your request's processing time.
 
@@ -66,7 +66,7 @@ Dedicated worker pool threads execute queued background jobs as soon as possible
 BackgroundJob.Enqueue(() => Console.WriteLine("Simple!"));
 ```
 
-[**Delayed tasks**](http://docs.hangfire.io/en/latest/users-guide/background-methods/calling-methods-with-delay.html)
+[**Delayed tasks**](http://docs.hangfire.io/en/latest/background-methods/calling-methods-with-delay.html)
 
 Scheduled background jobs are executed only after a given amount of time.
 
@@ -74,7 +74,7 @@ Scheduled background jobs are executed only after a given amount of time.
 BackgroundJob.Schedule(() => Console.WriteLine("Reliable!"), TimeSpan.FromDays(7));
 ```
 
-[**Recurring tasks**](http://docs.hangfire.io/en/latest/users-guide/background-methods/performing-recurrent-tasks.html)
+[**Recurring tasks**](http://docs.hangfire.io/en/latest/background-methods/performing-recurrent-tasks.html)
 
 Recurring jobs have never been simpler; just call the following method to perform any kind of recurring task using the [CRON expressions](http://en.wikipedia.org/wiki/Cron#CRON_expression).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.6.13-build-0{build}
+version: 1.6.14-build-0{build}
 
 os: Visual Studio 2015
 

--- a/nuspecs/Hangfire.AspNetCore.nuspec
+++ b/nuspecs/Hangfire.AspNetCore.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>ASP.NET Core support for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2016 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2017 Sergey Odinokov</copyright>
     <tags>hangfire aspnetcore</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.AspNetCore.nuspec
+++ b/nuspecs/Hangfire.AspNetCore.nuspec
@@ -14,6 +14,9 @@
     <tags>hangfire aspnetcore</tags>
     <releaseNotes>http://hangfire.io/blog/
     
+1.6.13
+• Fixed – Types are resolved using the `GetServiceOrCreateInstance` method (by @Tsabo).
+    
 1.6.7
 • Fixed – Parameterless AspNetCoreJobActivator.BeginScope method now returns a correct instance (by @pieceofsummer).
     

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>Core components for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2017 Sergey Odinokov</copyright>
     <tags>Hangfire OWIN Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -15,7 +15,11 @@
     <releaseNotes>http://hangfire.io/blog/
     
 1.6.13
-• Fixed – Don't throw NullReferenceException, when state was changed on Processing page.
+• Fixed – Continuation is fired on a wrong queue, when parent job is finished before the creation.
+• Fixed – Impossible to intercept failed state transition before `AutomaticRetryAttribute`.
+• Fixed – Fixed translation in Chinese localization on home page (by @JustinChia).
+• Fixed – Don't throw `NullReferenceException`, when state has changed during query on Processing page.
+• Fixed – `CreateBatchFailedException`, when batch creation takes longer than 1 hour.
     
 1.6.12
 • Fixed – Buggy state filters may cause background job to be infinitely retried.

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>MSMQ queues support for SQL Server job storage implementation for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2014-2016 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2014-2017 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer MSMQ</tags>
     <releaseNotes>http://hangfire.io/blog/
     

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -16,6 +16,8 @@
     
 1.6.13
 • Fixed – Don't hide errors occurred while running SQL migrations.
+• Fixed – `KeyNotFoundException` when accessing Deleted Jobs page in Dashboard.
+• Fixed – `SqlServerDistributedLock` leaks connections, when lock acquisition is failed.
     
 1.6.9
 • Fixed – `TimeoutException` on large arguments or large batches via `SqlServerOptions.CommandTimeout`.

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -10,9 +10,15 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://raw.github.com/HangfireIO/Hangfire/master/LICENSE.md</licenseUrl>
     <description>SQL Server 2008+ (including Express), SQL Server LocalDB and SQL Azure storage support for Hangfire (background job system for ASP.NET applications).</description>
-    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2017 Sergey Odinokov</copyright>
     <tags>Hangfire SqlServer SqlAzure LocalDB</tags>
     <releaseNotes>http://hangfire.io/blog/
+    
+1.6.14
+• Added – `SqlServerStorageOptions.SlidingInvisibilityTimeout` to fetch jobs without using transaction.
+• Fixed – Transaction log is full due to 'ACTIVE_TRANSACTION' by enabling to use new non-transactional fetch.
+• Fixed – `SqlServerJobQueueMonitoringApi` can't cause READ UNCOMMITTED isolation level to leak on SQL Server 2012 or earlier. 
+• Fixed – Add missing `SqlServerStorage(DbConnection, SqlServerStorageOptions)` constructor.
     
 1.6.13
 • Fixed – Don't hide errors occurred while running SQL migrations.

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -22,10 +22,19 @@
 1.6.13
 
 Hangfire.Core
-• Fixed – Don't throw NullReferenceException, when state was changed on Processing page.
+• Fixed – Continuation is fired on a wrong queue, when parent job is finished before the creation.
+• Fixed – Impossible to intercept failed state transition before `AutomaticRetryAttribute`.
+• Fixed – Fixed translation in Chinese localization on home page (by @JustinChia).
+• Fixed – Don't throw `NullReferenceException`, when state has changed during query on Processing page.
+• Fixed – `CreateBatchFailedException`, when batch creation takes longer than 1 hour.
+
+Hangfire.AspNetCore
+• Fixed – Types are resolved using the `GetServiceOrCreateInstance` method (by @Tsabo).
 
 Hangfire.SqlServer
 • Fixed – Don't hide errors occurred while running SQL migrations.
+• Fixed – `KeyNotFoundException` when accessing Deleted Jobs page in Dashboard.
+• Fixed – `SqlServerDistributedLock` leaks connections, when lock acquisition is failed.
     
 1.6.12
 

--- a/nuspecs/Hangfire.nuspec
+++ b/nuspecs/Hangfire.nuspec
@@ -15,9 +15,18 @@
       Backed by Redis, SQL Server, SQL Azure or MSMQ. This is a .NET alternative to Sidekiq, Resque and Celery.
       http://hangfire.io/
     </description>
-    <copyright>Copyright © 2013-2016 Sergey Odinokov</copyright>
+    <copyright>Copyright © 2013-2017 Sergey Odinokov</copyright>
     <tags>Hangfire AspNet MVC OWIN SqlServer Long-Running Background Fire-And-Forget Delayed Recurring Tasks Jobs Scheduler Threading Queues</tags>
     <releaseNotes>http://hangfire.io/blog/
+    
+1.6.14
+
+Hangfire.SqlServer
+
+• Added – `SqlServerStorageOptions.SlidingInvisibilityTimeout` to fetch jobs without using transaction.
+• Fixed – Transaction log is full due to 'ACTIVE_TRANSACTION' by enabling to use new non-transactional fetch.
+• Fixed – `SqlServerJobQueueMonitoringApi` can't cause READ UNCOMMITTED isolation level to leak on SQL Server 2012 or earlier. 
+• Fixed – Add missing `SqlServerStorage(DbConnection, SqlServerStorageOptions)` constructor.
     
 1.6.13
 

--- a/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
+++ b/src/Hangfire.AspNetCore/AspNetCore/AspNetCoreJobActivatorScope.cs
@@ -32,7 +32,7 @@ namespace Hangfire.AspNetCore
 
         public override object Resolve(Type type)
         {
-            return _serviceScope.ServiceProvider.GetRequiredService(type);
+            return ActivatorUtilities.GetServiceOrCreateInstance(_serviceScope.ServiceProvider, type);
         }
 
         public override void DisposeScope()

--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -98,6 +98,7 @@ namespace Hangfire
             Attempts = DefaultRetryAttempts;
             LogEvents = true;
             OnAttemptsExceeded = AttemptsExceededAction.Fail;
+            Order = 20;
         }
 
         /// <summary>

--- a/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
+++ b/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
@@ -41,7 +41,7 @@ namespace Hangfire.Client
                 context.Job,
                 parameters,
                 createdAt,
-                TimeSpan.FromHours(1));
+                TimeSpan.FromDays(30));
 
             var backgroundJob = new BackgroundJob(jobId, context.Job, createdAt);
 

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.zh.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.zh.resx
@@ -246,7 +246,7 @@
     <value>实时图表走势</value>
   </data>
   <data name="HomePage_Title" xml:space="preserve">
-    <value>式表盘</value>
+    <value>仪表盘</value>
   </data>
   <data name="JobDetailsPage_Created" xml:space="preserve">
     <value>创建</value>

--- a/src/Hangfire.Core/QueueAttribute.cs
+++ b/src/Hangfire.Core/QueueAttribute.cs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using Hangfire.Common;
 using Hangfire.States;
 
@@ -54,6 +55,7 @@ namespace Hangfire
         public QueueAttribute(string queue)
         {
             Queue = queue;
+            Order = Int32.MaxValue;
         }
 
         /// <summary>

--- a/src/Hangfire.SqlServer/Constants.cs
+++ b/src/Hangfire.SqlServer/Constants.cs
@@ -3,5 +3,17 @@
     internal class Constants
     {
         public static readonly string DefaultSchema = "HangFire";
+
+        // Limits.
+        public const int CounterKeyMaxLength = 100;
+        public const int HashKeyMaxLength = 100;
+        public const int HashFieldMaxLength = 100;
+        public const int JobParameterNameMaxLength = 40;
+        public const int ListKeyMaxLength = 100;
+        public const int ServerIdMaxLength = 100;
+        public const int SetKeyMaxLength = 100;
+        public const int SetValueMaxLength = 256;
+        public const int StateNameMaxLength = 20;
+        public const int StateReasonMaxLength = 100;
     }
 }

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.NetStandard.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.NetStandard.csproj
@@ -64,7 +64,6 @@
     <Compile Include="SqlServerConnection.cs" />
     <Compile Include="SqlServerDistributedLock.cs" />
     <Compile Include="SqlServerDistributedLockException.cs" />
-    <Compile Include="SqlServerFetchedJob.cs" />
     <Compile Include="SqlServerJobQueue.cs" />
     <Compile Include="SqlServerJobQueueMonitoringApi.cs" />
     <Compile Include="SqlServerJobQueueProvider.cs" />
@@ -73,6 +72,8 @@
     <Compile Include="SqlServerStorage.cs" />
     <Compile Include="SqlServerStorageExtensions.cs" />
     <Compile Include="SqlServerStorageOptions.cs" />
+    <Compile Include="SqlServerTimeoutJob.cs" />
+    <Compile Include="SqlServerTransactionJob.cs" />
     <Compile Include="SqlServerWriteOnlyTransaction.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
@@ -69,8 +69,9 @@
     <Compile Include="IPersistentJobQueueMonitoringApi.cs" />
     <Compile Include="IPersistentJobQueueProvider.cs" />
     <Compile Include="PersistentJobQueueProviderCollection.cs" />
+    <Compile Include="SqlServerTimeoutJob.cs" />
     <Compile Include="SqlServerJobQueue.cs" />
-    <Compile Include="SqlServerFetchedJob.cs" />
+    <Compile Include="SqlServerTransactionJob.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerDistributedLock.cs" />
     <Compile Include="SqlServerDistributedLockException.cs" />

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -111,8 +111,7 @@ values (@invocationData, @arguments, @createdAt, @expireAt)";
                         };
 
                         if (parameter.Key.Length <= Constants.JobParameterNameMaxLength) continue;
-                        
-                        ThrowArgumentExceedsMaxLengthException(nameof(parameters), parameter.Key, Constants.JobParameterNameMaxLength);
+                        throw new ArgumentException($@"""{parameter.Key}"" : the job parameter name length can't exceed {Constants.JobParameterNameMaxLength} characters.", nameof(parameters));
                     }
 
                     string insertParameterSql =
@@ -201,7 +200,7 @@ where j.Id = @jobId";
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             if (name == null) throw new ArgumentNullException(nameof(name));
-            if (name.Length > Constants.JobParameterNameMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(name), name, Constants.JobParameterNameMaxLength);
+            if (name.Length > Constants.JobParameterNameMaxLength) throw new ArgumentException($@"""{name}"" : the job parameter name length can't exceed {Constants.JobParameterNameMaxLength} characters.", nameof(name));
 
             _storage.UseConnection(connection =>
             {
@@ -257,7 +256,7 @@ when not matched then insert (JobId, Name, Value) values (Source.JobId, Source.N
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
             if (keyValuePairs == null) throw new ArgumentNullException(nameof(keyValuePairs));
-            if (key.Length > Constants.HashKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.HashKeyMaxLength);
+            if (key.Length > Constants.HashKeyMaxLength) throw new ArgumentException($@"""{key}"" : the hash key length can't exceed {Constants.HashKeyMaxLength} characters.", nameof(key));
 
             string sql =
 $@";merge [{_storage.SchemaName}].Hash with (holdlock) as Target
@@ -270,13 +269,11 @@ when not matched then insert ([Key], Field, Value) values (Source.[Key], Source.
             {
                 foreach (var keyValuePair in keyValuePairs)
                 {
-                    var field = keyValuePair.Key;
-                    
-                    if (field.Length > Constants.HashFieldMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(keyValuePairs), field, Constants.HashFieldMaxLength);
+                    if (keyValuePair.Key.Length > Constants.HashFieldMaxLength) throw new ArgumentException($@"""{keyValuePair.Key}"" : the hash field length can't exceed {Constants.HashFieldMaxLength} characters.", nameof(keyValuePairs));
                     
                     connection.Execute(
                         sql, 
-                        new { key = key, field = field, value = keyValuePair.Value }, 
+                        new { key = key, field = keyValuePair.Key, value = keyValuePair.Value }, 
                         transaction,
                         commandTimeout: _storage.CommandTimeout);
                 }
@@ -303,7 +300,7 @@ when not matched then insert ([Key], Field, Value) values (Source.[Key], Source.
         {
             if (serverId == null) throw new ArgumentNullException(nameof(serverId));
             if (context == null) throw new ArgumentNullException(nameof(context));
-            if (serverId.Length > Constants.ServerIdMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(serverId), serverId, Constants.ServerIdMaxLength);
+            if (serverId.Length > Constants.ServerIdMaxLength) throw new ArgumentException($@"""{serverId}"" : the server id length can't exceed {Constants.ServerIdMaxLength} characters.", nameof(serverId));
 
             var data = new ServerData
             {
@@ -511,11 +508,6 @@ where [Key] = @key
 order by [Id] desc";
 
             return _storage.UseConnection(connection => connection.Query<string>(query, new { key = key }, commandTimeout: _storage.CommandTimeout).ToList());
-        }
-
-        private void ThrowArgumentExceedsMaxLengthException(string argumentName, string value, int maxLength)
-        {
-            throw new ArgumentException($@"""{value}"" : the string length can't exceed {maxLength}.", argumentName);
         }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
+++ b/src/Hangfire.SqlServer/SqlServerDistributedLock.cs
@@ -72,7 +72,15 @@ namespace Hangfire.SqlServer
             {
                 _connection = storage.CreateAndOpenConnection();
 
-                Acquire(_connection, _resource, timeout);
+                try
+                {
+                    Acquire(_connection, _resource, timeout);
+                }
+                catch (Exception)
+                {
+                    storage.ReleaseConnection(_connection);
+                    throw;
+                }
 
                 if (!_storage.IsExistingConnection(_connection))
                 {

--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -37,7 +37,7 @@ namespace Hangfire.SqlServer
 
         private readonly SqlServerStorage _storage;
         private readonly SqlServerStorageOptions _options;
-		
+
         public SqlServerJobQueue([NotNull] SqlServerStorage storage, SqlServerStorageOptions options)
         {
             if (storage == null) throw new ArgumentNullException(nameof(storage));
@@ -53,14 +53,85 @@ namespace Hangfire.SqlServer
             if (queues == null) throw new ArgumentNullException(nameof(queues));
             if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
 
+            if (_options.UseInvisibilityTimeout && _options.InvisibilityTimeout > TimeSpan.Zero)
+            {
+                return DequeueUsingInvisibilityTimeout(queues, cancellationToken);
+            }
+
+            return DequeueUsingTransaction(queues, cancellationToken);
+        }
+
+#if NETFULL
+        public void Enqueue(IDbConnection connection, string queue, string jobId)
+#else
+        public void Enqueue(DbConnection connection, DbTransaction transaction, string queue, string jobId)
+#endif
+        {
+            string enqueueJobSql =
+$@"insert into [{_storage.SchemaName}].JobQueue (JobId, Queue) values (@jobId, @queue)";
+
+            connection.Execute(
+                enqueueJobSql, 
+                new { jobId = long.Parse(jobId), queue = queue }
+#if !NETFULL
+                , transaction
+#endif
+                , commandTimeout: _storage.CommandTimeout);
+        }
+
+        private SqlServerTimeoutJob DequeueUsingInvisibilityTimeout(string[] queues, CancellationToken cancellationToken)
+        {
+            if (queues == null) throw new ArgumentNullException(nameof(queues));
+            if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
+
+            FetchedJob fetchedJob = null;
+
+            var fetchJobSqlTemplate = $@"
+set transaction isolation level read committed
+update top (1) JQ
+set FetchedAt = GETUTCDATE()
+output INSERTED.Id, INSERTED.JobId, INSERTED.Queue
+from [{_storage.SchemaName}].JobQueue JQ with (readpast, updlock, rowlock, forceseek)
+where Queue in @queues and
+(FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))";
+
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                _storage.UseConnection(connection =>
+                {
+                    fetchedJob = connection
+                        .Query<FetchedJob>(
+                            fetchJobSqlTemplate,
+                            new { queues = queues, timeout = _options.InvisibilityTimeout.Negate().TotalSeconds })
+                        .SingleOrDefault();
+                });
+
+                if (fetchedJob != null)
+                {
+                    return new SqlServerTimeoutJob(
+                        _storage,
+                        fetchedJob.Id,
+                        fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
+                        fetchedJob.Queue);
+                }
+
+                cancellationToken.WaitHandle.WaitOne(_options.QueuePollInterval);
+                cancellationToken.ThrowIfCancellationRequested();
+            } while (true);
+        }
+
+        private SqlServerTransactionJob DequeueUsingTransaction(string[] queues, CancellationToken cancellationToken)
+        {
             FetchedJob fetchedJob = null;
             DbTransaction transaction = null;
 
             string fetchJobSqlTemplate =
-$@"delete top (1) JQ
+                $@"delete top (1) JQ
 output DELETED.Id, DELETED.JobId, DELETED.Queue
 from [{_storage.SchemaName}].JobQueue JQ with (readpast, updlock, rowlock, forceseek)
-where Queue in @queues";
+where Queue in @queues and (FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))";
 
             do
             {
@@ -73,13 +144,13 @@ where Queue in @queues";
 
                     fetchedJob = connection.Query<FetchedJob>(
                         fetchJobSqlTemplate,
-                        new { queues = queues },
+                        new { queues = queues, timeout = _options.InvisibilityTimeout.Negate().TotalSeconds },
                         transaction,
                         commandTimeout: _storage.CommandTimeout).SingleOrDefault();
 
                     if (fetchedJob != null)
                     {
-                        return new SqlServerFetchedJob(
+                        return new SqlServerTransactionJob(
                             _storage,
                             connection,
                             transaction,
@@ -101,24 +172,6 @@ where Queue in @queues";
                 WaitHandle.WaitAny(new[] { cancellationToken.WaitHandle, NewItemInQueueEvent }, _options.QueuePollInterval);
                 cancellationToken.ThrowIfCancellationRequested();
             } while (true);
-        }
-
-#if NETFULL
-        public void Enqueue(IDbConnection connection, string queue, string jobId)
-#else
-        public void Enqueue(DbConnection connection, DbTransaction transaction, string queue, string jobId)
-#endif
-        {
-            string enqueueJobSql =
-$@"insert into [{_storage.SchemaName}].JobQueue (JobId, Queue) values (@jobId, @queue)";
-
-            connection.Execute(
-                enqueueJobSql, 
-                new { jobId = long.Parse(jobId), queue = queue }
-#if !NETFULL
-                , transaction
-#endif
-                , commandTimeout: _storage.CommandTimeout);
         }
 
         [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
@@ -54,9 +54,9 @@ namespace Hangfire.SqlServer
             {
                 if (_queuesCache.Count == 0 || _cacheUpdated.Add(QueuesCacheTimeout) < DateTime.UtcNow)
                 {
-                    var result = UseTransaction((connection, transaction) =>
+                    var result = _storage.UseConnection(connection =>
                     {
-                        return connection.Query(sqlQuery, transaction: transaction, commandTimeout: _storage.CommandTimeout).Select(x => (string) x.Queue).ToList();
+                        return connection.Query(sqlQuery, commandTimeout: _storage.CommandTimeout).Select(x => (string) x.Queue).ToList();
                     });
 
                     _queuesCache = result;
@@ -69,21 +69,20 @@ namespace Hangfire.SqlServer
 
         public IEnumerable<int> GetEnqueuedJobIds(string queue, int @from, int perPage)
         {
-            string sqlQuery =
+            var sqlQuery =
 $@"select r.JobId from (
   select jq.JobId, row_number() over (order by jq.Id) as row_num 
-  from [{_storage.SchemaName}].JobQueue jq with (nolock)
+  from [{_storage.SchemaName}].JobQueue jq with (nolock, forceseek)
   where jq.Queue = @queue
 ) as r
 where r.row_num between @start and @end";
 
-            return UseTransaction((connection, transaction) =>
+            return _storage.UseConnection(connection =>
             {
                 // TODO: Remove cast to `int` to support `bigint`.
                 return connection.Query<JobIdDto>(
                     sqlQuery,
                     new { queue = queue, start = from + 1, end = @from + perPage },
-                    transaction,
                     commandTimeout: _storage.CommandTimeout)
                     .ToList()
                     .Select(x => (int)x.JobId)
@@ -93,28 +92,48 @@ where r.row_num between @start and @end";
 
         public IEnumerable<int> GetFetchedJobIds(string queue, int @from, int perPage)
         {
-            return Enumerable.Empty<int>();
+            var fetchedJobsSql = $@"
+select r.JobId from (
+  select jq.JobId, jq.FetchedAt, row_number() over (order by jq.Id) as row_num 
+  from [{_storage.SchemaName}].JobQueue jq with (nolock, forceseek)
+  where jq.Queue = @queue and jq.FetchedAt is not null
+) as r
+where r.row_num between @start and @end";
+
+            return _storage.UseConnection(connection =>
+            {
+                // TODO: Remove cast to `int` to support `bigint`.
+                return connection.Query<JobIdDto>(
+                        fetchedJobsSql,
+                        new { queue = queue, start = from + 1, end = @from + perPage })
+                    .ToList()
+                    .Select(x => (int)x.JobId)
+                    .ToList();
+            });
         }
 
         public EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue)
         {
-            string sqlQuery = $@"
-select count(Id) from [{_storage.SchemaName}].JobQueue with (nolock) where [Queue] = @queue";
+            var sqlQuery = $@"
+select sum(Enqueued) as EnqueuedCount, sum(Fetched) as FetchedCount 
+from (
+    select 
+        case when FetchedAt is null then 1 else 0 end as Enqueued,
+        case when FetchedAt is not null then 1 else 0 end as Fetched
+    from [{_storage.SchemaName}].JobQueue with (nolock, forceseek)
+    where Queue = @queue
+) q";
 
-            return UseTransaction((connection, transaction) =>
+            return _storage.UseConnection(connection =>
             {
-                var result = connection.ExecuteScalar<int>(sqlQuery, new { queue = queue }, transaction, commandTimeout: _storage.CommandTimeout);
+                var result = connection.Query(sqlQuery, new { queue = queue }).Single();
 
                 return new EnqueuedAndFetchedCountDto
                 {
-                    EnqueuedCount = result,
+                    EnqueuedCount = result.EnqueuedCount,
+                    FetchedCount = result.FetchedCount
                 };
             });
-        }
-
-        private T UseTransaction<T>(Func<DbConnection, DbTransaction, T> func)
-        {
-            return _storage.UseTransaction(func, IsolationLevel.ReadUncommitted);
         }
 
         private class JobIdDto

--- a/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueueMonitoringApi.cs
@@ -73,7 +73,7 @@ namespace Hangfire.SqlServer
 $@"select r.JobId from (
   select jq.JobId, row_number() over (order by jq.Id) as row_num 
   from [{_storage.SchemaName}].JobQueue jq with (nolock, forceseek)
-  where jq.Queue = @queue
+  where jq.Queue = @queue and jq.FetchedAt is null
 ) as r
 where r.row_num between @start and @end";
 

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -191,7 +191,7 @@ namespace Hangfire.SqlServer
                 (sqlJob, job, stateData) => new DeletedJobDto
                 {
                     Job = job,
-                    DeletedAt = JobHelper.DeserializeNullableDateTime(stateData["DeletedAt"])
+                    DeletedAt = JobHelper.DeserializeNullableDateTime(stateData.ContainsKey("DeletedAt") ? stateData["DeletedAt"] : null)
                 }));
         }
 

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -99,7 +99,7 @@ namespace Hangfire.SqlServer
 
         internal string SchemaName => _options.SchemaName;
         internal int? CommandTimeout => _options.CommandTimeout.HasValue ? (int)_options.CommandTimeout.Value.TotalSeconds : (int?)null;
-        internal TimeSpan InvisibilityTimeout => _options.InvisibilityTimeout;
+        internal TimeSpan? SlidingInvisibilityTimeout => _options.SlidingInvisibilityTimeout;
 
         public override IMonitoringApi GetMonitoringApi()
         {

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -27,13 +27,16 @@ namespace Hangfire.SqlServer
     {
         private TimeSpan _queuePollInterval;
         private string _schemaName;
+        private TimeSpan? _slidingInvisibilityTimeout;
 
         public SqlServerStorageOptions()
         {
             TransactionIsolationLevel = null;
             QueuePollInterval = TimeSpan.FromSeconds(15);
-            UseInvisibilityTimeout = false;
+            SlidingInvisibilityTimeout = null;
+#pragma warning disable 618
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
+#pragma warning restore 618
             JobExpirationCheckInterval = TimeSpan.FromMinutes(30);
             CountersAggregateInterval = TimeSpan.FromMinutes(5);
             PrepareSchemaIfNecessary = true;
@@ -64,8 +67,22 @@ namespace Hangfire.SqlServer
             }
         }
 
+        [Obsolete("Does not make sense anymore. Background jobs re-queued instantly even after ungraceful shutdown now. Will be removed in 2.0.0.")]
         public TimeSpan InvisibilityTimeout { get; set; }
-        public bool UseInvisibilityTimeout { get; set; }
+
+        public TimeSpan? SlidingInvisibilityTimeout
+        {
+            get { return _slidingInvisibilityTimeout; }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException("Sliding timeout should be greater than zero");
+                }
+
+                _slidingInvisibilityTimeout = value;
+            }
+        }
 
         public bool PrepareSchemaIfNecessary { get; set; }
 

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -32,9 +32,8 @@ namespace Hangfire.SqlServer
         {
             TransactionIsolationLevel = null;
             QueuePollInterval = TimeSpan.FromSeconds(15);
-#pragma warning disable 618
+            UseInvisibilityTimeout = false;
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
-#pragma warning restore 618
             JobExpirationCheckInterval = TimeSpan.FromMinutes(30);
             CountersAggregateInterval = TimeSpan.FromMinutes(5);
             PrepareSchemaIfNecessary = true;
@@ -65,8 +64,8 @@ namespace Hangfire.SqlServer
             }
         }
 
-        [Obsolete("Does not make sense anymore. Background jobs re-queued instantly even after ungraceful shutdown now. Will be removed in 2.0.0.")]
         public TimeSpan InvisibilityTimeout { get; set; }
+        public bool UseInvisibilityTimeout { get; set; }
 
         public bool PrepareSchemaIfNecessary { get; set; }
 

--- a/src/Hangfire.SqlServer/SqlServerTimeoutJob.cs
+++ b/src/Hangfire.SqlServer/SqlServerTimeoutJob.cs
@@ -1,0 +1,71 @@
+using System;
+using Dapper;
+using Hangfire.Annotations;
+using Hangfire.Storage;
+
+namespace Hangfire.SqlServer
+{
+    internal class SqlServerTimeoutJob : IFetchedJob
+    {
+        private readonly SqlServerStorage _storage;
+        private bool _disposed;
+        private bool _removedFromQueue;
+        private bool _requeued;
+
+        public SqlServerTimeoutJob(
+            [NotNull] SqlServerStorage storage,
+            long id,
+            [NotNull] string jobId,
+            [NotNull] string queue)
+        {
+            if (storage == null) throw new ArgumentNullException(nameof(storage));
+            if (jobId == null) throw new ArgumentNullException(nameof(jobId));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
+            _storage = storage;
+
+            Id = id;
+            JobId = jobId;
+            Queue = queue;
+        }
+
+        public long Id { get; }
+        public string JobId { get; }
+        public string Queue { get; }
+
+        public void RemoveFromQueue()
+        {
+            _storage.UseConnection(connection =>
+            {
+                connection.Execute(
+                    $"delete from {_storage.SchemaName}.JobQueue where Id = @id",
+                    new { id = Id });
+            });
+
+            _removedFromQueue = true;
+        }
+
+        public void Requeue()
+        {
+            _storage.UseConnection(connection =>
+            {
+                connection.Execute(
+                    $"update {_storage.SchemaName}.JobQueue set FetchedAt = null where Id = @id",
+                    new { id = Id });
+            });
+
+            _requeued = true;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            if (!_removedFromQueue && !_requeued)
+            {
+                Requeue();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/Hangfire.SqlServer/SqlServerTransactionJob.cs
+++ b/src/Hangfire.SqlServer/SqlServerTransactionJob.cs
@@ -23,7 +23,7 @@ using Hangfire.Storage;
 
 namespace Hangfire.SqlServer
 {
-    internal class SqlServerFetchedJob : IFetchedJob
+    internal class SqlServerTransactionJob : IFetchedJob
     {
         // Connections to SQL Azure Database that are idle for 30 minutes 
         // or longer will be terminated. And since we are using separate
@@ -38,7 +38,7 @@ namespace Hangfire.SqlServer
         private readonly Timer _timer;
         private readonly object _lockObject = new object();
 
-        public SqlServerFetchedJob(
+        public SqlServerTransactionJob(
             [NotNull] SqlServerStorage storage,
             [NotNull] IDbConnection connection, 
             [NotNull] IDbTransaction transaction, 

--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -101,7 +101,7 @@ values (@jobId, @name, @reason, @createdAt, @data);
 update [{_storage.SchemaName}].Job set StateId = SCOPE_IDENTITY(), StateName = @name where Id = @id;";
 
             var reason = state.Reason?.Length > Constants.StateReasonMaxLength 
-                ? TrancateReason(state.Reason) 
+                ? TruncateReason(state.Reason) 
                 : state.Reason;
 
             QueueCommand((connection, transaction) => connection.Execute(
@@ -128,7 +128,7 @@ $@"insert into [{_storage.SchemaName}].State (JobId, Name, Reason, CreatedAt, Da
 values (@jobId, @name, @reason, @createdAt, @data)";
 
             var reason = state.Reason?.Length > Constants.StateReasonMaxLength
-                ? TrancateReason(state.Reason)
+                ? TruncateReason(state.Reason)
                 : state.Reason;
 
             QueueCommand((connection, transaction) => connection.Execute(
@@ -481,7 +481,7 @@ update [{_storage.SchemaName}].[List] set ExpireAt = null where [Key] = @key";
             _lockedResources.Add($"{_storage.SchemaName}:{resource}:Lock");
         }
 
-        private string TrancateReason(string reason)
+        private string TruncateReason(string reason)
         {
             return reason.Substring(0, Constants.StateReasonMaxLength - 3) + "...";
         }

--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -93,7 +93,7 @@ namespace Hangfire.SqlServer
 
         public override void SetJobState(string jobId, IState state)
         {
-            if (state.Name.Length > Constants.StateNameMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(state), state.Name, Constants.StateNameMaxLength);
+            if (state.Name.Length > Constants.StateNameMaxLength) throw new ArgumentException($@"""{state.Name}"" : the state name length can't exceed {Constants.StateNameMaxLength} characters.", nameof(state));
 
             string addAndSetStateSql = 
 $@"insert into [{_storage.SchemaName}].State (JobId, Name, Reason, CreatedAt, Data)
@@ -121,7 +121,7 @@ update [{_storage.SchemaName}].Job set StateId = SCOPE_IDENTITY(), StateName = @
 
         public override void AddJobState(string jobId, IState state)
         {
-            if (state.Name.Length > Constants.StateNameMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(state), state.Name, Constants.StateNameMaxLength);
+            if (state.Name.Length > Constants.StateNameMaxLength) throw new ArgumentException($@"""{state.Name}"" : the state name length can't exceed {Constants.StateNameMaxLength} characters.", nameof(state));
 
             string addStateSql =
 $@"insert into [{_storage.SchemaName}].State (JobId, Name, Reason, CreatedAt, Data)
@@ -166,7 +166,7 @@ values (@jobId, @name, @reason, @createdAt, @data)";
 
         public override void IncrementCounter(string key)
         {
-            if (key.Length > Constants.CounterKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.CounterKeyMaxLength);
+            if (key.Length > Constants.CounterKeyMaxLength) throw new ArgumentException($@"""{key}"" : the counter key length can't exceed {Constants.CounterKeyMaxLength} characters.", nameof(key));
 
             QueueCommand((connection, transaction) => connection.Execute(
                 $@"insert into [{_storage.SchemaName}].Counter ([Key], [Value]) values (@key, @value)",
@@ -177,7 +177,7 @@ values (@jobId, @name, @reason, @createdAt, @data)";
 
         public override void IncrementCounter(string key, TimeSpan expireIn)
         {
-            if (key.Length > Constants.CounterKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.CounterKeyMaxLength);
+            if (key.Length > Constants.CounterKeyMaxLength) throw new ArgumentException($@"""{key}"" : the counter key length can't exceed {Constants.CounterKeyMaxLength} characters.", nameof(key));
             
             QueueCommand((connection, transaction) => connection.Execute(
                 $@"insert into [{_storage.SchemaName}].Counter ([Key], [Value], [ExpireAt]) values (@key, @value, @expireAt)",
@@ -188,7 +188,7 @@ values (@jobId, @name, @reason, @createdAt, @data)";
 
         public override void DecrementCounter(string key)
         {
-            if (key.Length > Constants.CounterKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.CounterKeyMaxLength);
+            if (key.Length > Constants.CounterKeyMaxLength) throw new ArgumentException($@"""{key}"" : the counter key length can't exceed {Constants.CounterKeyMaxLength} characters.", nameof(key));
             
             QueueCommand((connection, transaction) => connection.Execute(
                 $@"insert into [{_storage.SchemaName}].Counter ([Key], [Value]) values (@key, @value)",
@@ -199,7 +199,7 @@ values (@jobId, @name, @reason, @createdAt, @data)";
 
         public override void DecrementCounter(string key, TimeSpan expireIn)
         {
-            if (key.Length > Constants.CounterKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.CounterKeyMaxLength);
+            if (key.Length > Constants.CounterKeyMaxLength) throw new ArgumentException($@"""{key}"" : the counter key length can't exceed {Constants.CounterKeyMaxLength} characters.", nameof(key));
             
             QueueCommand((connection, transaction) => connection.Execute(
                 $@"insert into [{_storage.SchemaName}].Counter ([Key], [Value], [ExpireAt]) values (@key, @value, @expireAt)",
@@ -215,8 +215,8 @@ values (@jobId, @name, @reason, @createdAt, @data)";
 
         public override void AddToSet(string key, string value, double score)
         {
-            if (key.Length > Constants.SetKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.SetKeyMaxLength);
-            if (value.Length > Constants.SetValueMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(value), value, Constants.SetValueMaxLength);
+            if (key.Length > Constants.SetKeyMaxLength) throw new ArgumentException($@"""{key}"" : the set key length can't exceed {Constants.SetKeyMaxLength} characters.", nameof(key));
+            if (value.Length > Constants.SetValueMaxLength) throw new ArgumentException($@"""{value}"" : the set value length can't exceed {Constants.SetValueMaxLength} characters.", nameof(value));
             
             string addSql =
 $@";merge [{_storage.SchemaName}].[Set] with (holdlock) as Target
@@ -247,7 +247,7 @@ when not matched then insert ([Key], Value, Score) values (Source.[Key], Source.
 
         public override void InsertToList(string key, string value)
         {
-            if (key.Length > Constants.ListKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.ListKeyMaxLength);
+            if (key.Length > Constants.ListKeyMaxLength) throw new ArgumentException($@"""{key}"" : the list key length can't exceed {Constants.ListKeyMaxLength} characters.", nameof(key));
             
             AcquireListLock();
             QueueCommand((connection, transaction) => connection.Execute(
@@ -288,14 +288,14 @@ delete from cte where row_num not between @start and @end";
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
             if (keyValuePairs == null) throw new ArgumentNullException(nameof(keyValuePairs));
-            if (key.Length > Constants.HashKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.HashKeyMaxLength);
+            if (key.Length > Constants.HashKeyMaxLength) throw new ArgumentException($@"""{key}"" : the hash key length can't exceed {Constants.HashKeyMaxLength} characters.", nameof(key));
 
             var valuePairs = keyValuePairs as KeyValuePair<string, string>[] ?? keyValuePairs.ToArray();
 
             foreach (var keyValue in valuePairs)
             {
                 if (keyValue.Key.Length <= Constants.HashFieldMaxLength) continue;
-                ThrowArgumentExceedsMaxLengthException(nameof(keyValuePairs), keyValue.Key, Constants.HashFieldMaxLength);
+                throw new ArgumentException($@"""{keyValue.Key}"" : the hash field length can't exceed {Constants.HashFieldMaxLength} characters.", nameof(keyValuePairs));
             }
             
             string sql =
@@ -331,12 +331,12 @@ when not matched then insert ([Key], Field, Value) values (Source.[Key], Source.
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
             if (items == null) throw new ArgumentNullException(nameof(items));
-            if (key.Length > Constants.SetKeyMaxLength) ThrowArgumentExceedsMaxLengthException(nameof(key), key, Constants.SetKeyMaxLength);
+            if (key.Length > Constants.SetKeyMaxLength) throw new ArgumentException($@"""{key}"" : the set key length can't exceed { Constants.SetKeyMaxLength } characters.", nameof(key));
 
             foreach (var value in items)
             {
                 if (value.Length <= Constants.SetValueMaxLength) continue;
-                ThrowArgumentExceedsMaxLengthException(nameof(items), value, Constants.SetValueMaxLength);
+                throw new ArgumentException($@"""{value}"" : the set value can't exceed { Constants.SetValueMaxLength } characters.", nameof(items));
             }
             
             // TODO: Rewrite using the `MERGE` statement.
@@ -484,10 +484,6 @@ update [{_storage.SchemaName}].[List] set ExpireAt = null where [Key] = @key";
         private string TrancateReason(string reason)
         {
             return reason.Substring(0, Constants.StateReasonMaxLength - 3) + "...";
-        }
-        private void ThrowArgumentExceedsMaxLengthException(string argumentName, string value, int maxLength)
-        {
-            throw new ArgumentException($@"""{value}"" : the string length can't exceed {maxLength}.", argumentName);
         }
     }
 }

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.6.13")]
+[assembly: AssemblyVersion("1.6.14")]

--- a/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.csproj
+++ b/tests/Hangfire.SqlServer.Tests/Hangfire.SqlServer.Tests.csproj
@@ -76,7 +76,8 @@
     <Compile Include="SqlServerConnectionFacts.cs" />
     <Compile Include="ExpirationManagerFacts.cs" />
     <Compile Include="SqlServerJobQueueFacts.cs" />
-    <Compile Include="SqlServerFetchedJobFacts.cs" />
+    <Compile Include="SqlServerTimeoutJobFacts.cs" />
+    <Compile Include="SqlServerTransactionJobFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlServerDistributedLockFacts.cs" />
     <Compile Include="SqlServerStorageFacts.cs" />

--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -17,8 +17,8 @@ namespace Hangfire.SqlServer.Tests
 {
     public class SqlServerConnectionFacts
     {
-        private const string StringLongerThan40Characters = "Too long name containing more than 40 characters.";
-        private const string StringLongerThan100Characters = @"The string is too long. It contains more than 40 characters. Moreover it contains more than 100 characters.";
+        private static readonly string StringLongerThan40Characters = new string('*', 41);
+        private static readonly string StringLongerThan100Characters = new string('*', 101);
         
         private readonly Mock<IPersistentJobQueue> _queue;
         private readonly PersistentJobQueueProviderCollection _providers;

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -549,7 +549,7 @@ values (scope_identity(), @queue)";
         private static SqlServerJobQueue CreateJobQueue(SqlConnection connection, TimeSpan? invisibilityTimeout)
         {
             var storage = new SqlServerStorage(connection);
-            return new SqlServerJobQueue(storage, new SqlServerStorageOptions { SlidingInvisibilityTimeout = TimeSpan.FromMinutes(1) });
+            return new SqlServerJobQueue(storage, new SqlServerStorageOptions { SlidingInvisibilityTimeout = invisibilityTimeout });
         }
 
         private static void UseConnection(Action<SqlConnection> action)

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -12,6 +12,7 @@ namespace Hangfire.SqlServer.Tests
 {
     public class SqlServerJobQueueFacts
     {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
         private static readonly string[] DefaultQueues = { "default" };
 
         [Fact]
@@ -37,7 +38,7 @@ namespace Hangfire.SqlServer.Tests
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => queue.Dequeue(null, CreateTimingOutCancellationToken()));
@@ -51,7 +52,7 @@ namespace Hangfire.SqlServer.Tests
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 var exception = Assert.Throws<ArgumentException>(
                     () => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
@@ -67,7 +68,7 @@ namespace Hangfire.SqlServer.Tests
             {
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -80,7 +81,7 @@ namespace Hangfire.SqlServer.Tests
             UseConnection(connection =>
             {
                 var cts = new CancellationTokenSource(200);
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -102,7 +103,7 @@ select scope_identity() as Id;";
                 var id = (int)connection.Query(
                     arrangeSql,
                     new { jobId = 1, queue = "default" }).Single().Id;
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 // Act
                 var payload = (SqlServerTransactionJob)queue.Dequeue(
@@ -130,7 +131,7 @@ values (scope_identity(), @queue)";
                 connection.Execute(
                     arrangeSql,
                     new { invocationData = "", arguments = "", queue = "default" });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -166,7 +167,7 @@ values (scope_identity(), @queue, @fetchedAt)";
                         invocationData = "",
                         arguments = ""
                     });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -197,7 +198,7 @@ values (scope_identity(), @queue)";
                         new { queue = "default", invocationData = "", arguments = "" },
                         new { queue = "default", invocationData = "", arguments = "" }
                     });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -224,7 +225,7 @@ values (scope_identity(), @queue)";
 
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 connection.Execute(
                     arrangeSql,
@@ -256,7 +257,7 @@ values (scope_identity(), @queue)";
                         new { queue = "critical", invocationData = "", arguments = "" }
                     });
 
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 var critical = (SqlServerTransactionJob)queue.Dequeue(
                     new[] { "critical", "default" },
@@ -280,7 +281,7 @@ values (scope_identity(), @queue)";
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => queue.Dequeue(null, CreateTimingOutCancellationToken()));
@@ -294,7 +295,7 @@ values (scope_identity(), @queue)";
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 var exception = Assert.Throws<ArgumentException>(
                     () => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
@@ -310,7 +311,7 @@ values (scope_identity(), @queue)";
             {
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -323,7 +324,7 @@ values (scope_identity(), @queue)";
             UseConnection(connection =>
             {
                 var cts = new CancellationTokenSource(200);
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -344,7 +345,7 @@ select scope_identity() as Id;";
                 var id = (int)connection.Query(
                     arrangeSql,
                     new { jobId = 1, queue = "default" }).Single().Id;
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 // Act
                 var payload = (SqlServerTimeoutJob)queue.Dequeue(
@@ -373,7 +374,7 @@ values (scope_identity(), @queue)";
                 connection.Execute(
                     arrangeSql,
                     new { invocationData = "", arguments = "", queue = "default" });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -413,7 +414,7 @@ values (scope_identity(), @queue, @fetchedAt)";
                         invocationData = "",
                         arguments = ""
                     });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -444,7 +445,7 @@ values (scope_identity(), @queue)";
                         new { queue = "default", invocationData = "", arguments = "" },
                         new { queue = "default", invocationData = "", arguments = "" }
                     });
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -471,7 +472,7 @@ values (scope_identity(), @queue)";
 
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 connection.Execute(
                     arrangeSql,
@@ -503,7 +504,7 @@ values (scope_identity(), @queue)";
                         new { queue = "critical", invocationData = "", arguments = "" }
                     });
 
-                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: DefaultTimeout);
 
                 var critical = (SqlServerTimeoutJob)queue.Dequeue(
                     new[] { "critical", "default" },
@@ -526,7 +527,7 @@ values (scope_identity(), @queue)";
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: null);
 
                 queue.Enqueue(connection, "default", "1");
 
@@ -545,10 +546,10 @@ values (scope_identity(), @queue)";
 
         public static void Sample(string arg1, string arg2) { }
 
-        private static SqlServerJobQueue CreateJobQueue(SqlConnection connection, bool invisibilityTimeout)
+        private static SqlServerJobQueue CreateJobQueue(SqlConnection connection, TimeSpan? invisibilityTimeout)
         {
             var storage = new SqlServerStorage(connection);
-            return new SqlServerJobQueue(storage, new SqlServerStorageOptions { UseInvisibilityTimeout = invisibilityTimeout });
+            return new SqlServerJobQueue(storage, new SqlServerStorageOptions { SlidingInvisibilityTimeout = TimeSpan.FromMinutes(1) });
         }
 
         private static void UseConnection(Action<SqlConnection> action)

--- a/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerJobQueueFacts.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Dapper;
 using Xunit;
+// ReSharper disable ArgumentsStyleLiteral
 
 // ReSharper disable AssignNullToNotNullAttribute
 
@@ -36,7 +37,7 @@ namespace Hangfire.SqlServer.Tests
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => queue.Dequeue(null, CreateTimingOutCancellationToken()));
@@ -50,7 +51,7 @@ namespace Hangfire.SqlServer.Tests
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 var exception = Assert.Throws<ArgumentException>(
                     () => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
@@ -66,7 +67,7 @@ namespace Hangfire.SqlServer.Tests
             {
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -79,7 +80,7 @@ namespace Hangfire.SqlServer.Tests
             UseConnection(connection =>
             {
                 var cts = new CancellationTokenSource(200);
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 Assert.Throws<OperationCanceledException>(
                     () => queue.Dequeue(DefaultQueues, cts.Token));
@@ -101,10 +102,10 @@ select scope_identity() as Id;";
                 var id = (int)connection.Query(
                     arrangeSql,
                     new { jobId = 1, queue = "default" }).Single().Id;
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 // Act
-                var payload = (SqlServerFetchedJob)queue.Dequeue(
+                var payload = (SqlServerTransactionJob)queue.Dequeue(
                     DefaultQueues,
                     CreateTimingOutCancellationToken());
 
@@ -129,7 +130,7 @@ values (scope_identity(), @queue)";
                 connection.Execute(
                     arrangeSql,
                     new { invocationData = "", arguments = "", queue = "default" });
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -145,11 +146,11 @@ values (scope_identity(), @queue)";
         }
 
         [Fact, CleanDatabase]
-        public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue()
+        public void Dequeue_ShouldFetchTimedOutJobs_FromTheSpecifiedQueue()
         {
             const string arrangeSql = @"
 insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
-values (@invocationData, @arguments, getutcdate())
+values (@invocationData, @arguments, dateadd(minute, -60, getutcdate()))
 insert into HangFire.JobQueue (JobId, Queue, FetchedAt)
 values (scope_identity(), @queue, @fetchedAt)";
 
@@ -165,7 +166,7 @@ values (scope_identity(), @queue, @fetchedAt)";
                         invocationData = "",
                         arguments = ""
                     });
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -196,7 +197,7 @@ values (scope_identity(), @queue)";
                         new { queue = "default", invocationData = "", arguments = "" },
                         new { queue = "default", invocationData = "", arguments = "" }
                     });
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 // Act
                 var payload = queue.Dequeue(
@@ -223,7 +224,7 @@ values (scope_identity(), @queue)";
 
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 connection.Execute(
                     arrangeSql,
@@ -255,16 +256,263 @@ values (scope_identity(), @queue)";
                         new { queue = "critical", invocationData = "", arguments = "" }
                     });
 
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
-                var critical = (SqlServerFetchedJob)queue.Dequeue(
+                var critical = (SqlServerTransactionJob)queue.Dequeue(
                     new[] { "critical", "default" },
                     CreateTimingOutCancellationToken());
 
                 Assert.NotNull(critical.JobId);
                 Assert.Equal("critical", critical.Queue);
 
-                var @default = (SqlServerFetchedJob)queue.Dequeue(
+                var @default = (SqlServerTransactionJob)queue.Dequeue(
+                    new[] { "critical", "default" },
+                    CreateTimingOutCancellationToken());
+
+                Assert.NotNull(@default.JobId);
+                Assert.Equal("default", @default.Queue);
+            });
+        }
+
+        //---
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldThrowAnException_WhenQueuesCollectionIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => queue.Dequeue(null, CreateTimingOutCancellationToken()));
+
+                Assert.Equal("queues", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldThrowAnException_WhenQueuesCollectionIsEmpty()
+        {
+            UseConnection(connection =>
+            {
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                var exception = Assert.Throws<ArgumentException>(
+                    () => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
+
+                Assert.Equal("queues", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void Dequeue_InvisibilityTimeout_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning()
+        {
+            UseConnection(connection =>
+            {
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(DefaultQueues, cts.Token));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldWaitIndefinitely_WhenThereAreNoJobs()
+        {
+            UseConnection(connection =>
+            {
+                var cts = new CancellationTokenSource(200);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(DefaultQueues, cts.Token));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldFetchAJob_FromTheSpecifiedQueue()
+        {
+            const string arrangeSql = @"
+insert into HangFire.JobQueue (JobId, Queue)
+values (@jobId, @queue);
+select scope_identity() as Id;";
+
+            // Arrange
+            UseConnection(connection =>
+            {
+                var id = (int)connection.Query(
+                    arrangeSql,
+                    new { jobId = 1, queue = "default" }).Single().Id;
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                // Act
+                var payload = (SqlServerTimeoutJob)queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
+
+                // Assert
+                Assert.Equal(id, payload.Id);
+                Assert.Equal("1", payload.JobId);
+                Assert.Equal("default", payload.Queue);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values (@invocationData, @arguments, getutcdate())
+insert into HangFire.JobQueue (JobId, Queue)
+values (scope_identity(), @queue)";
+
+            // Arrange
+            UseConnection(connection =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new { invocationData = "", arguments = "", queue = "default" });
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
+
+                // Assert
+                Assert.NotNull(payload);
+
+                var fetchedAt = connection.Query<DateTime?>(
+                    "select FetchedAt from HangFire.JobQueue where JobId = @id",
+                    new { id = payload.JobId }).Single();
+
+                Assert.NotNull(fetchedAt);
+                Assert.True(fetchedAt > DateTime.UtcNow.AddMinutes(-1));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values (@invocationData, @arguments, getutcdate())
+insert into HangFire.JobQueue (JobId, Queue, FetchedAt)
+values (scope_identity(), @queue, @fetchedAt)";
+
+            // Arrange
+            UseConnection(connection =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new
+                    {
+                        queue = "default",
+                        fetchedAt = DateTime.UtcNow.AddDays(-1),
+                        invocationData = "",
+                        arguments = ""
+                    });
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
+
+                // Assert
+                Assert.NotEmpty(payload.JobId);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldSetFetchedAt_OnlyForTheFetchedJob()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values (@invocationData, @arguments, getutcdate())
+insert into HangFire.JobQueue (JobId, Queue)
+values (scope_identity(), @queue)";
+
+            // Arrange
+            UseConnection(connection =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new[]
+                    {
+                        new { queue = "default", invocationData = "", arguments = "" },
+                        new { queue = "default", invocationData = "", arguments = "" }
+                    });
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
+
+                // Assert
+                var otherJobFetchedAt = connection.Query<DateTime?>(
+                    "select FetchedAt from HangFire.JobQueue where JobId != @id",
+                    new { id = payload.JobId }).Single();
+
+                Assert.Null(otherJobFetchedAt);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldFetchJobs_OnlyFromSpecifiedQueues()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values (@invocationData, @arguments, getutcdate())
+insert into HangFire.JobQueue (JobId, Queue)
+values (scope_identity(), @queue)";
+
+            UseConnection(connection =>
+            {
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                connection.Execute(
+                    arrangeSql,
+                    new { queue = "critical", invocationData = "", arguments = "" });
+
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(
+                        DefaultQueues,
+                        CreateTimingOutCancellationToken()));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dequeue_InvisibilityTimeout_ShouldFetchJobs_FromMultipleQueues()
+        {
+            const string arrangeSql = @"
+insert into HangFire.Job (InvocationData, Arguments, CreatedAt)
+values (@invocationData, @arguments, getutcdate())
+insert into HangFire.JobQueue (JobId, Queue)
+values (scope_identity(), @queue)";
+
+            UseConnection(connection =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new[]
+                    {
+                        new { queue = "default", invocationData = "", arguments = "" },
+                        new { queue = "critical", invocationData = "", arguments = "" }
+                    });
+
+                var queue = CreateJobQueue(connection, invisibilityTimeout: true);
+
+                var critical = (SqlServerTimeoutJob)queue.Dequeue(
+                    new[] { "critical", "default" },
+                    CreateTimingOutCancellationToken());
+
+                Assert.NotNull(critical.JobId);
+                Assert.Equal("critical", critical.Queue);
+
+                var @default = (SqlServerTimeoutJob)queue.Dequeue(
                     new[] { "critical", "default" },
                     CreateTimingOutCancellationToken());
 
@@ -278,7 +526,7 @@ values (scope_identity(), @queue)";
         {
             UseConnection(connection =>
             {
-                var queue = CreateJobQueue(connection);
+                var queue = CreateJobQueue(connection, invisibilityTimeout: false);
 
                 queue.Enqueue(connection, "default", "1");
 
@@ -297,10 +545,10 @@ values (scope_identity(), @queue)";
 
         public static void Sample(string arg1, string arg2) { }
 
-        private static SqlServerJobQueue CreateJobQueue(SqlConnection connection)
+        private static SqlServerJobQueue CreateJobQueue(SqlConnection connection, bool invisibilityTimeout)
         {
             var storage = new SqlServerStorage(connection);
-            return new SqlServerJobQueue(storage, new SqlServerStorageOptions());
+            return new SqlServerJobQueue(storage, new SqlServerStorageOptions { UseInvisibilityTimeout = invisibilityTimeout });
         }
 
         private static void UseConnection(Action<SqlConnection> action)

--- a/tests/Hangfire.SqlServer.Tests/SqlServerTimeoutJobFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerTimeoutJobFacts.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Data;
+using System.Linq;
+using Dapper;
+using Moq;
+using Xunit;
+
+namespace Hangfire.SqlServer.Tests
+{
+    public class SqlServerTimeoutJobFacts
+    {
+        private const string JobId = "id";
+        private const string Queue = "queue";
+
+        private readonly Mock<SqlServerStorage> _storage;
+
+        public SqlServerTimeoutJobFacts()
+        {
+            _storage = new Mock<SqlServerStorage>(ConnectionUtils.GetConnectionString());
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new SqlServerTimeoutJob(null, 1, JobId, Queue));
+
+            Assert.Equal("storage", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenJobIdIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new SqlServerTimeoutJob(_storage.Object, 1, null, Queue));
+
+            Assert.Equal("jobId", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenQueueIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new SqlServerTimeoutJob(_storage.Object, 1, JobId, null));
+
+            Assert.Equal("queue", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_CorrectlySets_AllInstanceProperties()
+        {
+            var fetchedJob = new SqlServerTimeoutJob(_storage.Object, 1, JobId, Queue);
+
+            Assert.Equal(1, fetchedJob.Id);
+            Assert.Equal(JobId, fetchedJob.JobId);
+            Assert.Equal(Queue, fetchedJob.Queue);
+        }
+
+        [Fact, CleanDatabase]
+        public void RemoveFromQueue_ReallyDeletesTheJobFromTheQueue()
+        {
+            UseConnection(sql =>
+            {
+                // Arrange
+                var id = CreateJobQueueRecord(sql, "1", "default");
+                var processingJob = new SqlServerTimeoutJob(_storage.Object, id, "1", "default");
+
+                // Act
+                processingJob.RemoveFromQueue();
+
+                // Assert
+                var count = sql.Query<int>("select count(*) from HangFire.JobQueue").Single();
+                Assert.Equal(0, count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void RemoveFromQueue_DoesNotDelete_UnrelatedJobs()
+        {
+            UseConnection(sql =>
+            {
+                // Arrange
+                CreateJobQueueRecord(sql, "1", "default");
+                CreateJobQueueRecord(sql, "1", "critical");
+                CreateJobQueueRecord(sql, "2", "default");
+
+                var fetchedJob = new SqlServerTimeoutJob(_storage.Object, 999, "1", "default");
+
+                // Act
+                fetchedJob.RemoveFromQueue();
+
+                // Assert
+                var count = sql.Query<int>("select count(*) from HangFire.JobQueue").Single();
+                Assert.Equal(3, count);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Requeue_SetsFetchedAtValueToNull()
+        {
+            UseConnection(sql =>
+            {
+                // Arrange
+                var id = CreateJobQueueRecord(sql, "1", "default");
+                var processingJob = new SqlServerTimeoutJob(_storage.Object, id, "1", "default");
+
+                // Act
+                processingJob.Requeue();
+
+                // Assert
+                var record = sql.Query("select * from HangFire.JobQueue").Single();
+                Assert.Null(record.FetchedAt);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dispose_SetsFetchedAtValueToNull_IfThereWereNoCallsToComplete()
+        {
+            UseConnection(sql =>
+            {
+                // Arrange
+                var id = CreateJobQueueRecord(sql, "1", "default");
+                var processingJob = new SqlServerTimeoutJob(_storage.Object, id, "1", "default");
+
+                // Act
+                processingJob.Dispose();
+
+                // Assert
+                var record = sql.Query("select * from HangFire.JobQueue").Single();
+                Assert.Null(record.FetchedAt);
+            });
+        }
+
+        private static int CreateJobQueueRecord(IDbConnection connection, string jobId, string queue)
+        {
+            const string arrangeSql = @"
+insert into HangFire.JobQueue (JobId, Queue, FetchedAt)
+values (@id, @queue, getutcdate());
+select scope_identity() as Id";
+
+            return (int)connection.Query(arrangeSql, new { id = jobId, queue = queue }).Single().Id;
+        }
+
+        private static void UseConnection(Action<IDbConnection> action)
+        {
+            using (var connection = ConnectionUtils.CreateConnection())
+            {
+                action(connection);
+            }
+        }
+    }
+}

--- a/tests/Hangfire.SqlServer.Tests/SqlServerTimeoutJobFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerTimeoutJobFacts.cs
@@ -174,7 +174,7 @@ select scope_identity() as Id";
             {
                 var storage = new SqlServerStorage(
                     connection,
-                    new SqlServerStorageOptions { InvisibilityTimeout = TimeSpan.FromSeconds(10) });
+                    new SqlServerStorageOptions { SlidingInvisibilityTimeout = TimeSpan.FromSeconds(10) });
 
                 action(connection, storage);
             }

--- a/tests/Hangfire.SqlServer.Tests/SqlServerTransactionJobFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerTransactionJobFacts.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Hangfire.SqlServer.Tests
 {
-    public class SqlServerFetchedJobFacts
+    public class SqlServerTransactionJobFacts
     {
         private const string JobId = "id";
         private const string Queue = "queue";
@@ -16,7 +16,7 @@ namespace Hangfire.SqlServer.Tests
         private readonly Mock<IDbTransaction> _transaction;
         private readonly Mock<SqlServerStorage> _storage;
 
-        public SqlServerFetchedJobFacts()
+        public SqlServerTransactionJobFacts()
         {
             _connection = new Mock<IDbConnection>();
             _transaction = new Mock<IDbTransaction>();
@@ -27,7 +27,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenStorageIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerFetchedJob(null, _connection.Object, _transaction.Object, JobId, Queue));
+                () => new SqlServerTransactionJob(null, _connection.Object, _transaction.Object, JobId, Queue));
 
             Assert.Equal("storage", exception.ParamName);
         }
@@ -36,7 +36,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenConnectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerFetchedJob(_storage.Object, null, _transaction.Object, JobId, Queue));
+                () => new SqlServerTransactionJob(_storage.Object, null, _transaction.Object, JobId, Queue));
 
             Assert.Equal("connection", exception.ParamName);
         }
@@ -45,7 +45,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenTransactionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerFetchedJob(_storage.Object, _connection.Object, null, JobId, Queue));
+                () => new SqlServerTransactionJob(_storage.Object, _connection.Object, null, JobId, Queue));
 
             Assert.Equal("transaction", exception.ParamName);
         }
@@ -54,7 +54,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenJobIdIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerFetchedJob(_storage.Object, _connection.Object, _transaction.Object, null, Queue));
+                () => new SqlServerTransactionJob(_storage.Object, _connection.Object, _transaction.Object, null, Queue));
 
             Assert.Equal("jobId", exception.ParamName);
         }
@@ -63,7 +63,7 @@ namespace Hangfire.SqlServer.Tests
         public void Ctor_ThrowsAnException_WhenQueueIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new SqlServerFetchedJob(_storage.Object, _connection.Object, _transaction.Object, JobId, null));
+                () => new SqlServerTransactionJob(_storage.Object, _connection.Object, _transaction.Object, JobId, null));
 
             Assert.Equal("queue", exception.ParamName);
         }
@@ -71,7 +71,7 @@ namespace Hangfire.SqlServer.Tests
         [Fact]
         public void Ctor_CorrectlySets_AllInstanceProperties()
         {
-            var fetchedJob = new SqlServerFetchedJob(_storage.Object, _connection.Object, _transaction.Object, JobId, Queue);
+            var fetchedJob = new SqlServerTransactionJob(_storage.Object, _connection.Object, _transaction.Object, JobId, Queue);
 
             Assert.Equal(JobId, fetchedJob.JobId);
             Assert.Equal(Queue, fetchedJob.Queue);
@@ -116,9 +116,9 @@ namespace Hangfire.SqlServer.Tests
             _connection.Verify(x => x.Dispose());
         }
 
-        private SqlServerFetchedJob CreateFetchedJob(string jobId, string queue)
+        private SqlServerTransactionJob CreateFetchedJob(string jobId, string queue)
         {
-            return new SqlServerFetchedJob(_storage.Object, _connection.Object, _transaction.Object, jobId, queue);
+            return new SqlServerTransactionJob(_storage.Object, _connection.Object, _transaction.Object, jobId, queue);
         }
     }
 }

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -14,11 +14,9 @@ namespace Hangfire.SqlServer.Tests
 {
     public class SqlServerWriteOnlyTransactionFacts
     {
-        private const string StringLongerThan20Characters = "More than 20 characters.";
-        private const string StringLongerThan40Characters = "Too long string containing more than 40 characters.";
-        private const string StringLongerThan100Characters = @"The string is too long. It contains more than 40 characters. Moreover it contains more than 100 characters.";
-        private const string StringLongerThan256Characters = StringLongerThan100Characters + StringLongerThan100Characters + StringLongerThan40Characters + StringLongerThan20Characters;
-
+        private static readonly string StringLongerThan20Characters = new string('*', 21);
+        private static readonly string StringLongerThan100Characters = new string('*', 101);
+        private static readonly string StringLongerThan256Characters = new string('*', 257);
 
         private readonly PersistentJobQueueProviderCollection _queueProviders;
 


### PR DESCRIPTION
Now you can get exception during invocation of `SqlServerWriteOnlyTransaction.Commit()` because one of methods `SetJobState`, `IncrementCounter` and so on tries to insert a string whose length exceeds the allowed value. It's hard to track the certain place of a bug.
Also you can get non-informative `SqlException` during invocation of `SqlServerConnection` methods such as `SetRangeInHash`, `SetJobParameter` due to the same reason.

This PR suggests to check if inserting string value exceeds allowable length:
1. If it's important field: state name, job parameter name, set key/value and so on then appropriate method throws `ArgumentException`.
2. If it's state reason field then the reason is truncated and a row is inserted to the table.

Also I feel we should have common limits for all storages in the future. It will be easier to change Hangfire storage without problems.