### PR TITLE
add netcoreapp3.0 target for .Net Core 3 compatibility

### DIFF
--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;net461;netstandard1.3;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net451;net461;netstandard1.3;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,5 +34,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-  </ItemGroup>  
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.1" />
+  </ItemGroup>
 </Project>

--- a/src/Hangfire.AspNetCore/HangfireApplicationBuilderExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireApplicationBuilderExtensions.cs
@@ -20,7 +20,11 @@ using Hangfire.Annotations;
 using Hangfire.Dashboard;
 using Hangfire.Server;
 using Microsoft.AspNetCore.Builder;
+#if NETCOREAPP3_0
+using Microsoft.Extensions.Hosting;
+#else
 using Microsoft.AspNetCore.Hosting;
+#endif
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Hangfire.Common;
@@ -64,8 +68,11 @@ namespace Hangfire
             HangfireServiceCollectionExtensions.ThrowIfNotConfigured(app.ApplicationServices);
 
             var services = app.ApplicationServices;
+#if NETCOREAPP3_0
+            var lifetime = services.GetRequiredService<IHostApplicationLifetime>();
+#else
             var lifetime = services.GetRequiredService<IApplicationLifetime>();
-
+#endif
             storage = storage ?? services.GetRequiredService<JobStorage>();
             options = options ?? services.GetService<BackgroundJobServerOptions>() ?? new BackgroundJobServerOptions();
             additionalProcesses = additionalProcesses ?? services.GetServices<IBackgroundProcess>();


### PR DESCRIPTION
When using Hangfire from an ASP.NET Core 3.0 application, I encountered a version conflict for the 'Microsoft.Extensions.Logging.Abstractions' package. 

Please consider this PR with the following changes for .Net Core 3 compatibility:

- add netcoreapp3.0 target
- add framework reference to 'Microsoft.AspNetCore.App' 
- use 'IHostApplicationLifetime' instead of deprecated 'IApplicationLifetime'