### PR TITLE
System.OutOfMemoryException at System.Type.GetType

### DIFF
--- a/src/Hangfire.Core/Storage/InvocationData.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.cs
@@ -57,7 +57,7 @@ namespace Hangfire.Storage
         {
             try
             {
-                var type = System.Type.GetType(Type, throwOnError: true, ignoreCase: true);
+                var type = System.Type.GetType(Type, throwOnError: true, ignoreCase: false);
                 var parameterTypes = JsonConvert.DeserializeObject<Type[]>(ParameterTypes, SerializerSettings);
                 var method = type.GetNonOpenMatchingMethod(Method, parameterTypes);
                 


### PR DESCRIPTION
That is a workaround for https://github.com/dotnet/coreclr/issues/20616. Since the data is serialized exactly, there is no need to be case insensitive.