### PR TITLE
Feature/old school type allowance

### DIFF
--- a/src/Hangfire.Core/BackgroundJob.cs
+++ b/src/Hangfire.Core/BackgroundJob.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Hangfire.Annotations;
 using Hangfire.States;
@@ -107,6 +108,28 @@ namespace Hangfire
             return client.Enqueue(methodCall);
         }
 
+        /// <summary>Creates a new fire-and-forget job based on a given method call expression.</summary>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <returns>Unique identifier of a background job.</returns>
+        /// 
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="methodCall" /> is <see langword="null"/>.
+        /// <paramref name="parameters" /> is <see langword="null"/>.
+        /// </exception>
+        /// 
+        /// <seealso cref="EnqueuedState"/>
+        /// <seealso cref="O:Hangfire.IBackgroundJobClient.Enqueue"/>
+        public static string Enqueue(
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters)
+        {
+            var client = ClientFactory();
+            return client.Enqueue(methodCall, explicitType, parameters);
+        }
+
         /// <summary>
         /// Creates a new fire-and-forget job based on a given method call expression.
         /// </summary>
@@ -176,6 +199,26 @@ namespace Hangfire
         }
 
         /// <summary>
+        /// Creates a new background job based on a specified method
+        /// call expression and schedules it to be enqueued after a given delay.
+        /// </summary>
+        /// 
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <returns>Unique identifier of the created job.</returns>
+        public static string Schedule(
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            TimeSpan delay)
+        {
+            var client = ClientFactory();
+            return client.Schedule(methodCall, explicitType, parameters, delay);
+        }
+
+        /// <summary>
         /// Creates a new background job based on a specified method call expression
         /// and schedules it to be enqueued at the given moment of time.
         /// </summary>
@@ -205,6 +248,26 @@ namespace Hangfire
         {
             var client = ClientFactory();
             return client.Schedule(methodCall, enqueueAt);
+        }
+
+        /// <summary>
+        /// Creates a new background job based on a specified method call expression
+        /// and schedules it to be enqueued at the given moment of time.
+        /// </summary>
+        /// 
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="enqueueAt">The moment of time at which the job will be enqueued.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string Schedule(
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            DateTimeOffset enqueueAt)
+        {
+            var client = ClientFactory();
+            return client.Schedule(methodCall, explicitType, parameters, enqueueAt);
         }
 
         /// <summary>
@@ -354,6 +417,25 @@ namespace Hangfire
         /// of another background job to be enqueued.
         /// </summary>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters)
+        {
+            var client = ClientFactory();
+            return client.ContinueWith(parentId, methodCall, explicitType, parameters);
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for a successful completion 
+        /// of another background job to be enqueued.
+        /// </summary>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
@@ -378,6 +460,26 @@ namespace Hangfire
         {
             var client = ClientFactory();
             return client.ContinueWith(parentId, methodCall, options);
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for another background job to be enqueued.
+        /// </summary>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="options">Continuation options.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            JobContinuationOptions options)
+        {
+            var client = ClientFactory();
+            return client.ContinueWith(parentId, methodCall, explicitType, parameters, options);
         }
 
         /// <summary>

--- a/src/Hangfire.Core/BackgroundJobClientExtensions.cs
+++ b/src/Hangfire.Core/BackgroundJobClientExtensions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Hangfire.Annotations;
 using Hangfire.Common;
@@ -67,6 +68,29 @@ namespace Hangfire
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             return client.Create(methodCall, new EnqueuedState());
+        }
+
+        /// <summary>
+        ///     Creates a background job based on a specified <see cref="MethodInfo"/> 
+        ///     and places it into its actual queue. 
+        ///     Please, see the <see cref="QueueAttribute"/> to learn how to 
+        ///     place the job on a non-default queue.
+        /// </summary>
+        /// 
+        /// <param name="client">A job client instance.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <returns>Unique identifier of the created job.</returns>
+        public static string Enqueue(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            return client.Create(methodCall, explicitType, parameters, new EnqueuedState());
         }
 
         /// <summary>
@@ -146,6 +170,28 @@ namespace Hangfire
         }
 
         /// <summary>
