### PR TITLE
Avoid using the CancellationToken.WaitHandle property

### DIFF
--- a/nuspecs/Hangfire.AspNetCore.nuspec
+++ b/nuspecs/Hangfire.AspNetCore.nuspec
@@ -62,7 +62,7 @@
     
     <file src="..\src\Hangfire.AspNetCore\**\*.cs" target="src" exclude="**\obj*\**\*.cs" />
 
-    <file src="LICENSE" />
+    <file src="LICENSE.md" />
     <file src="NOTICES" />
     <file src="COPYING" />
     <file src="COPYING.LESSER" />

--- a/nuspecs/Hangfire.Core.nuspec
+++ b/nuspecs/Hangfire.Core.nuspec
@@ -175,7 +175,7 @@
     
     <file src="..\src\Hangfire.Core\**\*.cs;..\src\Hangfire.Core\**\*.cshtml" target="src" exclude="**\obj*\**\*.cs" />
 
-    <file src="LICENSE" />
+    <file src="LICENSE.md" />
     <file src="NOTICES" />
     <file src="COPYING" />
     <file src="COPYING.LESSER" />

--- a/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
+++ b/nuspecs/Hangfire.SqlServer.MSMQ.nuspec
@@ -43,7 +43,7 @@
     <file src="net45\Hangfire.SqlServer.Msmq.xml" target="lib\net45" />
     <file src="net45\Hangfire.SqlServer.Msmq.pdb" target="lib\net45" />
     <file src="..\src\Hangfire.SqlServer.Msmq\**\*.cs" target="src" exclude="**\obj*\**\*.cs" />
-    <file src="LICENSE" />
+    <file src="LICENSE.md" />
     <file src="NOTICES" />
     <file src="COPYING" />
     <file src="COPYING.LESSER" />

--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -122,7 +122,7 @@
     <file src="Tools\DefaultInstall.sql" target="tools\install.sql" />
     <file src="..\src\Hangfire.SqlServer\**\*.cs" target="src" exclude="**\obj*\**\*.cs" />
 
-    <file src="LICENSE" />
+    <file src="LICENSE.md" />
     <file src="NOTICES" />
     <file src="COPYING" />
     <file src="COPYING.LESSER" />

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -44,7 +44,7 @@ Task Collect -Depends Merge -Description "Copy all artifacts to the build folder
     Collect-Localizations "Hangfire.Core" "net45"
     Collect-Localizations "Hangfire.Core" "netstandard1.3"
 
-    Collect-File "LICENSE"
+    Collect-File "LICENSE.md"
     Collect-File "NOTICES"
     Collect-File "COPYING.LESSER"
     Collect-File "COPYING"

--- a/src/Hangfire.Core/Common/CancellationTokenExtentions.cs
+++ b/src/Hangfire.Core/Common/CancellationTokenExtentions.cs
@@ -1,0 +1,83 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2018 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading;
+
+namespace Hangfire.Common
+{
+    public static class CancellationTokenExtentions
+    {
+        /// <summary>
+        /// Returns a class that contains a <see cref="EventWaitHandle"/> that is set, when
+        /// the given <paramref name="cancellationToken"/> is canceled. This method is based
+        /// on cancellation token registration and avoids using the <see cref="CancellationToken.WaitHandle"/>
+        /// property as it may lead to high CPU issues.
+        /// </summary>
+        public static CancellationEvent GetCancellationEvent(this CancellationToken cancellationToken)
+        {
+            return new CancellationEvent(cancellationToken);
+        }
+
+        /// <summary>
+        /// Performs a wait until the specified <paramref name="timeout"/> is elapsed or the
+        /// given cancellation token is canceled. The wait is performed on a dedicated event
+        /// wait handle to avoid using the <see cref="CancellationToken.WaitHandle"/> property
+        /// that may lead to high CPU issues.
+        /// </summary>
+        public static bool Wait(this CancellationToken cancellationToken, TimeSpan timeout)
+        {
+            using (var cancellationEvent = GetCancellationEvent(cancellationToken))
+            {
+                return cancellationEvent.WaitHandle.WaitOne(timeout);
+            }
+        }
+
+        public class CancellationEvent : IDisposable
+        {
+            private readonly ManualResetEvent _mre;
+            private CancellationTokenRegistration _registration;
+
+            public CancellationEvent(CancellationToken cancellationToken)
+            {
+                _mre = new ManualResetEvent(false);
+                _registration = cancellationToken.Register(SetEvent, _mre);
+            }
+
+            public EventWaitHandle WaitHandle => _mre;
+
+            public void Dispose()
+            {
+                _registration.Dispose();
+                _mre.Dispose();
+            }
+
+            private static void SetEvent(object state)
+            {
+                try
+                {
+                    ((ManualResetEvent)state).Set();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // When our event instance is already disposed, we already
+                    // aren't interested in any notifications. This statement
+                    // is just to ensure we don't throw any exceptions.
+                }
+            }
+        }
+    }
+}

