### PR TITLE
Enable Net461 for Hangfire.AspNetCore

### DIFF
--- a/nuspecs/Hangfire.AspNetCore.nuspec
+++ b/nuspecs/Hangfire.AspNetCore.nuspec
@@ -56,6 +56,14 @@
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
         <dependency id="Hangfire.Core" version="[0.0.0]" />
       </group>
+      <group targetFramework="net461">
+        <dependency id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.AspNetCore.Antiforgery" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" />
+        <dependency id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" />
+        <dependency id="Hangfire.Core" version="[0.0.0]" />
+      </group>	  
     </dependencies>
   </metadata>
   <files>
@@ -70,6 +78,10 @@
     <file src="netstandard2.0\Hangfire.AspNetCore.dll" target="lib\netstandard2.0" />
     <file src="netstandard2.0\Hangfire.AspNetCore.xml" target="lib\netstandard2.0" />
     <file src="netstandard2.0\Hangfire.AspNetCore.pdb" target="lib\netstandard2.0" />
+	
+    <file src="net461\Hangfire.AspNetCore.dll" target="lib\net461" />
+    <file src="net461\Hangfire.AspNetCore.xml" target="lib\net461" />
+    <file src="net461\Hangfire.AspNetCore.pdb" target="lib\net461" />	
     
     <file src="..\src\Hangfire.AspNetCore\**\*.cs" target="src" exclude="**\obj*\**\*.cs" />
 

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -51,6 +51,8 @@ Task Collect -Depends Test -Description "Copy all artifacts to the build folder.
     Collect-Assembly "Hangfire.SqlServer" "netstandard2.0"
     Collect-Assembly "Hangfire.AspNetCore" "netstandard2.0"
     Collect-Assembly "Hangfire.NetCore" "netstandard2.0"
+	
+	Collect-Assembly "Hangfire.AspNetCore" "net461"
     
     Collect-Content "content\readme.txt"
     Collect-Tool "src\Hangfire.SqlServer\DefaultInstall.sql"

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -51,8 +51,8 @@ Task Collect -Depends Test -Description "Copy all artifacts to the build folder.
     Collect-Assembly "Hangfire.SqlServer" "netstandard2.0"
     Collect-Assembly "Hangfire.AspNetCore" "netstandard2.0"
     Collect-Assembly "Hangfire.NetCore" "netstandard2.0"
-	
-	Collect-Assembly "Hangfire.AspNetCore" "net461"
+    
+    Collect-Assembly "Hangfire.AspNetCore" "net461"
     
     Collect-Content "content\readme.txt"
     Collect-Tool "src\Hangfire.SqlServer\DefaultInstall.sql"

--- a/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
+++ b/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
@@ -1,4 +1,4 @@
-﻿#if ASPNETCORE2_AVAILABLE
+﻿#if NETSTANDARD2_0 || NET461
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
+++ b/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if ASPNETCORE2_AVAILABLE
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.3;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net451;net461;netstandard1.3;netstandard2.0;</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -8,8 +8,12 @@
     <RootNamespace>Hangfire</RootNamespace>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45' or '$(TargetFramework)'=='net461'">
     <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='netstandard2.0'">
+    <DefineConstants>ASPNETCORE2_AVAILABLE</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>
@@ -28,7 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.0" />

--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
@@ -12,10 +12,6 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='netstandard2.0'">
-    <DefineConstants>ASPNETCORE2_AVAILABLE</DefineConstants>
-  </PropertyGroup>
-  
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ using Hangfire.States;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-#if NETSTANDARD2_0
+#if ASPNETCORE2_AVAILABLE
 using Microsoft.Extensions.Hosting;
 #endif
 
@@ -121,7 +121,7 @@ namespace Hangfire
             return services;
         }
 
-#if NETSTANDARD2_0
+#if ASPNETCORE2_AVAILABLE
         public static IServiceCollection AddHangfireServer(
             [NotNull] this IServiceCollection services,
             [NotNull] Action<BackgroundJobServerOptions> optionsAction)

--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ using Hangfire.States;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-#if ASPNETCORE2_AVAILABLE
+#if NETSTANDARD2_0 || NET461
 using Microsoft.Extensions.Hosting;
 #endif
 
@@ -121,7 +121,7 @@ namespace Hangfire
             return services;
         }
 
-#if ASPNETCORE2_AVAILABLE
+#if NETSTANDARD2_0 || NET461
         public static IServiceCollection AddHangfireServer(
             [NotNull] this IServiceCollection services,
             [NotNull] Action<BackgroundJobServerOptions> optionsAction)


### PR DESCRIPTION
Adds net461 as a target framework and creates a new NuGet configuration for it. 

See #1487 for rationale. 