### PR TITLE
Add optional date bounds to recurring job

### DIFF
--- a/src/Hangfire.Core/RecurringJob.cs
+++ b/src/Hangfire.Core/RecurringJob.cs
@@ -36,6 +36,27 @@ namespace Hangfire
             AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
         }
 
+        public static void AddOrUpdate(
+            Expression<Action> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Action> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, endDate, timeZone, queue);
+        }
+
         public static void AddOrUpdate<T>(
             Expression<Action<T>> methodCall,
             Func<string> cronExpression,
@@ -43,6 +64,27 @@ namespace Hangfire
             string queue = EnqueuedState.DefaultQueue)
         {
             AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Action<T>> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Action<T>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, endDate, timeZone, queue);
         }
 
         public static void AddOrUpdate(
@@ -57,6 +99,33 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        public static void AddOrUpdate(
+            Expression<Action> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Action> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate<T>(
             Expression<Action<T>> methodCall,
             string cronExpression,
@@ -67,6 +136,33 @@ namespace Hangfire
             var id = GetRecurringJobId(job);
 
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Action<T>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Action<T>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
         }
 
         public static void AddOrUpdate(
@@ -79,6 +175,29 @@ namespace Hangfire
             AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
         }
 
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Action> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Action> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, endDate, timeZone, queue);
+        }
+
         public static void AddOrUpdate<T>(
             string recurringJobId,
             Expression<Action<T>> methodCall,
@@ -87,6 +206,29 @@ namespace Hangfire
             string queue = EnqueuedState.DefaultQueue)
         {
             AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Action<T>> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Action<T>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, endDate, timeZone, queue);
         }
 
         public static void AddOrUpdate(
@@ -100,6 +242,31 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Action> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Action> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate<T>(
             string recurringJobId,
             Expression<Action<T>> methodCall,
@@ -111,8 +278,63 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Action<T>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Action<T>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate(
             Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, endDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Func<T, Task>> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
             string queue = EnqueuedState.DefaultQueue)
@@ -123,10 +345,22 @@ namespace Hangfire
         public static void AddOrUpdate<T>(
             Expression<Func<T, Task>> methodCall,
             Func<string> cronExpression,
+            DateTime startDate,
             TimeZoneInfo timeZone = null,
             string queue = EnqueuedState.DefaultQueue)
         {
-            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Func<T, Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, cronExpression(), startDate, endDate, timeZone, queue);
         }
 
         public static void AddOrUpdate(
@@ -141,6 +375,33 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate(
+            Expression<Func<Task>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate<T>(
             Expression<Func<T, Task>> methodCall,
             string cronExpression,
@@ -152,10 +413,70 @@ namespace Hangfire
 
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
-        
+
+        public static void AddOrUpdate<T>(
+            Expression<Func<T, Task>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate<T>(
+            Expression<Func<T, Task>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate(
             string recurringJobId,
             Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Func<Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, endDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Func<T, Task>> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
             string queue = EnqueuedState.DefaultQueue)
@@ -167,10 +488,23 @@ namespace Hangfire
             string recurringJobId,
             Expression<Func<T, Task>> methodCall,
             Func<string> cronExpression,
+            DateTime startDate,
             TimeZoneInfo timeZone = null,
             string queue = EnqueuedState.DefaultQueue)
         {
-            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, timeZone, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Func<T, Task>> methodCall,
+            Func<string> cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), startDate, endDate, timeZone, queue);
         }
 
         public static void AddOrUpdate(
@@ -184,6 +518,31 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Func<Task>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate(
+            string recurringJobId,
+            Expression<Func<Task>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
+        }
+
         public static void AddOrUpdate<T>(
             string recurringJobId,
             Expression<Func<T, Task>> methodCall,
@@ -193,6 +552,31 @@ namespace Hangfire
         {
             var job = Job.FromExpression(methodCall);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Func<T, Task>> methodCall,
+            string cronExpression,
+            DateTime startDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, null);
+        }
+
+        public static void AddOrUpdate<T>(
+            string recurringJobId,
+            Expression<Func<T, Task>> methodCall,
+            string cronExpression,
+            DateTime? startDate,
+            DateTime endDate,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue, startDate, endDate);
         }
 
         public static void RemoveIfExists(string recurringJobId)

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -75,14 +75,12 @@ namespace Hangfire
 
                 if (options.StartDate.HasValue)
                 {
-                    var utcStartDate = TimeZoneInfo.ConvertTime(options.StartDate.Value, options.TimeZone, TimeZoneInfo.Utc);
-                    recurringJob["StartDate"] = JobHelper.SerializeDateTime(utcStartDate);
+                    recurringJob["StartDate"] = JobHelper.SerializeDateTime(options.StartDate.Value);
                 }
                 
                 if (options.EndDate.HasValue)
                 {
-                    var utcEndDate = TimeZoneInfo.ConvertTime(options.EndDate.Value, options.TimeZone, TimeZoneInfo.Utc);
-                    recurringJob["EndDate"] = JobHelper.SerializeDateTime(utcEndDate);
+                    recurringJob["EndDate"] = JobHelper.SerializeDateTime(options.EndDate.Value);
                 }
 
                 var existingJob = connection.GetAllEntriesFromHash($"recurring-job:{recurringJobId}");

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -72,6 +72,18 @@ namespace Hangfire
                 recurringJob["TimeZoneId"] = options.TimeZone.Id;
                 recurringJob["Queue"] = options.QueueName;
 
+                if (options.StartDate.HasValue)
+                {
+                    var utcStartDate = TimeZoneInfo.ConvertTime(options.StartDate.Value, options.TimeZone, TimeZoneInfo.Utc);
+                    recurringJob["StartDate"] = JobHelper.SerializeDateTime(utcStartDate);
+                }
+                
+                if (options.EndDate.HasValue)
+                {
+                    var utcEndDate = TimeZoneInfo.ConvertTime(options.EndDate.Value, options.TimeZone, TimeZoneInfo.Utc);
+                    recurringJob["EndDate"] = JobHelper.SerializeDateTime(utcEndDate);
+                }
+
                 var existingJob = connection.GetAllEntriesFromHash($"recurring-job:{recurringJobId}");
                 if (existingJob == null)
                 {

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -61,6 +61,7 @@ namespace Hangfire
             if (options == null) throw new ArgumentNullException(nameof(options));
             
             ValidateCronExpression(cronExpression);
+            ValidateDateBounds(options);
 
             using (var connection = _storage.GetConnection())
             {
@@ -102,7 +103,7 @@ namespace Hangfire
                 }
             }
         }
-
+        
         public void Trigger(string recurringJobId)
         {
             if (recurringJobId == null) throw new ArgumentNullException(nameof(recurringJobId));
@@ -153,6 +154,24 @@ namespace Hangfire
             catch (Exception ex)
             {
                 throw new ArgumentException("CRON expression is invalid. Please see the inner exception for details.", nameof(cronExpression), ex);
+            }
+        }
+
+        private void ValidateDateBounds(RecurringJobOptions options)
+        {
+            if (options.StartDate.HasValue && options.StartDate.Value.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentException("Start date must be in UTC", nameof(RecurringJobOptions.StartDate));
+            }
+
+            if (options.EndDate.HasValue && options.EndDate.Value.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentException("End date must be in UTC", nameof(RecurringJobOptions.EndDate));
+            }
+
+            if (options.StartDate.HasValue && options.EndDate.HasValue && options.EndDate.Value < options.StartDate.Value)
+            {
+                throw new ArgumentException("Start date must be before end date", nameof(options));
             }
         }
     }

--- a/src/Hangfire.Core/RecurringJobManagerExtensions.cs
+++ b/src/Hangfire.Core/RecurringJobManagerExtensions.cs
@@ -60,5 +60,49 @@ namespace Hangfire
                 cronExpression,
                 new RecurringJobOptions { QueueName = queue, TimeZone = timeZone });
         }
