### PR TITLE
Set default treshhold for slow log logger warning to 10 minutes. Adjus…

### DIFF
--- a/src/Hangfire.Core/Profiling/SlowLogProfiler.cs
+++ b/src/Hangfire.Core/Profiling/SlowLogProfiler.cs
@@ -22,7 +22,7 @@ namespace Hangfire.Profiling
 {
     internal class SlowLogProfiler : IProfiler
     {
-        private static readonly TimeSpan DefaultThreshold = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan DefaultThreshold = TimeSpan.FromMinutes(10); // Set to high number to avoid flooding Raygun with warnings in line 60.
 
         private readonly TimeSpan _threshold;
         private readonly ILog _logger;


### PR DESCRIPTION
…t as needed, or disable the logging in line 60 if no longer required at all.