### PR TITLE
Adding a GetRecurringJobs method with job id filter.  

### DIFF
--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -61,6 +61,18 @@ namespace Hangfire.Storage
             return GetRecurringJobDtos(connection, ids);
         }
 
+        public static List<RecurringJobDto> GetRecurringJobs([NotNull] this IStorageConnection connection, IEnumerable<string> recurringJobIds)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (recurringJobIds == null) throw new ArgumentNullException(nameof(recurringJobIds));
+
+            var ids = connection.GetAllItemsFromSet("recurring-jobs");
+
+            ids.IntersectWith(recurringJobIds);
+
+            return GetRecurringJobDtos(connection, ids);
+        }
+
         private static List<RecurringJobDto> GetRecurringJobDtos(IStorageConnection connection, IEnumerable<string> ids)
         {
             var result = new List<RecurringJobDto>();

--- a/tests/Hangfire.Core.Tests/Storage/StorageConnectionExtensionsFacts.cs
+++ b/tests/Hangfire.Core.Tests/Storage/StorageConnectionExtensionsFacts.cs
@@ -65,5 +65,26 @@ namespace Hangfire.Core.Tests.Storage
 			_connection.VerifyAll();
 		}
 
+         [Fact]
+         public void GetRecurringJobsById()
+         {
+             var validIds = new HashSet<string> { "1", "2", "3" };
+             var recurringJobIds = new [] { "1", "2", "4" };
+
+             _connection.Setup(o => o.GetAllItemsFromSet(It.IsAny<string>())).Returns( validIds );
+             _connection.Setup(o => o.GetAllEntriesFromHash("recurring-job:1")).Returns(new Dictionary<string, string>
+             {
+                 { "Cron", "A"}
+             }).Verifiable();
+             _connection.Setup(o => o.GetAllEntriesFromHash("recurring-job:2")).Returns(new Dictionary<string, string>
+             {
+                 { "Cron", "B"}
+             }).Verifiable();
+
+             var result = _connection.Object.GetRecurringJobs(recurringJobIds);
+
+             Assert.Equal(2, result.Count);
+             _connection.VerifyAll();
+         }
 	}
 }


### PR DESCRIPTION
The current GetRecurringJobs method does not allow for filtering and will in turn return all recurring jobs. I would like to short circuit the GetRecurringJobDtos call for job id's that are not required as the payload serialization process comes at a high price.

As coded in the pull request only job ids that intersect with valid job ids will be returned.

Cheers and thanks for the indispensable library!