+        /// Creates a new background job based on a specified lambda expression 
+        /// and schedules it to be enqueued after a given delay.
+        /// </summary>
+        /// <param name="client">A job client instance.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="delay">Delay, after which the job will be enqueued.</param>
+        /// <returns>Unique identifier of the created job.</returns>
+        public static string Schedule(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            TimeSpan delay)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            return client.Create(methodCall, explicitType, parameters, new ScheduledState(delay));
+        }
+
+        /// <summary>
         /// Creates a new background job based on a specified lambda expression
         /// and schedules it to be enqueued at the specified moment of time.
         /// </summary>
@@ -179,6 +225,29 @@ namespace Hangfire
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             return client.Create(methodCall, new ScheduledState(enqueueAt.UtcDateTime));
+        }
+
+        /// <summary>
+        ///     Creates a background job based on a specified <see cref="MethodInfo"/>
+        ///     and schedules it to be enqueued at the specified moment of time.
+        /// </summary>
+        /// 
+        /// <param name="client">A job client instance.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="enqueueAt">Moment of time at which the job will be enqueued.</param>
+        /// <returns>Unique identifier of the created job.</returns>
+        public static string Schedule(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            DateTimeOffset enqueueAt)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            return client.Create(methodCall, explicitType, parameters, new ScheduledState(enqueueAt.UtcDateTime));
         }
 
         /// <summary>
@@ -291,6 +360,29 @@ namespace Hangfire
             if (client == null) throw new ArgumentNullException(nameof(client));
 
             return client.Create(Job.FromExpression(methodCall), state);
+        }
+
+        /// <summary>
+        ///     Creates a background job based on a specified <see cref="MethodInfo"/>
+        ///     in a given state.
+        /// </summary>
+        /// 
+        /// <param name="client">A job client instance.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="state">Initial state of a job.</param>
+        /// <returns>Unique identifier of the created job.</returns>
+        public static string Create(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            [NotNull] IState state)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            return client.Create(Job.FromReflection(methodCall, explicitType, parameters), state);
         }
 
         /// <summary>
@@ -466,6 +558,26 @@ namespace Hangfire
         /// </summary>
         /// <param name="client">A job client instance.</param>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters)
+        {
+            return ContinueWith(client, parentId, methodCall, explicitType, parameters, new EnqueuedState());
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for a successful completion 
+        /// of another background job to be triggered in the <see cref="EnqueuedState"/>.
+        /// </summary>
+        /// <param name="client">A job client instance.</param>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param>
         /// <returns>Unique identifier of a created job.</returns>
         public static string ContinueWith<T>(
@@ -493,6 +605,29 @@ namespace Hangfire
             [NotNull] IState nextState)
         {
             return ContinueWith(client, parentId, methodCall, nextState, JobContinuationOptions.OnlyOnSucceededState);
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for a successful completion 
+        /// of another background job to be triggered.
+        /// </summary>
+        /// <param name="client">A job client instance.</param>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="nextState">Next state for a job, when continuation is triggered. 
+        /// If null, then <see cref="EnqueuedState"/> is used.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            [NotNull] IState nextState)
+        {
+            return ContinueWith(client, parentId, methodCall, explicitType, parameters, nextState, JobContinuationOptions.OnlyOnSucceededState);
         }
 
         /// <summary>
@@ -538,6 +673,28 @@ namespace Hangfire
         /// </summary>
         /// <param name="client">A job client instance.</param>
         /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="options">Continuation options.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            JobContinuationOptions options)
+        {
+            return ContinueWith(client, parentId, methodCall, explicitType, parameters, new EnqueuedState(), options);
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for another background job to be triggered
+        /// in the <see cref="EnqueuedState"/>.
+        /// </summary>
+        /// <param name="client">A job client instance.</param>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
         /// <param name="methodCall">Method call expression that will be marshalled to a server.</param> 
         /// <param name="options">Continuation options.</param>
         /// <returns>Unique identifier of a created job.</returns>
@@ -570,6 +727,32 @@ namespace Hangfire
 
             var state = new AwaitingState(parentId, nextState, options);
             return client.Create(Job.FromExpression(methodCall), state);
+        }
+
+        /// <summary>
+        /// Creates a new background job that will wait for another background job to be triggered.
+        /// </summary>
+        /// <param name="client">A job client instance.</param>
+        /// <param name="parentId">Identifier of a background job to wait completion for.</param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> that will be marshalled to the Server.</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="nextState">Next state for a job, when continuation is triggered.</param>
+        /// <param name="options">Continuation options.</param>
+        /// <returns>Unique identifier of a created job.</returns>
+        public static string ContinueWith(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string parentId,
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull, InstantHandle] Type explicitType,
+            [NotNull, InstantHandle] Object[] parameters,
+            [NotNull] IState nextState,
+            JobContinuationOptions options)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+
+            var state = new AwaitingState(parentId, nextState, options);
+            return client.Create(Job.FromReflection(methodCall, explicitType, parameters), state);
         }
 
         /// <summary>

