### PR TITLE
Improve display of job result and properties

### DIFF
--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -350,5 +350,17 @@ namespace Hangfire.Dashboard
         {
             return WebUtility.HtmlEncode(text);
         }
+
+        public string HtmlEncodePretty(string text)
+        {
+            try
+            {
+                return HtmlEncode(SerializationHelper.Deserialize<string>(text, SerializationOption.User)).Replace("\n", "<br/>");
+            }
+            catch (Exception)
+            {
+                return HtmlEncode(text);
+            }
+        }
     }
 }

--- a/src/Hangfire.Core/Dashboard/JobHistoryRenderer.cs
+++ b/src/Hangfire.Core/Dashboard/JobHistoryRenderer.cs
@@ -196,7 +196,7 @@ namespace Hangfire.Dashboard
             if (stateData.ContainsKey("Result") && !String.IsNullOrWhiteSpace(stateData["Result"]))
             {
                 var result = stateData["Result"];
-                builder.Append($"<dt>Result:</dt><dd>{html.HtmlEncode(result)}</dd>");
+                builder.Append($"<dt>Result:</dt><dd>{html.HtmlEncodePretty(result)}</dd>");
 
                 itemsAdded = true;
             }

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
@@ -1,4 +1,4 @@
-﻿@* Generator: Template TypeVisibility: Internal GeneratePrettyNames: True *@
+@* Generator: Template TypeVisibility: Internal GeneratePrettyNames: True *@
 @using System
 @using System.Collections.Generic
 @using System.Linq
@@ -101,7 +101,7 @@
                         {
                             <tr>
                                 <td class="width-15">@parameter.Key.Substring(4)</td>
-                                <td><pre><code>@parameter.Value</code></pre></td>
+                                <td><pre><code>@Html.HtmlEncodePretty(parameter.Value)</code></pre></td>
                             </tr>
                         }
                     </table>

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
@@ -400,7 +400,7 @@ WriteLiteral("</td>\r\n                                <td><pre><code>");
 
             
             #line 104 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                          Write(parameter.Value);
+                                          Write(Html.HtmlEncodePretty(parameter.Value));
 
             
             #line default


### PR DESCRIPTION
It's quite common that job properties and/or result are strings. Since everything is serialized as JSON in the database, a string becomes quoted and has escaped characters. For displaying in the dashboard, it's nicer without the quotes and escaped characters.

Before:
![Before](https://user-images.githubusercontent.com/51363/64873696-f1d90880-d649-11e9-8f32-290a4cc7b85a.png)

After:
![After](https://user-images.githubusercontent.com/51363/64873872-49777400-d64a-11e9-9d44-f43dfa47e620.png)