### PR TITLE
default datetime comes from TimeZoneInfo

### DIFF
--- a/src/Hangfire.Core/ITimeZoneResolver.cs
+++ b/src/Hangfire.Core/ITimeZoneResolver.cs
@@ -21,15 +21,21 @@ namespace Hangfire
 {
     public sealed class DefaultTimeZoneResolver : ITimeZoneResolver
     {
+        private TimeZoneInfo _timeZoneInfo;
         public TimeZoneInfo GetTimeZoneById(string timeZoneId)
         {
-            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            _timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            return _timeZoneInfo;
         }
+
+        public TimeZoneInfo GetCurrentTimeZoneInfo() => _timeZoneInfo;
     }
 
     public interface ITimeZoneResolver
     {
         [NotNull]
         TimeZoneInfo GetTimeZoneById([NotNull] string timeZoneId);
+
+        TimeZoneInfo GetCurrentTimeZoneInfo();
     }
 }

--- a/src/Hangfire.Core/RecurringJobManager.cs
+++ b/src/Hangfire.Core/RecurringJobManager.cs
@@ -57,7 +57,7 @@ namespace Hangfire
             [NotNull] JobStorage storage, 
             [NotNull] IJobFilterProvider filterProvider,
             [NotNull] ITimeZoneResolver timeZoneResolver)
-            : this(storage, filterProvider, timeZoneResolver, () => DateTime.UtcNow)
+            : this(storage, filterProvider, timeZoneResolver, () => TimeZoneInfo.ConvertTime(DateTime.Now, timeZoneResolver.GetCurrentTimeZoneInfo()))
         {
         }
 
@@ -76,7 +76,7 @@ namespace Hangfire
         }
 
         public RecurringJobManager([NotNull] JobStorage storage, [NotNull] IBackgroundJobFactory factory, [NotNull] ITimeZoneResolver timeZoneResolver)
-            : this(storage, factory, timeZoneResolver, () => DateTime.UtcNow)
+            : this(storage, factory, timeZoneResolver, () => TimeZoneInfo.ConvertTime(DateTime.Now, timeZoneResolver.GetCurrentTimeZoneInfo()))
         {
         }
 


### PR DESCRIPTION
Hi Odin,

Your RecurringJobManager constructors works with only DateTime.UtcNow, not affected by has been sent TimeZoneInfoResolver,

For Example:
*******
new RecurringJobManager().AddOrUpdate(String.Format("{0}:{1}", schedulejob.Code, schedulejob.Id), job, schedulejob.RunTimePattern,TimeZoneInfo.Local, queuename);
*******
If developers create recurring job (shown at above), TimeZoneId updated/created succesfully however, CreatedAt and NextExecution has values updated/created with DateTime.UtcNow,

This pull request solves that issue, your constructors now able to resolve datetimeformat via ITimeZoneResolver.


