### PR TITLE
Add HTML tags on Dashboard title

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -41,7 +41,7 @@
                             <span class="icon-bar"></span>
                             <span class="icon-bar"></span>
                         </button>
-                        <a class="navbar-brand" href="@Url.Home()">@DashboardOptions.DashboardTitle</a>
+                        <a class="navbar-brand" href="@Url.Home()">@Html.Raw(DashboardOptions.DashboardTitle)</a>
                     </div>
                     <div class="collapse navbar-collapse">
                         @Html.RenderPartial(new Navigation())


### PR DESCRIPTION
Small improvement upon #1231 to allow HTML tags on the title of the dashboard.