### PR TITLE
Adding a check to prevent double-commit of the SqlServerTransactionJob instance.

### DIFF
--- a/src/Hangfire.Core/Server/Worker.cs
+++ b/src/Hangfire.Core/Server/Worker.cs
@@ -117,7 +117,7 @@ namespace Hangfire.Server
                     }
 
                     // Checkpoint #3. Job is in the Processing state. However, there are
-                    // no guarantees that it was performed. We need to re-queue it even
+                    // no guarantees that it was performed. We need to re-queue it even if
                     // it was performed to guarantee that it was performed AT LEAST once.
                     // It will be re-queued after the JobTimeout was expired.
 
@@ -242,7 +242,7 @@ namespace Hangfire.Server
 
                 var result = _performer.Perform(performContext);
                 duration.Stop();
-
+                
                 return new SucceededState(result, (long) latency, duration.ElapsedMilliseconds);
             }
             catch (JobAbortedException)
@@ -258,7 +258,7 @@ namespace Hangfire.Server
                 {
                     Reason = ex.Message
                 };
-            }
+            }   
             catch (Exception ex)
             {
                 if (ex is OperationCanceledException && context.IsShutdownRequested)

--- a/tests/Hangfire.SqlServer.Tests/SqlServerTransactionJobFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerTransactionJobFacts.cs
@@ -82,12 +82,26 @@ namespace Hangfire.SqlServer.Tests
         {
             // Arrange
             var processingJob = CreateFetchedJob("1", "default");
-
+            
             // Act
             processingJob.RemoveFromQueue();
 
             // Assert
             _transaction.Verify(x => x.Commit());
+        }
+
+        [Fact, CleanDatabase]
+        public void RemoveFromQueue_DisposesTheTransaction_WhenTransactionAlreadyCommitted() 
+        {
+            // Arrange
+            _transaction.Setup(x => x.Commit()).Throws(new InvalidOperationException());
+            var processingJob = CreateFetchedJob("1", "default");
+
+            // Act
+            processingJob.RemoveFromQueue();
+
+            // Assert
+            _transaction.Verify(x => x.Dispose());
         }
 
         [Fact, CleanDatabase]
@@ -101,6 +115,20 @@ namespace Hangfire.SqlServer.Tests
 
             // Assert
             _transaction.Verify(x => x.Rollback());
+        }
+
+        [Fact, CleanDatabase]
+        public void Requeue_DisposesTheTransaction_WhenTransactionAlreadyCommitted() 
+        {
+            // Arrange
+            _transaction.Setup(x => x.Rollback()).Throws(new InvalidOperationException());
+            var processingJob = CreateFetchedJob("1", "default");
+
+            // Act
+            processingJob.Requeue();
+
+            // Assert
+            _transaction.Verify(x => x.Dispose());
         }
 
         [Fact, CleanDatabase]


### PR DESCRIPTION
If `Requeue` or `RemoveFromQueue` was called on a `SqlServerTransactionJob` instance and the transaction was already committed, an exception would be thrown, as an `IDbTransaction` cannot be committed (or rolled back) after it has been committed.

I wrapped these two functions in a simple `try` `catch` that disposes the transaction if `rollback` or `commit` fails.

This fixes #1304
