### PR TITLE
 _options.NonBlockingFetchSql added

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -90,7 +90,7 @@ $@"insert into [{_storage.SchemaName}].JobQueue (JobId, Queue) values (@jobId, @
             if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
 
             var lockResource = $"{_storage.SchemaName}_FetchLockLock_{String.Join("_", queues.OrderBy(x => x))}";
-            var isBlocking = false;
+            var isBlocking = _options.NonBlockingFetchSql;
 
             var pollingDelayMs = Math.Min(
                 Math.Max((int)_options.QueuePollInterval.TotalMilliseconds, MinPollingDelayMs),


### PR DESCRIPTION
I am huge fan of Hangfire I am using it for multiple environments however I found that the most resource hogger for our sql server is the sp_getapplock. Please not this server is a huge report server with many data load (importing data from the cloud), and we get the the most wait time for sp_getapplock.