### PR TITLE
Fix for catching DistributedLockTimeoutException based on resource name.

### DIFF
--- a/src/Hangfire.Core/Server/DelayedJobScheduler.cs
+++ b/src/Hangfire.Core/Server/DelayedJobScheduler.cs
@@ -191,7 +191,7 @@ namespace Hangfire.Server
                     return action(connection);
                 }
             }
-            catch (DistributedLockTimeoutException e) when (e.Resource == resource)
+            catch (DistributedLockTimeoutException e) when (e.Resource.EndsWith(resource))
             {
                 // DistributedLockTimeoutException here doesn't mean that delayed jobs weren't enqueued.
                 // It just means another Hangfire server did this work.

--- a/src/Hangfire.Core/Server/RecurringJobScheduler.cs
+++ b/src/Hangfire.Core/Server/RecurringJobScheduler.cs
@@ -242,7 +242,7 @@ namespace Hangfire.Server
                     action(connection);
                 }
             }
-            catch (DistributedLockTimeoutException e) when (e.Resource == resource)
+            catch (DistributedLockTimeoutException e) when (e.Resource.EndsWith(resource))
             {
                 // DistributedLockTimeoutException here doesn't mean that recurring jobs weren't scheduled.
                 // It just means another Hangfire server did this work.


### PR DESCRIPTION
Before acquiring the lock in SqlServerConnection the resource name is modified by prepending schema name:
https://github.com/HangfireIO/Hangfire/blob/0f3d7a3ebf176c8ab90c1315b160d9d85d7cbf59/src/Hangfire.SqlServer/SqlServerConnection.cs#L63

The modified resource name is included in DistributedLockTimeoutException ctor:
https://github.com/HangfireIO/Hangfire/blob/0f3d7a3ebf176c8ab90c1315b160d9d85d7cbf59/src/Hangfire.SqlServer/SqlServerDistributedLock.cs#L218

Since the resource name doesn't match the initial one, it is missed in the scheduler try/catch:
https://github.com/HangfireIO/Hangfire/blob/0f3d7a3ebf176c8ab90c1315b160d9d85d7cbf59/src/Hangfire.Core/Server/RecurringJobScheduler.cs#L240

This sends it to AutomaticRetryProcess wrapper which causes multiple retries and log entries with different log levels:

```[14:43:04 **INF**] Error occurred during execution of 'RecurringJobScheduler' process. Execution will be retried (attempt #2) in 00:00:04 seconds.
Hangfire.Storage.DistributedLockTimeoutException: Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'HangFire:recurring-jobs:lock' resource.
   at Hangfire.SqlServer.SqlServerDistributedLock.Acquire(IDbConnection connection, String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireLock(String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireDistributedLock(String resource, TimeSpan timeout)
   at Hangfire.Server.RecurringJobScheduler.UseConnectionDistributedLock(JobStorage storage, Action``1 action)
   at Hangfire.Server.RecurringJobScheduler.Execute(BackgroundProcessContext context)
   at Hangfire.Server.AutomaticRetryProcess.Execute(BackgroundProcessContext context)
[14:45:04 **WRN**] Error occurred during execution of 'RecurringJobScheduler' process. Execution will be retried (attempt #3) in 00:00:06 seconds.
Hangfire.Storage.DistributedLockTimeoutException: Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'HangFire:recurring-jobs:lock' resource.
   at Hangfire.SqlServer.SqlServerDistributedLock.Acquire(IDbConnection connection, String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireLock(String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireDistributedLock(String resource, TimeSpan timeout)
   at Hangfire.Server.RecurringJobScheduler.UseConnectionDistributedLock(JobStorage storage, Action``1 action)
   at Hangfire.Server.RecurringJobScheduler.Execute(BackgroundProcessContext context)
   at Hangfire.Server.AutomaticRetryProcess.Execute(BackgroundProcessContext context)
[14:47:04 **ERR**] Error occurred during execution of 'RecurringJobScheduler' process. Execution will be retried (attempt #4) in 00:00:13 seconds.
Hangfire.Storage.DistributedLockTimeoutException: Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'HangFire:recurring-jobs:lock' resource.
   at Hangfire.SqlServer.SqlServerDistributedLock.Acquire(IDbConnection connection, String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireLock(String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireDistributedLock(String resource, TimeSpan timeout)
   at Hangfire.Server.RecurringJobScheduler.UseConnectionDistributedLock(JobStorage storage, Action``1 action)
   at Hangfire.Server.RecurringJobScheduler.Execute(BackgroundProcessContext context)
   at Hangfire.Server.AutomaticRetryProcess.Execute(BackgroundProcessContext context)
[14:49:04 **ERR**] Error occurred during execution of 'RecurringJobScheduler' process. Execution will be retried (attempt #5) in 00:00:21 seconds.
Hangfire.Storage.DistributedLockTimeoutException: Timeout expired. The timeout elapsed prior to obtaining a distributed lock on the 'HangFire:recurring-jobs:lock' resource.
   at Hangfire.SqlServer.SqlServerDistributedLock.Acquire(IDbConnection connection, String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireLock(String resource, TimeSpan timeout)
   at Hangfire.SqlServer.SqlServerConnection.AcquireDistributedLock(String resource, TimeSpan timeout)
   at Hangfire.Server.RecurringJobScheduler.UseConnectionDistributedLock(JobStorage storage, Action``1 action)
   at Hangfire.Server.RecurringJobScheduler.Execute(BackgroundProcessContext context)
   at Hangfire.Server.AutomaticRetryProcess.Execute(BackgroundProcessContext context)
