### PR TITLE
Support async jobs returning ValueTask<T>

### DIFF
--- a/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
@@ -109,7 +109,7 @@ namespace Hangfire.Server
                 var methodInfo = context.BackgroundJob.Job.Method;
                 var result = methodInfo.Invoke(instance, arguments);
 
-                if (result != null)
+                if (result != null && !methodInfo.ReturnType.GetTypeInfo().IsPrimitive)
                 {
                     var getAwaiterMethod = methodInfo.ReturnType.GetRuntimeMethod("GetAwaiter", EmptyTypes);
                     if (getAwaiterMethod != null)

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -754,6 +754,13 @@ namespace Hangfire.Core.Tests.Common
 
                 return FunctionReturningValue();
             }
+
+            public async ValueTask<string> FunctionReturningValueTaskResultingInString()
+            {
+                await Task.Yield();
+
+                return FunctionReturningValue();
+            }
         }
 
         public class DerivedInstance : Instance

--- a/tests/Hangfire.Core.Tests/Common/JobFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/JobFacts.cs
@@ -754,12 +754,10 @@ namespace Hangfire.Core.Tests.Common
 
                 return FunctionReturningValue();
             }
-
-            public async ValueTask<string> FunctionReturningValueTaskResultingInString()
+            
+            public ValueTask<string> FunctionReturningValueTaskResultingInString()
             {
-                await Task.Yield();
-
-                return FunctionReturningValue();
+                return new ValueTask<string>(FunctionReturningTaskResultingInString());
             }
         }
 

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.project.json
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Moq": "4.6.36-alpha",
     "Moq.Sequences.NoNUnit": "1.0.1",
+    "System.Threading.Tasks.Extensions": "4.4.0",
     "xunit": "2.2.0-beta2-build3300"
   },
   "runtimes": {

--- a/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
@@ -376,6 +376,19 @@ namespace Hangfire.Core.Tests.Server
         }
 #pragma warning restore 4014
 
+#pragma warning disable 4014
+        [Fact]
+        public void Run_ReturnsTaskResult_WhenCallingFunctionReturningValueTask()
+        {
+            _context.BackgroundJob.Job = Job.FromExpression<JobFacts.Instance>(x => x.FunctionReturningValueTaskResultingInString());
+            var performer = CreatePerformer();
+
+            var result = performer.Perform(_context.Object);
+
+            Assert.Equal("Return value", result);
+        }
+#pragma warning restore 4014
+
         public void InstanceMethod()
         {
             _methodInvoked = true;


### PR DESCRIPTION
C# 7 adds support for [generalized async return types](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7#generalized-async-return-types), i.e. async method may not only return `Task` subclass but also an arbitrary object with `GetAwaiter()` method, e.g. `ValueTask<T>`.