### PR TITLE
Expiration Time is Hardcode

### DIFF
--- a/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
+++ b/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
@@ -74,7 +74,7 @@ namespace Hangfire.Client
                 context.Job,
                 parameters,
                 createdAt,
-                TimeSpan.FromDays(30)));
+                JobStorage.Current.JobExpirationTimeout));
 
             var backgroundJob = new BackgroundJob(jobId, context.Job, createdAt);
 

--- a/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
+++ b/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
@@ -74,7 +74,7 @@ namespace Hangfire.Client
                 context.Job,
                 parameters,
                 createdAt,
-                JobStorage.Current.JobExpirationTimeout));
+                JobStorage.Current?.JobExpirationTimeout ?? TimeSpan.FromDays(30)));
 
             var backgroundJob = new BackgroundJob(jobId, context.Job, createdAt);
 

--- a/src/Hangfire.Core/Server/ServerJobCancellationToken.cs
+++ b/src/Hangfire.Core/Server/ServerJobCancellationToken.cs
@@ -1,5 +1,5 @@
 // This file is part of Hangfire.
-// Copyright © 2013-2014 Sergey Odinokov.
+// Copyright Â© 2013-2014 Sergey Odinokov.
 // 
 // Hangfire is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as 
@@ -194,7 +194,9 @@ namespace Hangfire.Server
         {
             var state = connection.GetStateData(_jobId);
 
-            if (state == null || !state.Name.Equals(ProcessingState.StateName, StringComparison.OrdinalIgnoreCase))
+            if (state == null || 
+                (!state.Name.Equals(EnqueuedState.StateName, StringComparison.OrdinalIgnoreCase) && 
+                !state.Name.Equals(ProcessingState.StateName, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }


### PR DESCRIPTION
When using the BackgroundJobClient class to enqueue jobs the expiration time is hardcode.

Example:
![image](https://user-images.githubusercontent.com/1153361/62654991-0e896e80-b92f-11e9-8604-8b5d9b8faec0.png)

It may not be the best solution, but the idea is to be able to easily modify this time from outside the API.