### PR TITLE
Fixing #828

### DIFF
--- a/src/Hangfire.Core/JobActivator.cs
+++ b/src/Hangfire.Core/JobActivator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using Hangfire.Annotations;
+using Hangfire.Server;
 
 namespace Hangfire
 {
@@ -59,6 +60,11 @@ namespace Hangfire
 #pragma warning disable 618
             return BeginScope();
 #pragma warning restore 618
+        }
+
+        public virtual JobActivatorScope BeginScope(PerformContext context)
+        {
+            return this.BeginScope(new JobActivatorContext(context.Connection, context.BackgroundJob, context.CancellationToken));
         }
 
         class SimpleJobActivatorScope : JobActivatorScope

--- a/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
@@ -44,8 +44,7 @@ namespace Hangfire.Server
 
         public object Perform(PerformContext context)
         {
-            using (var scope = _activator.BeginScope(
-                new JobActivatorContext(context.Connection, context.BackgroundJob, context.CancellationToken)))
+            using (var scope = _activator.BeginScope(context))
             {
                 object instance = null;
 


### PR DESCRIPTION
Provides the JobActivator BeginScope with the full Performcontext.
Examples and motivation can be found here: https://github.com/HangfireIO/Hangfire/issues/828

This change is fully backward compatible with previous versions