--- a/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.NetStandard.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Client\IClientExceptionFilter.cs" />
     <Compile Include="Client\IClientFilter.cs" />
     <Compile Include="Common\CachedExpressionCompiler.cs" />
+    <Compile Include="Common\CancellationTokenExtentions.cs" />
     <Compile Include="Common\ExpressionUtil\BinaryExpressionFingerprint.cs" />
     <Compile Include="Common\ExpressionUtil\CachedExpressionCompiler.cs" />
     <Compile Include="Common\ExpressionUtil\ConditionalExpressionFingerprint.cs" />

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -78,6 +78,7 @@
     <Compile Include="BackgroundJobServer.cs" />
     <Compile Include="BackgroundJobServerOptions.cs" />
     <Compile Include="Client\CoreBackgroundJobFactory.cs" />
+    <Compile Include="Common\CancellationTokenExtentions.cs" />
     <Compile Include="Common\MethodInfoExtensions.cs" />
     <Compile Include="Dashboard\Content\resx\Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Hangfire.Core/Server/BackgroundProcessContext.cs
+++ b/src/Hangfire.Core/Server/BackgroundProcessContext.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Hangfire.Annotations;
+using Hangfire.Common;
 
 namespace Hangfire.Server
 {
@@ -54,7 +55,7 @@ namespace Hangfire.Server
 
         public void Wait(TimeSpan timeout)
         {
-            CancellationToken.WaitHandle.WaitOne(timeout);
+            CancellationToken.Wait(timeout);
         }
     }
 }

--- a/src/Hangfire.Core/Server/EveryMinuteThrottler.cs
+++ b/src/Hangfire.Core/Server/EveryMinuteThrottler.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using Hangfire.Common;
 
 namespace Hangfire.Server
 {
@@ -36,7 +37,7 @@ namespace Hangfire.Server
 
         private static void WaitASecondOrThrowIfCanceled(CancellationToken token)
         {
-            token.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+            token.Wait(TimeSpan.FromSeconds(1));
             token.ThrowIfCancellationRequested();
         }
     }

--- a/src/Hangfire.SqlServer/CountersAggregator.cs
+++ b/src/Hangfire.SqlServer/CountersAggregator.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Threading;
 using Dapper;
+using Hangfire.Common;
 using Hangfire.Logging;
 using Hangfire.Server;
 
@@ -63,7 +64,7 @@ namespace Hangfire.SqlServer
 
                 if (removedCount >= NumberOfRecordsInSinglePass)
                 {
-                    cancellationToken.WaitHandle.WaitOne(DelayBetweenPasses);
+                    cancellationToken.Wait(DelayBetweenPasses);
                     cancellationToken.ThrowIfCancellationRequested();
                 }
                 // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
@@ -71,7 +72,7 @@ namespace Hangfire.SqlServer
 
             Logger.Trace("Records from the 'Counter' table aggregated.");
 
-            cancellationToken.WaitHandle.WaitOne(_interval);
+            cancellationToken.Wait(_interval);
         }
 
         public override string ToString()

--- a/src/Hangfire.SqlServer/ExpirationManager.cs
+++ b/src/Hangfire.SqlServer/ExpirationManager.cs
@@ -18,6 +18,7 @@ using System;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Threading;
+using Hangfire.Common;
 using Hangfire.Logging;
 using Hangfire.Server;
 using Hangfire.Storage;
@@ -85,7 +86,7 @@ namespace Hangfire.SqlServer
                 Logger.Trace($"Outdated records removed from the '{table}' table.");
             }
 
-            cancellationToken.WaitHandle.WaitOne(_checkInterval);
+            cancellationToken.Wait(_checkInterval);
         }
 
         public override string ToString()

--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Threading;
 using Dapper;
 using Hangfire.Annotations;
+using Hangfire.Common;
 using Hangfire.Storage;
 
 // ReSharper disable RedundantAnonymousTypePropertyName
@@ -95,31 +96,34 @@ from [{_storage.SchemaName}].JobQueue JQ with (readpast, updlock, rowlock, force
 where Queue in @queues and
 (FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))";
 