+
+        public static void AddOrUpdate(
+             [NotNull] this IRecurringJobManager manager,
+             [NotNull] string recurringJobId,
+             [NotNull] Job job,
+             [NotNull] string cronExpression,
+             DateTime? startDate,
+             DateTime? endDate)
+        {
+            AddOrUpdate(manager, recurringJobId, job, cronExpression, TimeZoneInfo.Utc, startDate, endDate);
+        }
+
+        public static void AddOrUpdate(
+            [NotNull] this IRecurringJobManager manager,
+            [NotNull] string recurringJobId,
+            [NotNull] Job job,
+            [NotNull] string cronExpression,
+            [NotNull] TimeZoneInfo timeZone,
+            DateTime? startDate,
+            DateTime? endDate)
+        {
+            AddOrUpdate(manager, recurringJobId, job, cronExpression, timeZone, EnqueuedState.DefaultQueue, startDate, endDate);
+        }
+
+        public static void AddOrUpdate(
+            [NotNull] this IRecurringJobManager manager,
+            [NotNull] string recurringJobId,
+            [NotNull] Job job,
+            [NotNull] string cronExpression,
+            [NotNull] TimeZoneInfo timeZone,
+            [NotNull] string queue,
+            DateTime? startDate,
+            DateTime? endDate)
+        {
+            if (manager == null) throw new ArgumentNullException(nameof(manager));
+            if (timeZone == null) throw new ArgumentNullException(nameof(timeZone));
+            if (queue == null) throw new ArgumentNullException(nameof(queue));
+
+            manager.AddOrUpdate(
+                recurringJobId,
+                job,
+                cronExpression,
+                new RecurringJobOptions { QueueName = queue, TimeZone = timeZone, StartDate = startDate, EndDate = endDate });
+        }
     }
 }

