### PR TITLE
I found that the most resource hogger for our sql server is the sp_getapplock.

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerJobQueue.cs
+++ b/src/Hangfire.SqlServer/SqlServerJobQueue.cs
@@ -90,7 +90,7 @@ $@"insert into [{_storage.SchemaName}].JobQueue (JobId, Queue) values (@jobId, @
             if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
 
             var lockResource = $"{_storage.SchemaName}_FetchLockLock_{String.Join("_", queues.OrderBy(x => x))}";
-            var isBlocking = false;
+            var isBlocking = _options.NonBlockingFetchSql;
 
             var pollingDelayMs = Math.Min(
                 Math.Max((int)_options.QueuePollInterval.TotalMilliseconds, MinPollingDelayMs),

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -45,6 +45,7 @@ namespace Hangfire.SqlServer
             TransactionTimeout = TimeSpan.FromMinutes(1);
             DisableGlobalLocks = false;
             UsePageLocksOnDequeue = false;
+            NonBlockingFetchSql = true;
         }
 
         [Obsolete("TransactionIsolationLevel option is deprecated, please set UseRecommendedIsolationLevel instead. Will be removed in 2.0.0.")]
@@ -122,5 +123,7 @@ namespace Hangfire.SqlServer
         public bool UsePageLocksOnDequeue { get; set; }
         public bool UseRecommendedIsolationLevel { get; set; }
         public bool EnableHeavyMigrations { get; set; }
+
+        public bool NonBlockingFetchSql { get; set; }
     }
 }


### PR DESCRIPTION
This server is a huge report server with many data load (importing data from the cloud), and we get the the most wait time is sp_getapplock.

I would recommend a new option and we can dequeue jobs without applock. WITH (ROWLOCK) for update should be enough