### PR TITLE
change log4net method

### DIFF
--- a/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
+++ b/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
@@ -697,7 +697,7 @@ namespace Hangfire.Logging.LogProviders
         private static Func<string, object> GetGetLoggerMethodCall()
         {
             Type logManagerType = GetLogManagerType();
-            MethodInfo method = logManagerType.GetRuntimeMethod("GetLogger", new[] { typeof(string) });
+            MethodInfo method = logManagerType.GetRuntimeMethod("GetLogger", new[] { typeof(Assembly), typeof(string) });
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
             MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { Expression.Constant(typeof(Log4NetLogProvider).GetTypeInfo().Assembly), nameParam });
             return Expression.Lambda<Func<string, object>>(methodCall, new[] { nameParam }).Compile();

--- a/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
+++ b/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
@@ -51,7 +51,7 @@ namespace Hangfire.Logging
         /// <remarks>
         /// Note to implementers: the message func should not be called if the loglevel is not enabled
         /// so as not to incur performance penalties.
-        /// 
+        ///
         /// To check IsEnabled call Log with only LogLevel and check the return value, no event will be written
         /// </remarks>
         bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null);
@@ -699,7 +699,7 @@ namespace Hangfire.Logging.LogProviders
             Type logManagerType = GetLogManagerType();
             MethodInfo method = logManagerType.GetRuntimeMethod("GetLogger", new[] { typeof(string) });
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
-            MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { nameParam });
+            MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { Expression.Constant(Assembly.GetEntryAssembly()), nameParam });
             return Expression.Lambda<Func<string, object>>(methodCall, new[] { nameParam }).Compile();
         }
 
@@ -1030,7 +1030,7 @@ namespace Hangfire.Logging.LogProviders
             ParameterExpression destructureObjectsParam = Expression.Parameter(typeof(bool), "destructureObjects");
             MethodCallExpression methodCall = Expression.Call(null, method, new Expression[]
             {
-                propertyNameParam, 
+                propertyNameParam,
                 valueParam,
                 destructureObjectsParam
             });
@@ -1098,7 +1098,7 @@ namespace Hangfire.Logging.LogProviders
                 MethodInfo writeExceptionMethodInfo = loggerType.GetRuntimeMethod("Write", new[]
                 {
                     logEventTypeType,
-                    typeof(Exception), 
+                    typeof(Exception),
                     typeof(string),
                     typeof(object[])
                 });
@@ -1286,7 +1286,7 @@ namespace Hangfire.Logging.LogProviders
 
             MethodInfo method = logManagerType.GetMethod("Write", new[]
                                                                   {
-                                                                      logMessageSeverityType, typeof(string), typeof(int), typeof(Exception), typeof(bool), 
+                                                                      logMessageSeverityType, typeof(string), typeof(int), typeof(Exception), typeof(bool),
                                                                       logWriteModeType, typeof(string), typeof(string), typeof(string), typeof(string), typeof(object[])
                                                                   });
 

--- a/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
+++ b/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
@@ -699,7 +699,7 @@ namespace Hangfire.Logging.LogProviders
             Type logManagerType = GetLogManagerType();
             MethodInfo method = logManagerType.GetRuntimeMethod("GetLogger", new[] { typeof(string) });
             ParameterExpression nameParam = Expression.Parameter(typeof(string), "name");
-            MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { Expression.Constant(Assembly.GetEntryAssembly()), nameParam });
+            MethodCallExpression methodCall = Expression.Call(null, method, new Expression[] { Expression.Constant(typeof(Log4NetLogProvider).GetTypeInfo().Assembly), nameParam });
             return Expression.Lambda<Func<string, object>>(methodCall, new[] { nameParam }).Compile();
         }
 

--- a/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
+++ b/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
@@ -51,7 +51,7 @@ namespace Hangfire.Logging
         /// <remarks>
         /// Note to implementers: the message func should not be called if the loglevel is not enabled
         /// so as not to incur performance penalties.
-        ///
+        /// 
         /// To check IsEnabled call Log with only LogLevel and check the return value, no event will be written
         /// </remarks>
         bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null);
@@ -1030,7 +1030,7 @@ namespace Hangfire.Logging.LogProviders
             ParameterExpression destructureObjectsParam = Expression.Parameter(typeof(bool), "destructureObjects");
             MethodCallExpression methodCall = Expression.Call(null, method, new Expression[]
             {
-                propertyNameParam,
+                propertyNameParam, 
                 valueParam,
                 destructureObjectsParam
             });
@@ -1098,7 +1098,7 @@ namespace Hangfire.Logging.LogProviders
                 MethodInfo writeExceptionMethodInfo = loggerType.GetRuntimeMethod("Write", new[]
                 {
                     logEventTypeType,
-                    typeof(Exception),
+                    typeof(Exception), 
                     typeof(string),
                     typeof(object[])
                 });
@@ -1286,7 +1286,7 @@ namespace Hangfire.Logging.LogProviders
 
             MethodInfo method = logManagerType.GetMethod("Write", new[]
                                                                   {
-                                                                      logMessageSeverityType, typeof(string), typeof(int), typeof(Exception), typeof(bool),
+                                                                      logMessageSeverityType, typeof(string), typeof(int), typeof(Exception), typeof(bool), 
                                                                       logWriteModeType, typeof(string), typeof(string), typeof(string), typeof(string), typeof(object[])
                                                                   });
 


### PR DESCRIPTION
follow up PR for fix for log4net for dotnet standard #1096

GetLogger(string name) no longer exists in log4net dotnet core. Use GetLogger(Assembly assembly, string name) as fallback

fixes #1095