--- a/src/Hangfire.Core/RecurringJobOptions.cs
+++ b/src/Hangfire.Core/RecurringJobOptions.cs
@@ -53,5 +53,9 @@ namespace Hangfire
                 _queueName = value;
             }
         }
+
+        public DateTime? StartDate { get; set; }
+ 
+        public DateTime? EndDate { get; set; }
     }
 }

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -23,6 +23,7 @@ using Hangfire.Logging;
 using Hangfire.States;
 using Hangfire.Storage;
 using Cronos;
+using System.Linq;
 
 namespace Hangfire.Server
 {
@@ -160,8 +161,8 @@ namespace Hangfire.Server
 
         private void TryScheduleJob(
             JobStorage storage,
-            IStorageConnection connection, 
-            string recurringJobId, 
+            IStorageConnection connection,
+            string recurringJobId,
             IReadOnlyDictionary<string, string> recurringJob)
         {
             var serializedJob = JobHelper.FromJson<InvocationData>(recurringJob["Job"]);
@@ -171,6 +172,19 @@ namespace Hangfire.Server
 
             try
             {
+
+                var startDate = JobHelper.DeserializeNullableDateTime(recurringJob.ContainsKey("StartDate") ? recurringJob["StartDate"] : null);
+                if (startDate.HasValue)
+                {
+                    startDate = DateTime.SpecifyKind(startDate.Value, DateTimeKind.Utc);
+                }
+
+                var endDate = JobHelper.DeserializeNullableDateTime(recurringJob.ContainsKey("EndDate") ? recurringJob["EndDate"] : null);
+                if (endDate.HasValue)
+                {
+                    endDate = DateTime.SpecifyKind(endDate.Value, DateTimeKind.Utc);
+                }
+
                 var timeZone = recurringJob.ContainsKey("TimeZoneId")
                     ? TimeZoneInfo.FindSystemTimeZoneById(recurringJob["TimeZoneId"])
                     : TimeZoneInfo.Utc;
@@ -180,7 +194,32 @@ namespace Hangfire.Server
 
                 var changedFields = new Dictionary<string, string>();
 
-                var nextInstant = cronExpression.GetNextOccurrence(lastInstant, timeZone);
+                var lowerBound = lastInstant;
+                var fromInclusive = false;
+                var toInclusive = false;
+
+                if (startDate.HasValue && lastInstant < startDate)
+                {
+                    lowerBound = startDate.Value;
+                    fromInclusive = true;
+                }
+
+                DateTime? nextInstant;
+
+                if (endDate.HasValue)
+                {
+                    toInclusive = true;
+                    nextInstant = cronExpression.GetOccurrences(lowerBound, endDate.Value, timeZone, fromInclusive, toInclusive).FirstOrDefault();
+
+                    if (nextInstant == default(DateTime))
+                    {
+                        nextInstant = null;
+                    }
+                }
+                else
+                {
+                    nextInstant = cronExpression.GetNextOccurrence(lowerBound, timeZone, fromInclusive);
+                }
 
                 if (nextInstant <= nowInstant)
                 {
@@ -206,13 +245,13 @@ namespace Hangfire.Server
 
                     nextInstant = cronExpression.GetNextOccurrence(nowInstant, timeZone);
                 }
-                
+
                 // Fixing old recurring jobs that doesn't have the CreatedAt field
                 if (!recurringJob.ContainsKey("CreatedAt"))
                 {
                     changedFields.Add("CreatedAt", JobHelper.SerializeDateTime(nowInstant));
                 }
-                    
+
                 changedFields.Add("NextExecution", nextInstant.HasValue ? JobHelper.SerializeDateTime(nextInstant.Value) : null);
 
                 connection.SetRangeInHash(

--- a/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
+++ b/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
@@ -179,6 +179,22 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
+        public void AddOrUpdate_SetsTheRecurringJobEntry_IncludingOptionalDateRange()
+        {
+            var startDate = DateTime.UtcNow.AddSeconds(-1);
+            var endDate = DateTime.UtcNow.AddSeconds(1);
+            var manager = CreateManager();
+
+            manager.AddOrUpdate(_id, _job, _cronExpression, startDate, endDate);
+
+            _transaction.Verify(x => x.SetRangeInHash(
+                $"recurring-job:{_id}",
+                It.Is<Dictionary<string, string>>(rj =>
+                    JobHelper.DeserializeNullableDateTime(rj["StartDate"]) == startDate
+                    && JobHelper.DeserializeNullableDateTime(rj["EndDate"]) == endDate)));
+        }
+
+        [Fact]
         public void AddOrUpdate_CommitsTransaction()
         {
             var manager = CreateManager();

--- a/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
+++ b/tests/Hangfire.Core.Tests/RecurringJobManagerFacts.cs
@@ -195,6 +195,43 @@ namespace Hangfire.Core.Tests
         }
 
         [Fact]
+        public void AddOrUpdate_RequiresStartDate_ToBeUtc()
+        {
+            var startDate = DateTime.Now;
+            var manager = CreateManager();
+
+            var exception = Record.Exception(() => manager.AddOrUpdate(_id, _job, _cronExpression, startDate, null));
+
+            Assert.IsType<ArgumentException>(exception);
+            Assert.True(((ArgumentException)exception).ParamName == nameof(RecurringJobOptions.StartDate));
+        }
+
+        [Fact]
+        public void AddOrUpdate_RequiresEndDate_ToBeUtc()
+        {
+            var endDate = DateTime.Now;
+            var manager = CreateManager();
+
+            var exception = Record.Exception(() => manager.AddOrUpdate(_id, _job, _cronExpression, null, endDate));
+
+            Assert.IsType<ArgumentException>(exception);
+            Assert.True(((ArgumentException)exception).ParamName == nameof(RecurringJobOptions.EndDate));
+        }
+
+        [Fact]
+        public void AddOrUpdate_RequiresEndDate_ToBeAfterStartDate()
+        {
+            var startDate = DateTime.UtcNow;
+            var endDate = startDate.AddSeconds(-1);
+            var manager = CreateManager();
+
+            var exception = Record.Exception(() => manager.AddOrUpdate(_id, _job, _cronExpression, startDate, endDate));
+
+            Assert.IsType<ArgumentException>(exception);
+            Assert.True(((ArgumentException)exception).ParamName == "options");
+        }
+
+        [Fact]
         public void AddOrUpdate_CommitsTransaction()
         {
             var manager = CreateManager();


### PR DESCRIPTION
This PR supersedes #939. I realized there's a dev branch that already has cronos merged. I went ahead and applied the same logic from the previous PR into the dev branch.

* New overloads are added to RecurringJob.AddOrUpdate to allow for specifying a start and/or end date in UTC. Specifying these dates would queue new jobs only if the cron expression is matched and this run falls within the date bounds (inclusive).
* Specifying start and or end date creates an allowable window for jobs to be queued. Null start implies queue immediately like existing recurring jobs. Null end implies queue forever.
* Start and end dates are stored in the recurring job dictionary which, in sql server, end up in the Hash table. I haven't tested with Redis but I assume the serializer automatically handles it just like the it did for sql server.
* I _think_ there's no impact on current users since the two fields are optional. The job scheduler checks if start/end dates have a value. If not, the existing logic is used.

Questions:
* Regarding @burningice2866's [comment][2], adding explicit overloads for start and end dates results in 48 overloads for AddOrUpdate. Would it be better to create a new method (e.g. AddOrUpdateBounded) that uses optional params or is that many overloads OK?
* Regarding @aidmsu's [comment][0] and my response (point 1), I have made it so the dates must already be in UTC. Is there a scenario where that wouldn't work?
* Does the UI portion need to be a part of this PR or can/should it be a part of another?
* What are the thoughts on my [previous comments][1](point 2) about UI?

[0]: https://github.com/HangfireIO/Hangfire/pull/939#issuecomment-315063423
[1]: https://github.com/HangfireIO/Hangfire/pull/939#issuecomment-315159243
[2]: https://github.com/HangfireIO/Hangfire/pull/939#issuecomment-315044477