### PR TITLE
Fix nuspec pointing to version of Newtonsoft.Json that does not exist

### DIFF
--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -130,7 +130,7 @@
     <dependencies>
       <group targetFramework="net45">
         <dependency id="Owin" version="1.0" />
-        <dependency id="Newtonsoft.Json" version="5.0.0" />
+        <dependency id="Newtonsoft.Json" version="5.0.1" />
       </group>
       <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />


### PR DESCRIPTION
The .nuspec file for Hangfire.Core is currently pointing to version 5.0.0 of Newtonsoft.Json, which does not exist. The correct version is 5.0.1.

This causes these kinds of issues:
![nuget-warning](https://user-images.githubusercontent.com/2027834/34297163-cfdccee8-e716-11e7-8f41-e2f19a055613.PNG)

Closes #947, closes #973