### PR TITLE
Support non assembly qualified name

### DIFF
--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -48,7 +48,7 @@ namespace Hangfire.Storage
         {
             get
             {
-                return Environment.GetEnvironmentVariable("Hangfire:StrictAssemblyQualifiedName", EnvironmentVariableTarget.User) == "true";
+                return Environment.GetEnvironmentVariable("Hangfire:StrictAssemblyQualifiedName") == "true";
             }
         }
 

--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -32,10 +32,24 @@ namespace Hangfire.Storage
         public InvocationData(
             string type, string method, string parameterTypes, string arguments)
         {
-            Type = type;
+            string qualifiedName = type;
+            if (!StrictAssemblyQualifiedName)
+            {
+                qualifiedName = type.Split(new string[] { ", Version=" }, StringSplitOptions.RemoveEmptyEntries)[0];
+            }
+
+            Type = qualifiedName;
             Method = method;
             ParameterTypes = parameterTypes;
             Arguments = arguments;
+        }
+
+        public static bool StrictAssemblyQualifiedName
+        {
+            get
+            {
+                return Environment.GetEnvironmentVariable("Hangfire:StrictAssemblyQualifiedName", EnvironmentVariableTarget.User) == "true";
+            }
         }
 
         public string Type { get; }


### PR DESCRIPTION
This PR resolve assembly versioning issue. Here are the steps to reproduce:

1. Register a job with any type in an assembly
2. Upgrade that assembly to new version
3. Job invocation will be result in error: cannot load assembly...

We should have an option to skip strictly on qualified name of an assembly. 