### PR TITLE
Change all static logger fields to be instance-based

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -82,7 +82,7 @@ namespace Hangfire
         /// </remarks>
         public static readonly int DefaultRetryAttempts = 10;
 
-        private static readonly ILog Logger = LogProvider.For<AutomaticRetryAttribute>();
+        private readonly ILog _logger = LogProvider.For<AutomaticRetryAttribute>();
         
         private readonly object _lockObject = new object();
         private int _attempts;
@@ -166,7 +166,7 @@ namespace Hangfire
             {
                 if (LogEvents)
                 {
-                    Logger.ErrorException(
+                    _logger.ErrorException(
                         $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred.",
                         failedState.Exception);
                 }
@@ -219,7 +219,7 @@ namespace Hangfire
 
             if (LogEvents)
             {
-                Logger.WarnException(
+                _logger.WarnException(
                     $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred. Retry attempt {retryAttempt} of {Attempts} will be performed in {delay}.",
                     failedState.Exception);
             }
@@ -241,7 +241,7 @@ namespace Hangfire
 
             if (LogEvents)
             {
-                Logger.WarnException(
+                _logger.WarnException(
                     $"Failed to process the job '{context.BackgroundJob.Id}': an exception occured. Job was automatically deleted because the retry attempt count exceeded {Attempts}.",
                     failedState.Exception);
             }

--- a/src/Hangfire.Core/BackgroundJobServer.cs
+++ b/src/Hangfire.Core/BackgroundJobServer.cs
@@ -29,7 +29,7 @@ namespace Hangfire
 {
     public class BackgroundJobServer : IDisposable
     {
-        private static readonly ILog Logger = LogProvider.For<BackgroundJobServer>();
+        private readonly ILog _logger = LogProvider.For<BackgroundJobServer>();
 
         private readonly BackgroundJobServerOptions _options;
         private readonly BackgroundProcessingServer _processingServer;
@@ -114,16 +114,16 @@ namespace Hangfire
                 { "WorkerCount", options.WorkerCount }
             };
 
-            Logger.Info("Starting Hangfire Server");
-            Logger.Info($"Using job storage: '{storage}'");
+            _logger.Info("Starting Hangfire Server");
+            _logger.Info($"Using job storage: '{storage}'");
 
-            storage.WriteOptionsToLog(Logger);
+            storage.WriteOptionsToLog(_logger);
 
-            Logger.Info("Using the following options for Hangfire Server:");
-            Logger.Info($"    Worker count: {options.WorkerCount}");
-            Logger.Info($"    Listening queues: {String.Join(", ", options.Queues.Select(x => "'" + x + "'"))}");
-            Logger.Info($"    Shutdown timeout: {options.ShutdownTimeout}");
-            Logger.Info($"    Schedule polling interval: {options.SchedulePollingInterval}");
+            _logger.Info("Using the following options for Hangfire Server:");
+            _logger.Info($"    Worker count: {options.WorkerCount}");
+            _logger.Info($"    Listening queues: {String.Join(", ", options.Queues.Select(x => "'" + x + "'"))}");
+            _logger.Info($"    Shutdown timeout: {options.ShutdownTimeout}");
+            _logger.Info($"    Schedule polling interval: {options.SchedulePollingInterval}");
             
             _processingServer = new BackgroundProcessingServer(
                 storage, 
@@ -134,14 +134,14 @@ namespace Hangfire
 
         public void SendStop()
         {
-            Logger.Debug("Hangfire Server is stopping...");
+            _logger.Debug("Hangfire Server is stopping...");
             _processingServer.SendStop();
         }
 
         public void Dispose()
         {
             _processingServer.Dispose();
-            Logger.Info("Hangfire Server stopped.");
+            _logger.Info("Hangfire Server stopped.");
         }
 
         private IEnumerable<IBackgroundProcess> GetRequiredProcesses(

--- a/src/Hangfire.Core/ContinuationsSupportAttribute.cs
+++ b/src/Hangfire.Core/ContinuationsSupportAttribute.cs
@@ -149,7 +149,7 @@ namespace Hangfire
             {
                 if (String.IsNullOrWhiteSpace(continuation.JobId)) continue;
 
-                var currentState = GetContinuaionState(context, continuation.JobId, ContinuationStateFetchTimeout);
+                var currentState = GetContinuationState(context, continuation.JobId, ContinuationStateFetchTimeout);
                 if (currentState == null)
                 {
                     continue;
@@ -203,7 +203,7 @@ namespace Hangfire
             }
         }
 
-        private static StateData GetContinuaionState(ElectStateContext context, string continuationJobId, TimeSpan timeout)
+        private StateData GetContinuationState(ElectStateContext context, string continuationJobId, TimeSpan timeout)
         {
             StateData currentState = null;
 

--- a/src/Hangfire.Core/ContinuationsSupportAttribute.cs
+++ b/src/Hangfire.Core/ContinuationsSupportAttribute.cs
@@ -32,7 +32,7 @@ namespace Hangfire
         private static readonly TimeSpan ContinuationStateFetchTimeout = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan ContinuationInvalidTimeout = TimeSpan.FromMinutes(15);
 
-        private static readonly ILog Logger = LogProvider.For<ContinuationsSupportAttribute>();
+        private readonly ILog _logger = LogProvider.For<ContinuationsSupportAttribute>();
 
         private readonly HashSet<string> _knownFinalStates;
         private readonly IBackgroundJobStateChanger _stateChanger;
@@ -215,7 +215,7 @@ namespace Hangfire
                 var continuationData = context.Connection.GetJobData(continuationJobId);
                 if (continuationData == null)
                 {
-                    Logger.Warn(
+                    _logger.Warn(
                         $"Can not start continuation '{continuationJobId}' for background job '{context.BackgroundJob.Id}': continuation does not exist.");
 
                     break;
@@ -229,7 +229,7 @@ namespace Hangfire
 
                 if (DateTime.UtcNow - continuationData.CreatedAt > ContinuationInvalidTimeout)
                 {
-                    Logger.Warn(
+                    _logger.Warn(
                         $"Continuation '{continuationJobId}' has been ignored: it was deemed to be aborted, because its state is still non-initialized.");
 
                     break;

--- a/src/Hangfire.Core/LatencyTimeoutAttribute.cs
+++ b/src/Hangfire.Core/LatencyTimeoutAttribute.cs
@@ -13,7 +13,7 @@ namespace Hangfire
     /// </summary>
     public sealed class LatencyTimeoutAttribute : JobFilterAttribute, IElectStateFilter
     {
-        private static readonly ILog Logger = LogProvider.For<LatencyTimeoutAttribute>();
+        private readonly ILog _logger = LogProvider.For<LatencyTimeoutAttribute>();
 
         private readonly int _timeoutInSeconds;
         
@@ -63,7 +63,7 @@ namespace Hangfire
                     Reason = $"Background job has exceeded latency timeout of {_timeoutInSeconds} second(s)"
                 };
 
-                Logger.Log(
+                _logger.Log(
                     LogLevel,
                     () => $"Background job '{context.BackgroundJob.Id}' has exceeded latency timeout of {_timeoutInSeconds} second(s) and will be deleted");
             }

--- a/src/Hangfire.Core/Server/BackgroundProcessingServer.cs
+++ b/src/Hangfire.Core/Server/BackgroundProcessingServer.cs
@@ -44,7 +44,7 @@ namespace Hangfire.Server
     public sealed class BackgroundProcessingServer : IBackgroundProcess, IDisposable
     {
         public static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(15);
-        private static readonly ILog Logger = LogProvider.For<BackgroundProcessingServer>();
+        private readonly ILog _logger = LogProvider.For<BackgroundProcessingServer>();
 
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 #pragma warning disable 618
@@ -128,7 +128,7 @@ namespace Hangfire.Server
 
             if (!_bootstrapTask.Wait(_options.ShutdownTimeout))
             {
-                Logger.Warn("Processing server takes too long to shutdown. Performing ungraceful shutdown.");
+                _logger.Warn("Processing server takes too long to shutdown. Performing ungraceful shutdown.");
             }
         }
 

--- a/src/Hangfire.Core/Server/DelayedJobScheduler.cs
+++ b/src/Hangfire.Core/Server/DelayedJobScheduler.cs
@@ -68,9 +68,9 @@ namespace Hangfire.Server
         /// The value of this field is <c>TimeSpan.FromSeconds(15)</c>.
         /// </remarks>
         public static readonly TimeSpan DefaultPollingDelay = TimeSpan.FromSeconds(15);
-
-        private static readonly ILog Logger = LogProvider.For<DelayedJobScheduler>();
         private static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromMinutes(1);
+
+        private readonly ILog _logger = LogProvider.For<DelayedJobScheduler>();
 
         private readonly IBackgroundJobStateChanger _stateChanger;
         private readonly TimeSpan _pollingDelay;
@@ -130,7 +130,7 @@ namespace Hangfire.Server
 
             if (jobsEnqueued != 0)
             {
-                Logger.Info($"{jobsEnqueued} scheduled job(s) enqueued.");
+                _logger.Info($"{jobsEnqueued} scheduled job(s) enqueued.");
             }
 
             context.Wait(_pollingDelay);
@@ -195,7 +195,7 @@ namespace Hangfire.Server
             {
                 // DistributedLockTimeoutException here doesn't mean that delayed jobs weren't enqueued.
                 // It just means another Hangfire server did this work.
-                Logger.DebugException(
+                _logger.DebugException(
                     $@"An exception was thrown during acquiring distributed lock on the {resource} resource within {DefaultLockTimeout.TotalSeconds} seconds. The scheduled jobs have not been handled this time.
 It will be retried in {_pollingDelay.TotalSeconds} seconds", 
                     e);

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -66,8 +66,8 @@ namespace Hangfire.Server
     public class RecurringJobScheduler : IBackgroundProcess
     {
         private static readonly TimeSpan LockTimeout = TimeSpan.FromMinutes(1);
-        private static readonly ILog Logger = LogProvider.For<RecurringJobScheduler>();
-        
+
+        private readonly ILog _logger = LogProvider.For<RecurringJobScheduler>();
         private readonly IBackgroundJobFactory _factory;
         private readonly Func<CrontabSchedule, TimeZoneInfo, IScheduleInstant> _instantFactory;
         private readonly IThrottler _throttler;
@@ -134,7 +134,7 @@ namespace Hangfire.Server
                     }
                     catch (JobLoadException ex)
                     {
-                        Logger.WarnException(
+                        _logger.WarnException(
                             $"Recurring job '{recurringJobId}' can not be scheduled due to job load exception.",
                             ex);
                     }
@@ -190,7 +190,7 @@ namespace Hangfire.Server
 
                     if (String.IsNullOrEmpty(jobId))
                     {
-                        Logger.Debug($"Recurring job '{recurringJobId}' execution at '{nowInstant.NowInstant}' has been canceled.");
+                        _logger.Debug($"Recurring job '{recurringJobId}' execution at '{nowInstant.NowInstant}' has been canceled.");
                     }
 
                     changedFields.Add("LastExecution", JobHelper.SerializeDateTime(nowInstant.NowInstant));
@@ -219,7 +219,7 @@ namespace Hangfire.Server
                 if (!ex.GetType().Name.Equals("TimeZoneNotFoundException")) throw;
 #endif
 
-                Logger.ErrorException(
+                _logger.ErrorException(
                     $"Recurring job '{recurringJobId}' was not triggered: {ex.Message}.",
                     ex);
             }
@@ -241,7 +241,7 @@ namespace Hangfire.Server
             {
                 // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
                 // It just means another Hangfire server did this work.
-                Logger.Log(
+                _logger.Log(
                     LogLevel.Debug,
                     () => $@"An exception was thrown during acquiring distributed lock the {resource} resource within {LockTimeout.TotalSeconds} seconds. The recurring jobs have not been handled this time.",
                     e);

--- a/src/Hangfire.Core/Server/ServerWatchdog.cs
+++ b/src/Hangfire.Core/Server/ServerWatchdog.cs
@@ -24,7 +24,7 @@ namespace Hangfire.Server
         public static readonly TimeSpan DefaultCheckInterval = TimeSpan.FromMinutes(5);
         public static readonly TimeSpan DefaultServerTimeout = TimeSpan.FromMinutes(5);
 
-        private static readonly ILog Logger = LogProvider.For<ServerWatchdog>();
+        private readonly ILog _logger = LogProvider.For<ServerWatchdog>();
 
         private readonly TimeSpan _checkInterval;
         private readonly TimeSpan _serverTimeout;
@@ -42,7 +42,7 @@ namespace Hangfire.Server
                 var serversRemoved = connection.RemoveTimedOutServers(_serverTimeout);
                 if (serversRemoved != 0)
                 {
-                    Logger.Info($"{serversRemoved} servers were removed due to timeout");
+                    _logger.Info($"{serversRemoved} servers were removed due to timeout");
                 }
             }
 

--- a/src/Hangfire.Core/Server/Worker.cs
+++ b/src/Hangfire.Core/Server/Worker.cs
@@ -208,7 +208,7 @@ namespace Hangfire.Server
                 cancellationToken));
         }
 
-        private static void Requeue(IFetchedJob fetchedJob)
+        private void Requeue(IFetchedJob fetchedJob)
         {
             try
             {

--- a/src/Hangfire.Core/Server/Worker.cs
+++ b/src/Hangfire.Core/Server/Worker.cs
@@ -43,7 +43,7 @@ namespace Hangfire.Server
         private static readonly TimeSpan JobInitializationWaitTimeout = TimeSpan.FromMinutes(1);
         private static readonly int MaxStateChangeAttempts = 10;
 
-        private static readonly ILog Logger = LogProvider.For<Worker>();
+        private readonly ILog _logger = LogProvider.For<Worker>();
 
         private readonly string _workerId;
         private readonly string[] _queues;
@@ -143,13 +143,13 @@ namespace Hangfire.Server
                 {
                     if (context.IsShutdownRequested)
                     {
-                        Logger.Info(String.Format(
+                        _logger.Info(String.Format(
                             "Shutdown request requested while processing background job '{0}'. It will be re-queued.",
                             fetchedJob.JobId));
                     }
                     else
                     {
-                        Logger.ErrorException("An exception occurred while processing a job. It will be re-queued.", ex);
+                        _logger.ErrorException("An exception occurred while processing a job. It will be re-queued.", ex);
                     }
 
                     Requeue(fetchedJob);
@@ -188,7 +188,7 @@ namespace Hangfire.Server
                 }
                 catch (Exception ex)
                 {
-                    Logger.DebugException(
+                    _logger.DebugException(
                         String.Format("State change attempt {0} of {1} failed due to an error, see inner exception for details", retryAttempt+1, MaxStateChangeAttempts), 
                         ex);
 
@@ -216,7 +216,7 @@ namespace Hangfire.Server
             }
             catch (Exception ex)
             {
-                Logger.WarnException($"Failed to immediately re-queue the background job '{fetchedJob.JobId}'. Next invocation may be delayed, if invisibility timeout is used", ex);
+                _logger.WarnException($"Failed to immediately re-queue the background job '{fetchedJob.JobId}'. Next invocation may be delayed, if invisibility timeout is used", ex);
             }
         }
 

--- a/src/Hangfire.SqlServer/CountersAggregator.cs
+++ b/src/Hangfire.SqlServer/CountersAggregator.cs
@@ -26,14 +26,13 @@ namespace Hangfire.SqlServer
     internal class CountersAggregator : IServerComponent
 #pragma warning restore 618
     {
-        private static readonly ILog Logger = LogProvider.For<CountersAggregator>();
-        
         // This number should be high enough to aggregate counters efficiently,
         // but low enough to not to cause large amount of row locks to be taken.
         // Lock escalation to page locks may pause the background processing.
         private const int NumberOfRecordsInSinglePass = 1000;
         private static readonly TimeSpan DelayBetweenPasses = TimeSpan.FromMilliseconds(500);
 
+        private readonly ILog _logger = LogProvider.For<CountersAggregator>();
         private readonly SqlServerStorage _storage;
         private readonly TimeSpan _interval;
 
@@ -47,7 +46,7 @@ namespace Hangfire.SqlServer
 
         public void Execute(CancellationToken cancellationToken)
         {
-            Logger.Debug("Aggregating records in 'Counter' table...");
+            _logger.Debug("Aggregating records in 'Counter' table...");
 
             int removedCount = 0;
 
@@ -69,7 +68,7 @@ namespace Hangfire.SqlServer
                 // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
             } while (removedCount >= NumberOfRecordsInSinglePass);
 
-            Logger.Trace("Records from the 'Counter' table aggregated.");
+            _logger.Trace("Records from the 'Counter' table aggregated.");
 
             cancellationToken.WaitHandle.WaitOne(_interval);
         }

--- a/src/Hangfire.SqlServer/ExpirationManager.cs
+++ b/src/Hangfire.SqlServer/ExpirationManager.cs
@@ -28,8 +28,6 @@ namespace Hangfire.SqlServer
     internal class ExpirationManager : IServerComponent
 #pragma warning restore 618
     {
-        private static readonly ILog Logger = LogProvider.For<ExpirationManager>();
-
         private const string DistributedLockKey = "locks:expirationmanager";
         private static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromMinutes(5);
         
@@ -49,6 +47,7 @@ namespace Hangfire.SqlServer
             "Hash",
         };
 
+        private readonly ILog _logger = LogProvider.For<ExpirationManager>();
         private readonly SqlServerStorage _storage;
         private readonly TimeSpan _checkInterval;
 
@@ -64,7 +63,7 @@ namespace Hangfire.SqlServer
         {
             foreach (var table in ProcessedTables)
             {
-                Logger.Debug($"Removing outdated records from the '{table}' table...");
+                _logger.Debug($"Removing outdated records from the '{table}' table...");
 
                 UseConnectionDistributedLock(_storage, connection =>
                 {
@@ -82,7 +81,7 @@ namespace Hangfire.SqlServer
                     } while (affected == NumberOfRecordsInSinglePass);
                 });
 
-                Logger.Trace($"Outdated records removed from the '{table}' table.");
+                _logger.Trace($"Outdated records removed from the '{table}' table.");
             }
 
             cancellationToken.WaitHandle.WaitOne(_checkInterval);
@@ -115,7 +114,7 @@ namespace Hangfire.SqlServer
             {
                 // DistributedLockTimeoutException here doesn't mean that outdated records weren't removed.
                 // It just means another Hangfire server did this work.
-                Logger.Log(
+                _logger.Log(
                     LogLevel.Debug,
                     () => $@"An exception was thrown during acquiring distributed lock on the {DistributedLockKey} resource within {DefaultLockTimeout.TotalSeconds} seconds. Outdated records were not removed.
 It will be retried in {_checkInterval.TotalSeconds} seconds.",

--- a/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
+++ b/src/Hangfire.SqlServer/SqlServerObjectsInstaller.cs
@@ -29,8 +29,6 @@ namespace Hangfire.SqlServer
         public static readonly int RequiredSchemaVersion = 5;
         private const int RetryAttempts = 3;
 
-        private static readonly ILog Log = LogProvider.GetLogger(typeof(SqlServerStorage));
-
         public static void Install(DbConnection connection)
         {
             Install(connection, null);
@@ -40,7 +38,9 @@ namespace Hangfire.SqlServer
         {
             if (connection == null) throw new ArgumentNullException(nameof(connection));
 
-            Log.Info("Start installing Hangfire SQL objects...");
+            var log = LogProvider.GetLogger(typeof(SqlServerObjectsInstaller));
+
+            log.Info("Start installing Hangfire SQL objects...");
 
             if (!IsSqlEditionSupported(connection))
             {
@@ -67,7 +67,7 @@ namespace Hangfire.SqlServer
                 {
                     if (ex.ErrorCode == 1205)
                     {
-                        Log.WarnException("Deadlock occurred during automatic migration execution. Retrying...", ex);
+                        log.WarnException("Deadlock occurred during automatic migration execution. Retrying...", ex);
                     }
                     else
                     {
@@ -79,7 +79,7 @@ namespace Hangfire.SqlServer
             connection.Execute(script, commandTimeout: 0);
 #endif
 
-            Log.Info("Hangfire SQL objects installed.");
+            log.Info("Hangfire SQL objects installed.");
         }
 
         private static bool IsSqlEditionSupported(DbConnection connection)

--- a/src/Hangfire.SqlServer/SqlServerTimeoutJob.cs
+++ b/src/Hangfire.SqlServer/SqlServerTimeoutJob.cs
@@ -9,7 +9,7 @@ namespace Hangfire.SqlServer
 {
     internal class SqlServerTimeoutJob : IFetchedJob
     {
-        private static readonly ILog Logger = LogProvider.GetLogger(typeof(SqlServerTimeoutJob));
+        private readonly ILog _logger = LogProvider.GetLogger(typeof(SqlServerTimeoutJob));
 
         private readonly object _syncRoot = new object();
         private readonly SqlServerStorage _storage;
@@ -109,11 +109,11 @@ namespace Hangfire.SqlServer
                             commandTimeout: _storage.CommandTimeout);
                     });
 
-                    Logger.Trace($"Keep-alive query for message {Id} sent");
+                    _logger.Trace($"Keep-alive query for message {Id} sent");
                 }
                 catch (Exception ex)
                 {
-                    Logger.DebugException($"Unable to execute keep-alive query for message {Id}", ex);
+                    _logger.DebugException($"Unable to execute keep-alive query for message {Id}", ex);
                 }
             }
         }


### PR DESCRIPTION
And yet another PR for the logging subsystem. This change is making logger initialization more deterministic and predictable, because it's not intuitive when a static field is initialized. Logger is now initialized when we are creating an instance of the corresponding class, and that's the expected behavior.