### PR TITLE
Allow `Type` to be passed down.

### DIFF
--- a/src/Hangfire.Core/BackgroundJob.cs
+++ b/src/Hangfire.Core/BackgroundJob.cs
@@ -75,6 +75,7 @@ namespace Hangfire
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -83,16 +84,18 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue([NotNull, InstantHandle] Expression<Action> methodCall)
+        public static string Enqueue([NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, explicitType);
         }
 
         /// <summary>
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a background job.</returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -101,10 +104,11 @@ namespace Hangfire
         /// 
         /// <seealso cref="EnqueuedState"/>
         /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
-        public static string Enqueue([NotNull, InstantHandle] Expression<Func<Task>> methodCall)
+        public static string Enqueue([NotNull, InstantHandle] Expression<Func<Task>> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Enqueue(methodCall);
+            return client.Enqueue(methodCall, explicitType);
         }
 
         /// <summary>
@@ -150,13 +154,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, explicitType);
         }
 
         /// <summary>
@@ -166,13 +172,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, delay);
+            return client.Schedule(methodCall, delay, explicitType);
         }
 
         /// <summary>
@@ -182,13 +190,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, explicitType);
         }
 
         /// <summary>
@@ -198,13 +208,15 @@ namespace Hangfire
         /// 
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string Schedule(
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.Schedule(methodCall, enqueueAt);
+            return client.Schedule(methodCall, enqueueAt, explicitType);
         }
 
         /// <summary>
@@ -340,13 +352,15 @@ namespace Hangfire
         /// </summary>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId, 
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall);
+            return client.ContinueWith(parentId, methodCall, explicitType);
         }
 
         /// <summary>
@@ -370,14 +384,16 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId, 
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options);
+            return client.ContinueWith(parentId, methodCall, options, explicitType);
         }
 
         /// <summary>
@@ -387,14 +403,16 @@ namespace Hangfire
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] Type explicitType = null)
         {
             var client = ClientFactory();
-            return client.ContinueWith(parentId, methodCall, options: options);
+            return client.ContinueWith(parentId, methodCall, options: options, explicitType: explicitType);
         }
 
         /// <summary>

--- a/src/Hangfire.Core/BackgroundJobClientExtensions.cs
+++ b/src/Hangfire.Core/BackgroundJobClientExtensions.cs
@@ -40,14 +40,16 @@ namespace Hangfire
         /// 
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue(
             [NotNull] this IBackgroundJobClient client, 
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            return client.Create(methodCall, new EnqueuedState(), explicitType);
         }
 
         /// <summary>
@@ -59,14 +61,16 @@ namespace Hangfire
         /// 
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Enqueue(
             [NotNull] this IBackgroundJobClient client,
-            [NotNull, InstantHandle] Expression<Func<Task>> methodCall)
+            [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new EnqueuedState());
+            return client.Create(methodCall, new EnqueuedState(), explicitType);
         }
 
         /// <summary>
@@ -116,15 +120,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull, InstantHandle] Expression<Action> methodCall, 
-            TimeSpan delay)
+            TimeSpan delay,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            return client.Create(methodCall, new ScheduledState(delay), explicitType);
         }
 
         /// <summary>
@@ -134,15 +140,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Instance method call expression that will be marshalled to the Server.</param>
         /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            TimeSpan delay)
+            TimeSpan delay,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(delay));
+            return client.Create(methodCall, new ScheduledState(delay), explicitType);
         }
 
         /// <summary>
@@ -152,15 +160,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment of time at which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier or a created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime), explicitType);
         }
 
         /// <summary>
@@ -170,15 +180,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to the Server.</param>
         /// <param name="enqueueAt">Moment of time at which the job will be enqueued.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier or a created job.</returns>
         public static string Schedule(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            DateTimeOffset enqueueAt)
+            DateTimeOffset enqueueAt,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+            return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime), explicitType);
         }
 
         /// <summary>
@@ -265,15 +277,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
         /// <param name="state">Initial state of a job.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Create(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            [NotNull] IState state)
+            [NotNull] IState state,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(Job.FromExpression(methodCall), state);
+            return client.Create(Job.FromExpression(methodCall, explicitType), state);
         }
 
         /// <summary>
@@ -282,15 +296,17 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="methodCall">Static method call expression that will be marshalled to the Server.</param>
         /// <param name="state">Initial state of a job.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of the created job.</returns>
         public static string Create(
             [NotNull] this IBackgroundJobClient client,
             [NotNull, InstantHandle] Expression<Func<Task>> methodCall,
-            [NotNull] IState state)
+            [NotNull] IState state,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
-            return client.Create(Job.FromExpression(methodCall), state);
+            return client.Create(Job.FromExpression(methodCall, explicitType), state);
         }
 
         /// <summary>
@@ -451,13 +467,15 @@ namespace Hangfire
         /// <param name="client">A job client instance.</param>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client, 
             [NotNull] string parentId,
-            [NotNull, InstantHandle] Expression<Action> methodCall)
+            [NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState());
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(), explicitType);
         }
 
         /// <summary>
@@ -485,14 +503,16 @@ namespace Hangfire
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="nextState">Next state for a job, when continuation is triggered. 
         /// If null, then <see cref="EnqueuedState"/> is used.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            [NotNull] IState nextState)
+            [NotNull] IState nextState,
+            [CanBeNull] Type explicitType = null)
         {
-            return ContinueWith(client, parentId, methodCall, nextState, JobContinuationOptions.OnlyOnSucceededState);
+            return ContinueWith(client, parentId, methodCall, nextState, JobContinuationOptions.OnlyOnSucceededState, explicitType);
         }
 
         /// <summary>