-            do
+            using (var cancellationEvent = cancellationToken.GetCancellationEvent())
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                _storage.UseConnection(null, connection =>
+                do
                 {
-                    fetchedJob = connection
-                        .Query<FetchedJob>(
-                            fetchJobSqlTemplate,
-                            new { queues = queues, timeout = _options.SlidingInvisibilityTimeout.Value.Negate().TotalSeconds })
-                        .SingleOrDefault();
-                });
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                if (fetchedJob != null)
-                {
-                    return new SqlServerTimeoutJob(
-                        _storage,
-                        fetchedJob.Id,
-                        fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
-                        fetchedJob.Queue);
-                }
+                    _storage.UseConnection(null, connection =>
+                    {
+                        fetchedJob = connection
+                            .Query<FetchedJob>(
+                                fetchJobSqlTemplate,
+                                new { queues = queues, timeout = _options.SlidingInvisibilityTimeout.Value.Negate().TotalSeconds })
+                            .SingleOrDefault();
+                    });
 
-                WaitHandle.WaitAny(new[] { cancellationToken.WaitHandle, NewItemInQueueEvent }, _options.QueuePollInterval);
-                cancellationToken.ThrowIfCancellationRequested();
-            } while (true);
+                    if (fetchedJob != null)
+                    {
+                        return new SqlServerTimeoutJob(
+                            _storage,
+                            fetchedJob.Id,
+                            fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
+                            fetchedJob.Queue);
+                    }
+
+                    WaitHandle.WaitAny(new WaitHandle[] { cancellationEvent.WaitHandle, NewItemInQueueEvent }, _options.QueuePollInterval);
+                    cancellationToken.ThrowIfCancellationRequested();
+                } while (true);
+            }
         }
 
         private SqlServerTransactionJob DequeueUsingTransaction(string[] queues, CancellationToken cancellationToken)
@@ -133,47 +137,50 @@ output DELETED.Id, DELETED.JobId, DELETED.Queue
 from [{_storage.SchemaName}].JobQueue JQ with (readpast, updlock, rowlock, forceseek)
 where Queue in @queues and (FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))";
 
-            do
+            using (var cancellationEvent = cancellationToken.GetCancellationEvent())
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var connection = _storage.CreateAndOpenConnection();
-
-                try
+                do
                 {
-                    transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var connection = _storage.CreateAndOpenConnection();
 
-                    fetchedJob = connection.Query<FetchedJob>(
-                        fetchJobSqlTemplate,
+                    try
+                    {
+                        transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);
+
+                        fetchedJob = connection.Query<FetchedJob>(
+                            fetchJobSqlTemplate,
 #pragma warning disable 618
                         new { queues = queues, timeout = _options.InvisibilityTimeout.Negate().TotalSeconds },
 #pragma warning restore 618
                         transaction,
-                        commandTimeout: _storage.CommandTimeout).SingleOrDefault();
+                            commandTimeout: _storage.CommandTimeout).SingleOrDefault();
 
-                    if (fetchedJob != null)
-                    {
-                        return new SqlServerTransactionJob(
-                            _storage,
-                            connection,
-                            transaction,
-                            fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
-                            fetchedJob.Queue);
+                        if (fetchedJob != null)
+                        {
+                            return new SqlServerTransactionJob(
+                                _storage,
+                                connection,
+                                transaction,
+                                fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
+                                fetchedJob.Queue);
+                        }
                     }
-                }
-                finally
-                {
-                    if (fetchedJob == null)
+                    finally
                     {
-                        transaction?.Dispose();
-                        transaction = null;
+                        if (fetchedJob == null)
+                        {
+                            transaction?.Dispose();
+                            transaction = null;
 
-                        _storage.ReleaseConnection(connection);
+                            _storage.ReleaseConnection(connection);
+                        }
                     }
-                }
 
-                WaitHandle.WaitAny(new[] { cancellationToken.WaitHandle, NewItemInQueueEvent }, _options.QueuePollInterval);
-                cancellationToken.ThrowIfCancellationRequested();
-            } while (true);
+                    WaitHandle.WaitAny(new WaitHandle[] { cancellationEvent.WaitHandle, NewItemInQueueEvent }, _options.QueuePollInterval);
+                    cancellationToken.ThrowIfCancellationRequested();
+                } while (true);
+            }
         }
 
         [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/tests/Hangfire.Core.Tests/Common/CancellationTokenExtentionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/CancellationTokenExtentionsFacts.cs
@@ -27,7 +27,7 @@ namespace Hangfire.Core.Tests.Common
             stopwatch.Stop();
 
             Assert.False(result);
-            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(999), $"Elapsed: {stopwatch.Elapsed}");
+            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(900), $"Elapsed: {stopwatch.Elapsed}");
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Hangfire.Core.Tests.Common
             stopwatch.Stop();
 
             Assert.True(result);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(999), $"Elapsed: {stopwatch.Elapsed}");
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(900), $"Elapsed: {stopwatch.Elapsed}");
         }
     }
 }

