### PR TITLE
Use serilog SourceContext naming convention

### DIFF
--- a/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
+++ b/src/Hangfire.Core/App_Packages/LibLog.1.4/LibLog.cs
@@ -1040,7 +1040,7 @@ namespace Hangfire.Logging.LogProviders
                 valueParam,
                 destructureObjectsParam
             }).Compile();
-            return name => func("Name", name, false);
+            return name => func("SourceContext", name, false);
         }
 
         internal class SerilogCallbacks


### PR DESCRIPTION
This fixes #1359.