@@ -522,14 +542,16 @@ namespace Hangfire
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [NotNull, InstantHandle] Expression<Action> methodCall,
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] Type explicitType = null)
         {
-            return ContinueWith(client, parentId, methodCall, new EnqueuedState(), options);
+            return ContinueWith(client, parentId, methodCall, new EnqueuedState(), options, explicitType);
         }
 
         /// <summary>
@@ -558,18 +580,20 @@ namespace Hangfire
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <param name="nextState">Next state for a job, when continuation is triggered.</param>
         /// <param name="options">Continuation options.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [InstantHandle] Expression<Action> methodCall,
             [NotNull] IState nextState,
-            JobContinuationOptions options)
+            JobContinuationOptions options,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             var state = new AwaitingState(parentId, nextState, options);
-            return client.Create(Job.FromExpression(methodCall), state);
+            return client.Create(Job.FromExpression(methodCall, explicitType), state);
         }
 
         /// <summary>
@@ -582,18 +606,20 @@ namespace Hangfire
         /// If null, then <see cref="EnqueuedState"/> is used.</param>
         /// <param name="options">Continuation options. By default, 
         /// <see cref="JobContinuationOptions.OnlyOnSucceededState"/> is used.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith(
             [NotNull] this IBackgroundJobClient client,
             [NotNull] string parentId,
             [InstantHandle] Expression<Func<Task>> methodCall,
             [CanBeNull] IState nextState = null,
-            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState)
+            JobContinuationOptions options = JobContinuationOptions.OnlyOnSucceededState,
+            [CanBeNull] Type explicitType = null)
         {
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             var state = new AwaitingState(parentId, nextState ?? new EnqueuedState(), options);
-            return client.Create(Job.FromExpression(methodCall), state);
+            return client.Create(Job.FromExpression(methodCall, explicitType), state);
         }
 
         /// <summary>

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -209,7 +209,7 @@ namespace Hangfire.Common
         /// </summary>
         /// 
         /// <param name="methodCall">Expression tree of a method call.</param>
-        /// 
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// <exception cref="ArgumentNullException"><paramref name="methodCall"/> is null.</exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="methodCall"/> expression body is not of type 
@@ -231,9 +231,10 @@ namespace Hangfire.Common
         /// <b>only used to obtain the type</b> for a job. It is not
         /// serialized and not passed across the process boundaries.</note>
         /// </remarks>
-        public static Job FromExpression([NotNull, InstantHandle] Expression<Action> methodCall)
+        public static Job FromExpression([NotNull, InstantHandle] Expression<Action> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
-            return FromExpression(methodCall, null);
+            return FromExpression(methodCall, explicitType);
         }
 
         /// <summary>
@@ -242,6 +243,7 @@ namespace Hangfire.Common
         /// </summary>
         /// 
         /// <param name="methodCall">Expression tree of a method call.</param>
+        /// <param name="explicitType"><see cref="Type" /> used to invoke <paramref name="methodCall" />.</param>
         /// 
         /// <exception cref="ArgumentNullException"><paramref name="methodCall"/> is null.</exception>
         /// <exception cref="ArgumentException">
@@ -264,9 +266,10 @@ namespace Hangfire.Common
         /// <b>only used to obtain the type</b> for a job. It is not
         /// serialized and not passed across the process boundaries.</note>
         /// </remarks>
-        public static Job FromExpression([NotNull, InstantHandle] Expression<Func<Task>> methodCall)
+        public static Job FromExpression([NotNull, InstantHandle] Expression<Func<Task>> methodCall,
+            [CanBeNull] Type explicitType = null)
         {
-            return FromExpression(methodCall, null);
+            return FromExpression(methodCall, explicitType);
         }
 
         /// <summary>

--- a/src/Hangfire.Core/RecurringJob.cs
+++ b/src/Hangfire.Core/RecurringJob.cs
@@ -31,9 +31,10 @@ namespace Hangfire
             Expression<Action> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(methodCall, cronExpression(), timeZone, queue, explicitType);
         }
 
         public static void AddOrUpdate<T>(
@@ -49,9 +50,10 @@ namespace Hangfire
             Expression<Action> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            var job = Job.FromExpression(methodCall);
+            var job = Job.FromExpression(methodCall, explicitType);
             var id = GetRecurringJobId(job);
 
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
@@ -74,9 +76,10 @@ namespace Hangfire
             Expression<Action> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue, explicitType);
         }
 
         public static void AddOrUpdate<T>(
@@ -94,9 +97,10 @@ namespace Hangfire
             Expression<Action> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            var job = Job.FromExpression(methodCall);
+            var job = Job.FromExpression(methodCall, explicitType);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
@@ -115,9 +119,10 @@ namespace Hangfire
             Expression<Func<Task>> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(methodCall, cronExpression(), timeZone, queue, explicitType);
         }
 
         public static void AddOrUpdate<T>(
@@ -133,9 +138,10 @@ namespace Hangfire
             Expression<Func<Task>> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            var job = Job.FromExpression(methodCall);
+            var job = Job.FromExpression(methodCall, explicitType);
             var id = GetRecurringJobId(job);
 
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
@@ -158,9 +164,10 @@ namespace Hangfire
             Expression<Func<Task>> methodCall,
             Func<string> cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+            AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue, explicitType);
         }
 
         public static void AddOrUpdate<T>(
@@ -178,9 +185,10 @@ namespace Hangfire
             Expression<Func<Task>> methodCall,
             string cronExpression,
             TimeZoneInfo timeZone = null,
-            string queue = EnqueuedState.DefaultQueue)
+            string queue = EnqueuedState.DefaultQueue,
+            Type explicitType = null)
         {
-            var job = Job.FromExpression(methodCall);
+            var job = Job.FromExpression(methodCall, explicitType);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 


### PR DESCRIPTION
The functionality is already present, but only present for Genetics.