--- a/tests/Hangfire.Core.Tests/Common/CancellationTokenExtentionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Common/CancellationTokenExtentionsFacts.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using Hangfire.Common;
+using Xunit;
+
+namespace Hangfire.Core.Tests.Common
+{
+    public class CancellationTokenExtentionsFacts
+    {
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+        [Fact]
+        public void GetCancellationEvent_ReturnsSomething()
+        {
+            var cancellationEvent = _cts.Token.GetCancellationEvent();
+
+            Assert.NotNull(cancellationEvent);
+            Assert.NotNull(cancellationEvent.WaitHandle);
+        }
+
+        [Fact]
+        public void Wait_PerformsWait_NotLessThanTheSpecifiedTime()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var result = _cts.Token.Wait(TimeSpan.FromSeconds(1));
+            stopwatch.Stop();
+
+            Assert.False(result);
+            Assert.True(stopwatch.Elapsed >= TimeSpan.FromMilliseconds(999), $"Elapsed: {stopwatch.Elapsed}");
+        }
+
+        [Fact]
+        public void Wait_DoesNotPerformWait_WhenTokenIsCanceled()
+        {
+            _cts.Cancel();
+            var stopwatch = Stopwatch.StartNew();
+            var result = _cts.Token.Wait(TimeSpan.FromSeconds(1));
+            stopwatch.Stop();
+
+            Assert.True(result);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(999), $"Elapsed: {stopwatch.Elapsed}");
+        }
+    }
+}

--- a/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
+++ b/tests/Hangfire.Core.Tests/Hangfire.Core.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Client\CreatedContextFacts.cs" />
     <Compile Include="Client\CreatingContextFacts.cs" />
     <Compile Include="Client\BackgroundJobFactoryFacts.cs" />
+    <Compile Include="Common\CancellationTokenExtentionsFacts.cs" />
     <Compile Include="Common\JobFilterCollectionFacts.cs" />
     <Compile Include="Common\JobArgumentFacts.cs" />
     <Compile Include="Common\JobFacts.cs" />


### PR DESCRIPTION
Last week I received a report regarding the high CPU spikes that appear after several hours of running Hangfire server with the following profiler trace:

![image001 3](https://user-images.githubusercontent.com/1078718/41913707-b225c802-7959-11e8-8c2f-dbb292299020.png)

As we can see, the application is busy by constantly invoking the `DateTime.Now` and `WaitHandle.WaitOne` members, and the only place in Hangfire where the `Now` property is used is the [`Throttle`](https://github.com/HangfireIO/Hangfire/blob/f8d3c6342c691663fa54b27a3ab8ac4074cbe4b2/src/Hangfire.Core/Server/EveryMinuteThrottler.cs#L24) method. And it contains both calls to `get_Now` and `WaitOne` methods as in the trace above:

```csharp
while (DateTime.Now.Second != 0)
{
    token.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
    token.ThrowIfCancellationRequested();
}
````

But how can this loop generate so many calls to the both methods? When cancellation token isn't canceled, it will wait for one second before the next attempt. If it is canceled, then an exception will be thrown and the whole background job server will go down.

Even more, if we change the call to the `WaitOne` method with one of the following methods, then high CPU issue will disappear:

```csharp
Task.Delay(TimeSpan.FromSeconds(1), token).Wait(token);
```

```csharp
// or this one
using (mre = new ManualResetEvent(false))
using (token.Register(() => mre.Set()))
{
    mre.WaitOne(TimeSpan.FromSeconds(1));
    token.ThrowIfCancellationRequested();
}
```

But if we try to use the following method, the problem appears again:

```csharp
if (token.WaitHandle.WaitOne(TimeSpan.FromSeconds(1)))
{
    throw new OperationCanceledException(token);
}
```

The problem appears when using .NET Framework 4.7 on the wide range of OS, including Windows 10, Windows Server 2012 and Windows Server 2016 and hardware, so likely relate to a bug in .NET itself. Looking at the source code of .NET's BCL I see the `CancellationToken.WaitHandle` property is used only in the `BlockingCollection` class, so it's very unpopular.

Did someone else face with such an issue?