### PR TITLE
enable fast scheduler wakeup

### DIFF
--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -162,7 +162,7 @@ namespace Hangfire
                 processes.Add(new Worker(_options.Queues, performer, stateChanger));
             }
             
-            processes.Add(new DelayedJobScheduler(_options.SchedulePollingInterval, stateChanger));
+            processes.Add(new DelayedJobScheduler(_options.SchedulePollingInterval,_options.SchedulerNotificationEvent, stateChanger));
             processes.Add(new RecurringJobScheduler(factory));
 
             return processes;

--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -1,5 +1,5 @@
 // This file is part of Hangfire.
-// Copyright © 2013-2014 Sergey Odinokov.
+// Copyright ï¿½ 2013-2014 Sergey Odinokov.
 // 
 // Hangfire is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as 
@@ -19,6 +19,7 @@ using Hangfire.Annotations;
 using Hangfire.Common;
 using Hangfire.Server;
 using Hangfire.States;
+using System.Threading;
 
 namespace Hangfire
 {
@@ -74,6 +75,7 @@ namespace Hangfire
         public TimeSpan HeartbeatInterval { get; set; }
         public TimeSpan ServerTimeout { get; set; }
         public TimeSpan ServerCheckInterval { get; set; }
+        public AutoResetEvent SchedulerNotificationEvent;
 
         [Obsolete("Please use `ServerTimeout` or `ServerCheckInterval` options instead. Will be removed in 2.0.0.")]
         public ServerWatchdogOptions ServerWatchdogOptions { get; set; }


### PR DESCRIPTION
The polling delay on the scheduler is done in a different way from the queue poll delay. This means that the scheduler wait cannot be preempted by an event (the queue wait is in the storage plugin so the implementer can wake up anyway they like)

The change allows the hoster to provide an event that the scheduler should wait on