### PR TITLE
Add MapHangfireDashboard for ASP.NET Core endpoint routing

### DIFF
--- a/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
+++ b/src/Hangfire.AspNetCore/BackgroundJobServerHostedService.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0 || NET461
+﻿#if NETCOREAPP3_0 || NETSTANDARD2_0 || NET461
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
+++ b/src/Hangfire.AspNetCore/Hangfire.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net451;net461;netstandard1.3;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net451;net461;netstandard1.3;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -34,5 +34,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-  </ItemGroup>  
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 </Project>

--- a/src/Hangfire.AspNetCore/HangfireEndpointRouteBuilderExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,53 @@
+#if NETCOREAPP3_0
+
+using Hangfire.Annotations;
+using Hangfire.Dashboard;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Hangfire
+{
+    public static class HangfireEndpointRouteBuilderExtensions
+    {
+        public static IEndpointConventionBuilder MapHangfireDashboard(
+            [NotNull] this IEndpointRouteBuilder endpoints,
+            [CanBeNull] DashboardOptions options = null,
+            [CanBeNull] JobStorage storage = null)
+        {
+            return MapHangfireDashboard(endpoints, "/hangfire", options, storage);
+        }
+
+        public static IEndpointConventionBuilder MapHangfireDashboard(
+            [NotNull] this IEndpointRouteBuilder endpoints,
+            [NotNull] string pattern,
+            [CanBeNull] DashboardOptions options = null,
+            [CanBeNull] JobStorage storage = null)
+        {
+            if (endpoints == null) throw new ArgumentNullException(nameof(endpoints));
+            if (pattern == null) throw new ArgumentNullException(nameof(pattern));
+
+            var app = endpoints.CreateApplicationBuilder();
+
+            HangfireServiceCollectionExtensions.ThrowIfNotConfigured(app.ApplicationServices);
+
+            var services = app.ApplicationServices;
+
+            storage = storage ?? services.GetRequiredService<JobStorage>();
+            options = options ?? services.GetService<DashboardOptions>() ?? new DashboardOptions();
+            options.TimeZoneResolver = options.TimeZoneResolver ?? services.GetService<ITimeZoneResolver>();
+
+            var routes = app.ApplicationServices.GetRequiredService<Dashboard.RouteCollection>();
+
+            var pipeline = app
+                .UsePathBase(pattern)
+                .UseMiddleware<AspNetCoreDashboardMiddleware>(storage, options, routes)
+                .Build();
+
+            return endpoints.Map(pattern + "/{**path}", pipeline);
+        }
+    }
+}
+
+#endif

--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ using Hangfire.States;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-#if NETSTANDARD2_0 || NET461
+#if NETCOREAPP3_0 || NETSTANDARD2_0 || NET461
 using Microsoft.Extensions.Hosting;
 #endif
 
@@ -121,7 +121,7 @@ namespace Hangfire
             return services;
         }
 
-#if NETSTANDARD2_0 || NET461
+#if NETCOREAPP3_0 || NETSTANDARD2_0 || NET461
         public static IServiceCollection AddHangfireServer(
             [NotNull] this IServiceCollection services,
             [NotNull] Action<BackgroundJobServerOptions> optionsAction)


### PR DESCRIPTION
Enables ASP.NET Core users using endpoint routing to map the
Hangfire dashboard. This includes adding netcoreapp3.0 to the
target frameworks for Hangfire.AspNetCore.

Thanks @billbogaiv for the wildcard route mapping advice.