### PR TITLE
all dashboards requests will include initial query string

### DIFF
--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardRequest.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardRequest.cs
@@ -37,6 +37,8 @@ namespace Hangfire.Dashboard
         public override string PathBase => _context.Request.PathBase.Value;
         public override string LocalIpAddress => _context.Connection.LocalIpAddress.ToString();
         public override string RemoteIpAddress => _context.Connection.RemoteIpAddress.ToString();
+
+        public override string QueryString => _context.Request.QueryString.Value;
         public override string GetQuery(string key) => _context.Request.Query[key];
 
         public override async Task<IList<string>> GetFormValuesAsync(string key)

--- a/src/Hangfire.Core/Dashboard/DashboardRequest.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRequest.cs
@@ -28,7 +28,10 @@ namespace Hangfire.Dashboard
         public abstract string LocalIpAddress { get; }
         public abstract string RemoteIpAddress { get; }
 
+        public abstract string QueryString { get; }
+
         public abstract string GetQuery(string key);
+
         public abstract Task<IList<string>> GetFormValuesAsync(string key);
     }
 }

--- a/src/Hangfire.Core/Dashboard/Owin/OwinDashboardRequest.cs
+++ b/src/Hangfire.Core/Dashboard/Owin/OwinDashboardRequest.cs
@@ -38,6 +38,7 @@ namespace Hangfire.Dashboard
         public override string PathBase => _context.Request.PathBase.Value;
         public override string LocalIpAddress => _context.Request.LocalIpAddress;
         public override string RemoteIpAddress => _context.Request.RemoteIpAddress;
+        public override string QueryString => _context.Request.QueryString.ToString();
 
         public override string GetQuery(string key) => _context.Request.Query[key];
 

--- a/src/Hangfire.Core/Dashboard/UrlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/UrlHelper.cs
@@ -50,7 +50,8 @@ namespace Hangfire.Dashboard
 #endif
                        _context.Request.PathBase
                        + relativePath
-                   );
+                   )
+                + _context.Request.QueryString;
         }
 
         public string Home()


### PR DESCRIPTION
If initial query to dashboard (i.e. `/hangfire`) also provides a query string, this will be used for all links and requests within the dashboard. 

This is useful to make the dashboard accessible based on a bearer token or similar. See [this discussion](https://discuss.hangfire.io/t/using-bearer-auth-token/2166).

If the query string is empty (default case), no link / url is changed.