### PR TITLE
Allow Pager.PageUrl to be overridden by a subclass

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pager.cs
+++ b/src/Hangfire.Core/Dashboard/Pager.cs
@@ -49,7 +49,7 @@ namespace Hangfire.Dashboard
 
         internal ICollection<Item> PagerItems { get; }
 
-        public string PageUrl(int page)
+        public virtual string PageUrl(int page)
         {
             if (page < 1 || page > TotalPageCount) return "#";
 


### PR DESCRIPTION
**ISSUE**
If you are customizing pages, and want to re-use the existing Paginator HtmlHelper, there is no way to specify additional query string parameters to be included in the pager URLs. This can be the case when you have custom searches or filters and you want those to persist while paging through the data.

**SOLUTION**
Make `Pager.PageUrl` `virtual`, to allow `override` capability by a subclass that maintain state of additional query string variables. After this change, it would be possible to make a custom pager like so:
```
public class CustomPager : Pager
{
    private readonly string query;

    public CustomPager(int from, int perPage, long total, string query) 
        : base(from, perPage, total)
    {
        this.query = query;
    }

    public override string PageUrl(int page)
    {
        var url = base.PageUrl(page);
        return url + "&q=" + query;
    }
}
```