--- a/src/Hangfire.Core/Common/Job.cs
+++ b/src/Hangfire.Core/Common/Job.cs
@@ -363,6 +363,33 @@ namespace Hangfire.Common
                 GetExpressionValues(callExpression.Arguments));
         }
 
+        /// <summary>
+        ///     Gets a new instance of the <see cref="Job" /> class using Reflection-based types
+        ///     given the <paramref name="methodCall" /> with explicit
+        ///     type specification.
+        /// </summary>
+        /// <param name="methodCall"><see cref="MethodInfo" /> to invoke</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <returns>The <see cref="Job" /> instance built from the parameters</returns>
+        public static Job FromReflection(
+            [NotNull, InstantHandle] MethodInfo methodCall,
+            [CanBeNull] Type explicitType,
+            [NotNull] Object[] parameters)
+        {
+            if (methodCall == null)
+                throw new ArgumentNullException(nameof(methodCall));
+
+            var type = explicitType ?? methodCall.DeclaringType;
+            var method = methodCall;
+
+            return new Job(
+                // ReSharper disable once AssignNullToNotNullAttribute
+                type,
+                method,
+                parameters);
+        }
+
         private static void Validate(
             Type type, 
             [InvokerParameterName] string typeParameterName,

--- a/src/Hangfire.Core/RecurringJob.cs
+++ b/src/Hangfire.Core/RecurringJob.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading.Tasks;
 using Hangfire.Common;
 using Hangfire.States;
@@ -45,6 +46,24 @@ namespace Hangfire
             AddOrUpdate(methodCall, cronExpression(), timeZone, queue);
         }
 
