### PR TITLE
Add verification to job expiration check interval

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -86,7 +86,18 @@ namespace Hangfire.SqlServer
 
         public bool PrepareSchemaIfNecessary { get; set; }
 
-        public TimeSpan JobExpirationCheckInterval { get; set; }
+        public TimeSpan JobExpirationCheckInterval 
+        {
+            get { return _jobExpirationCheckInterval; } 
+            set {
+                if (value.TotalMilliseconds > int.MaxValue)
+                {
+                    throw new ArgumentOutOfRangeException("Job expiration check interval cannot be greater than int.MaxValue");
+                }
+                _jobExpirationCheckInterval = value;
+            }
+        }
+
         public TimeSpan CountersAggregateInterval { get; set; }
 
         public int? DashboardJobListLimit { get; set; }

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -27,6 +27,7 @@ namespace Hangfire.SqlServer
     {
         private TimeSpan _queuePollInterval;
         private string _schemaName;
+        private TimeSpan _jobExpirationCheckInterval;
         private TimeSpan? _slidingInvisibilityTimeout;
 
         public SqlServerStorageOptions()


### PR DESCRIPTION
If this value is over int.MaxValue then continual errors will be logged as reported in #1069. This will tell the consumer upfront that they have an issue with their settings. Verified based on the [docs for WaitOne](https://docs.microsoft.com/en-us/dotnet/api/system.threading.waithandle.waitone?view=netframework-4.7.2#System_Threading_WaitHandle_WaitOne_System_TimeSpan_).

```
Error occurred during execution of 'Hangfire.SqlServer.ExpirationManager' process. Execution will be retried (attempt #77) in 00:05:00 seconds.

System.ArgumentOutOfRangeException: Number must be either non-negative and less than or equal to Int32.MaxValue or -1.Parameter name: timeout   
at System.Threading.WaitHandle.WaitOne(TimeSpan timeout, Boolean exitContext)   at System.Threading.WaitHandle.WaitOne(TimeSpan timeout)   
at Hangfire.Common.CancellationTokenExtentions.Wait(CancellationToken cancellationToken, TimeSpan timeout)   
at Hangfire.SqlServer.ExpirationManager.Execute(CancellationToken cancellationToken)   
at Hangfire.Server.AutomaticRetryProcess.Execute(BackgroundProcessContext context)

<properties><property key='SourceContext'>Hangfire.SqlServer.ExpirationManager</property></properties>
```