### PR TITLE
Don't render arguments whose size is too big in dashboard

### DIFF
--- a/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobMethodCallRenderer.cs
@@ -29,6 +29,8 @@ namespace Hangfire.Dashboard
 {
     internal static class JobMethodCallRenderer
     {
+        private const int MaxArgumentToRenderSize = 4096;
+
         public static NonEscapedString Render(Job job)
         {
             if (job == null) { return new NonEscapedString("<em>Can not find the target method.</em>"); }
@@ -96,8 +98,15 @@ namespace Hangfire.Dashboard
 #pragma warning disable 618
                 if (i < job.Arguments.Length)
                 {
-                    var argument = job.Arguments[i]; // TODO: check bounds
+                    var argument = job.Arguments[i];
 #pragma warning restore 618
+
+                    if (argument.Length > MaxArgumentToRenderSize)
+                    {
+                        renderedArguments.Add(Encode("<VALUE IS TOO BIG>"));
+                        continue;
+                    }
+
                     string renderedArgument;
 
                     var enumerableArgument = GetIEnumerableGenericArgument(parameter.ParameterType);


### PR DESCRIPTION
Too big job arguments may cause dashboard to fail with the `OutOfMemoryException`, because there are many manipulations with strings here. Despite it's not recommended to have big arguments (it's better to save the data somewhere else and use identifiers instead), we shouldn't cause the whole process to die when one is using them.

Fixes #1051