### PR TITLE
Return the BackgroundJobId when triggering a RecurringJob

### DIFF
--- a/src/Hangfire.Core/IRecurringJobManager.cs
+++ b/src/Hangfire.Core/IRecurringJobManager.cs
@@ -27,7 +27,7 @@ namespace Hangfire
             [NotNull] string cronExpression, 
             [NotNull] RecurringJobOptions options);
 
-        void Trigger([NotNull] string recurringJobId);
+        string Trigger([NotNull] string recurringJobId);
         void RemoveIfExists([NotNull] string recurringJobId);
     }
 }

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -134,7 +134,8 @@ namespace Hangfire
             }
         }
 
-        public void Trigger(string recurringJobId)
+        /// <returns>Unique identifier of a background job.</returns>
+        public string Trigger(string recurringJobId)
         {
             if (recurringJobId == null) throw new ArgumentNullException(nameof(recurringJobId));
 
@@ -144,7 +145,7 @@ namespace Hangfire
                 var now = _nowFactory();
 
                 var recurringJob = connection.GetRecurringJob(recurringJobId, _timeZoneResolver, now);
-                if (recurringJob == null) return;
+                if (recurringJob == null) return null;
 
                 var backgroundJob = _factory.TriggerRecurringJob(_storage, connection, EmptyProfiler.Instance, recurringJob, now);
 
@@ -169,6 +170,8 @@ namespace Hangfire
                         transaction.Commit();
                     }
                 }
+
+                return backgroundJob?.Id;
             }
         }
 


### PR DESCRIPTION
W're triggering recurring jobs programmatically and would like to use the created jobid after that. Otherwise we have to query that by hand from the database.