### PR TITLE
Use custom lock in SqlConnection.SetRangeInHash to prevent deadlocks

### DIFF
--- a/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerConnectionFacts.cs
@@ -903,6 +903,21 @@ values (@key, 0.0, @value)";
         }
 
         [Fact, CleanDatabase]
+        public void SetRangeInHash_ReleasesTheAcquiredLock()
+        {
+            UseConnections((sql, connection) =>
+            {
+                connection.SetRangeInHash("some-hash", new Dictionary<string, string>
+                {
+                    { "Key", "Value" }
+                });
+
+                var result = sql.QuerySingle<string>($"select APPLOCK_MODE( 'public' , 'HangFire:Hash:Lock' , 'Session' )");
+                Assert.Equal("NoLock", result);
+            });
+        }
+
+        [Fact, CleanDatabase]
         public void GetAllEntriesFromHash_ThrowsAnException_WhenKeyIsNull()
         {
             UseConnection(connection =>


### PR DESCRIPTION
There are a lot of indexes in the Hash table, and the clustered one is simply based on an incremental id. Without using a lock as in transactions, sooner or later this method will cause a deadlock. Without
using a lock as in transactions, sooner or later this method will cause a deadlock.

In 1.7.0 and later it would be possible to get rid of custom locks, because clustered keys were changed to better organize table's physical structure and remove almost all of the secondary indexes (via #898). But manual sorting would be required. But currently, custom locking is the only option.

Fixes #1124