### PR TITLE
Fail Appveyor build when unit tests fail

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,3 @@
 @echo off
 .nuget\NuGet.exe install .nuget\packages.config -OutputDirectory packages -Verbosity normal
-powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& {Import-Module '.\packages\psake.*\tools\psake.psm1'; invoke-psake .\psake-project.ps1 %*; if ($LastExitCode -and $LastExitCode -ne 0) {write-host "ERROR CODE: $LastExitCode" -fore RED; exit $lastexitcode} }"
+powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& {Import-Module '.\packages\psake.*\tools\psake.psm1'; invoke-psake .\psake-project.ps1 %*; if ($psake.build_success -eq $false) { write-host "ERROR, build/test failure" -fore RED;  exit 1 } else { if ($LastExitCode -and $LastExitCode -ne 0) { write-host "ERROR CODE: $LastExitCode" -fore RED; exit $lastexitcode } } }"


### PR DESCRIPTION
Changes to the build.bat script to check for failed tests in the psake script.  This should cause appveyor to fail the build (but this is untested until this PR is created).