### PR TITLE
Prevent recurring jobs dashboard from throwing null exception.

### DIFF
--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -92,7 +92,7 @@ namespace Hangfire.Storage
 
                 if (hash.ContainsKey("NextExecution"))
                 {
-                    dto.NextExecution = JobHelper.DeserializeDateTime(hash["NextExecution"]);
+                    dto.NextExecution = JobHelper.DeserializeNullableDateTime(hash["NextExecution"]);
                 }
 
                 if (hash.ContainsKey("LastJobId") && !string.IsNullOrWhiteSpace(hash["LastJobId"]))
@@ -113,7 +113,7 @@ namespace Hangfire.Storage
 
                 if (hash.ContainsKey("LastExecution"))
                 {
-                    dto.LastExecution = JobHelper.DeserializeDateTime(hash["LastExecution"]);
+                    dto.LastExecution = JobHelper.DeserializeNullableDateTime(hash["LastExecution"]);
                 }
 
                 if (hash.ContainsKey("TimeZoneId"))
@@ -123,7 +123,7 @@ namespace Hangfire.Storage
 
                 if (hash.ContainsKey("CreatedAt"))
                 {
-                    dto.CreatedAt = JobHelper.DeserializeDateTime(hash["CreatedAt"]);
+                    dto.CreatedAt = JobHelper.DeserializeNullableDateTime(hash["CreatedAt"]);
                 }
 
                 result.Add(dto);

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -128,7 +128,6 @@ namespace Hangfire.Storage
 
                 result.Add(dto);
             }
-
             return result;
         }
     }

--- a/tests/Hangfire.Core.Tests/Storage/StorageConnectionExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/StorageConnectionExtensionsFacts.cs
@@ -44,5 +44,26 @@ namespace Hangfire.Core.Tests.Storage
                 "job:some-id:state-lock",
                 timeout));
         }
-    }
+
+	    [Fact]
+	    public void GetRecurringJobsWithNullDateTimeHashValues() 
+		{
+			_connection.Setup(o => o.GetAllItemsFromSet(It.IsAny<string>())).Returns(new HashSet<string> { "1" });
+		    _connection.Setup(o => o.GetAllEntriesFromHash("recurring-job:1")).Returns(new Dictionary<string, string>
+		    {
+			    { "Cron", "A"},
+			    { "Job", @"{""Type"":""ConsoleApplication1.CommandHandler, ConsoleApplication1"",""Method"":""Handle"",""ParameterTypes"":""[\""string\""]"",""Arguments"":""[\""Text\""]""}"},
+				{ "NextExecution", null },
+			    { "LastExecution", null },
+			    { "CreatedAt", null }
+		    }).Verifiable();
+
+			var result = _connection.Object.GetRecurringJobs();
+			Assert.Null(result[0].LastExecution);
+			Assert.Null(result[0].NextExecution);
+			Assert.Null(result[0].CreatedAt);
+			_connection.VerifyAll();
+		}
+
+	}
 }


### PR DESCRIPTION
Changing the `GetRecurringJobs` to use the `DeserializeNullableDateTime` method when deserializing nullable dates `NextExecution`, `LastExecution`, and `CreatedAt`.

These properties are nullable `DateTime` types and the `DeserializeDateTime` method was throwing errors when a null value was being provided.  Using the null safe method that wraps around `DeserializeDateTime`.

Fixes #1199 