+        /// <summary>Creates or updates a described recurring <see cref="Job" /></summary>
+        /// <param name="methodCall"><see cref="MethodInfo" /> to invoke</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="cronExpression"><see cref="Func{String}" /> yielding a CRON expression for <see cref="Job" /> execution frequency</param>
+        /// <param name="timeZone"><see cref="TimeZoneInfo" /> describing the target time zone</param>
+        /// <param name="queue">Name of the queue to use for processing the <see cref="Job" /></param>
+        public static void AddOrUpdate(
+            MethodInfo methodCall,
+            Type explicitType,
+            Object[] parameters,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(methodCall, explicitType, parameters, cronExpression(), timeZone, queue);
+        }
+
         public static void AddOrUpdate(
             Expression<Action> methodCall,
             string cronExpression,
@@ -69,6 +88,27 @@ namespace Hangfire
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
+        /// <summary>Creates or updates a described recurring <see cref="Job" /></summary>
+        /// <param name="methodCall"><see cref="MethodInfo" /> to invoke</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="cronExpression">CRON expression for <see cref="Job" /> execution frequency</param>
+        /// <param name="timeZone"><see cref="TimeZoneInfo" /> describing the target time zone</param>
+        /// <param name="queue">Name of the queue to use for processing the <see cref="Job" /></param>
+        public static void AddOrUpdate(
+            MethodInfo methodCall,
+            Type explicitType,
+            Object[] parameters,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromReflection(methodCall, explicitType, parameters);
+            var id = GetRecurringJobId(job);
+
+            Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
         public static void AddOrUpdate(
             string recurringJobId,
             Expression<Action> methodCall,
@@ -87,6 +127,26 @@ namespace Hangfire
             string queue = EnqueuedState.DefaultQueue)
         {
             AddOrUpdate(recurringJobId, methodCall, cronExpression(), timeZone, queue);
+        }
+
+        /// <summary>Creates or updates a described recurring <see cref="Job" /></summary>
+        /// <param name="recurringJobId">Unique ID used to identify the recurring <see cref="Job" /></param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> to invoke</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="cronExpression"><see cref="Func{String}" /> yielding a CRON expression for <see cref="Job" /> execution frequency</param>
+        /// <param name="timeZone"><see cref="TimeZoneInfo" /> describing the target time zone</param>
+        /// <param name="queue">Name of the queue to use for processing the <see cref="Job" /></param>
+        public static void AddOrUpdate(
+            string recurringJobId,
+            MethodInfo methodCall,
+            Type explicitType,
+            Object[] parameters,
+            Func<string> cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            AddOrUpdate(recurringJobId, methodCall, explicitType, parameters, cronExpression(), timeZone, queue);
         }
 
         public static void AddOrUpdate(
@@ -108,6 +168,27 @@ namespace Hangfire
             string queue = EnqueuedState.DefaultQueue)
         {
             var job = Job.FromExpression(methodCall);
+            Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
+        }
+
+        /// <summary>Creates or updates a described recurring <see cref="Job" /></summary>
+        /// <param name="recurringJobId">Unique ID used to identify the recurring <see cref="Job" /></param>
+        /// <param name="methodCall"><see cref="MethodInfo" /> to invoke</param>
+        /// <param name="explicitType"><see cref="Type" /> to instantiate prior to invocation</param>
+        /// <param name="parameters">Parameters to pass into <paramref name="methodCall" /> when invoking it. If no parameters, must be an empty array.</param>
+        /// <param name="cronExpression">CRON expression for <see cref="Job" /> execution frequency</param>
+        /// <param name="timeZone"><see cref="TimeZoneInfo" /> describing the target time zone</param>
+        /// <param name="queue">Name of the queue to use for processing the <see cref="Job" /></param>
+        public static void AddOrUpdate(
+            string recurringJobId,
+            MethodInfo methodCall,
+            Type explicitType,
+            Object[] parameters,
+            string cronExpression,
+            TimeZoneInfo timeZone = null,
+            string queue = EnqueuedState.DefaultQueue)
+        {
+            var job = Job.FromReflection(methodCall, explicitType, parameters);
             Instance.Value.AddOrUpdate(recurringJobId, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
 
@@ -152,7 +233,7 @@ namespace Hangfire
 
             Instance.Value.AddOrUpdate(id, job, cronExpression, timeZone ?? TimeZoneInfo.Utc, queue);
         }
-        
+
         public static void AddOrUpdate(
             string recurringJobId,
             Expression<Func<Task>> methodCall,


### PR DESCRIPTION
Due to the need to serialize several Recurring Jobs simultaneously, implemented and exposed a method of Job creation based on the underlying Reflection types. It's not the cool lambdas of today, but it allows for a collection of a universal type to be passed in and jobs all registered