### PR TITLE
Implement IsBatchingAvailable check as a simple property

### DIFF
--- a/src/Hangfire.Core/JobStorage.cs
+++ b/src/Hangfire.Core/JobStorage.cs
@@ -71,6 +71,8 @@ namespace Hangfire
             }
         }
 
+        public virtual bool IsBatchingAvailable => false;
+
         public abstract IMonitoringApi GetMonitoringApi();
 
         public abstract IStorageConnection GetConnection();

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -132,6 +132,8 @@ namespace Hangfire.SqlServer
         internal int? CommandBatchMaxTimeout => _options.CommandBatchMaxTimeout.HasValue ? (int)_options.CommandBatchMaxTimeout.Value.TotalSeconds : (int?)null;
         internal TimeSpan? SlidingInvisibilityTimeout => _options.SlidingInvisibilityTimeout;
 
+        public override bool IsBatchingAvailable => true;
+
         public override IMonitoringApi GetMonitoringApi()
         {
             return new SqlServerMonitoringApi(this, _options.DashboardJobListLimit);


### PR DESCRIPTION
This way we don't need expensive runtime checks and duplicate logic in `RecurringJobScheduler` / `DelayedJobScheduler`, and those storages that actually implement batching may just override it in their `JobStorage` subclasses. It's not as if any storages (except for SqlServer, and maybe Redis from HF Pro) support it right now. But it would be much harder to change it later, when this feature would gradually become adopted by 3rd-party storages.

I'm not quite sure if this should be a property of `JobStorage` though. It might seem reasonable to make it a property of `JobStorageConnection` instead, but that would require safe cast before we can actually check it.