### PR TITLE
[Dashboard] AspNetCore 3.0+ authorization policy support via extensions

### DIFF
--- a/src/Hangfire.AspNetCore/HangfireEndpointRouteBuilderExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,5 @@
 #if NETCOREAPP3_0
-
+using System.Collections.Generic;
 using Hangfire.Annotations;
 using Hangfire.Dashboard;
 using Microsoft.AspNetCore.Builder;
@@ -46,6 +46,35 @@ namespace Hangfire
                 .Build();
 
             return endpoints.Map(pattern + "/{**path}", pipeline);
+        }
+
+        public static IEndpointConventionBuilder MapHangfireDashboardWithAuthorizationPolicy(
+            [NotNull] this IEndpointRouteBuilder endpoints,
+            [NotNull] string authorizationPolicyName,
+            [CanBeNull] DashboardOptions options = null,
+            [CanBeNull] JobStorage storage = null)
+        {
+            return MapHangfireDashboardWithAuthorizationPolicy(endpoints, authorizationPolicyName, "/hangfire", options, storage);
+        }
+
+        public static IEndpointConventionBuilder MapHangfireDashboardWithAuthorizationPolicy(
+            [NotNull] this IEndpointRouteBuilder endpoints,
+            [NotNull] string authorizationPolicyName,
+            [NotNull] string pattern,
+            [CanBeNull] DashboardOptions options = null,
+            [CanBeNull] JobStorage storage = null)
+        {
+            if (options == null)
+            {
+                options = new DashboardOptions()
+                {
+                    Authorization = new List<IDashboardAuthorizationFilter>() // We don't require the default LocalHost only filter since we provide our own policy
+                };
+            }
+
+            return endpoints
+                .MapHangfireDashboard(pattern, options, storage)
+                .RequireAuthorization(authorizationPolicyName);
         }
     }
 }


### PR DESCRIPTION
The current DashboardOptions constructor sets the `LocalRequestsOnlyAuthorizationFilter` as a default filter. When you setup your Hangfire Dashboard using the new endpoints pattern and set an authorization policy it still goes ahead and uses the default anyway. To circumvent it we need to pass an empty list to `Authorization` as shown below.

```
            app.UseEndpoints(endpoints =>
            {
                endpoints.MapControllers()
                    .RequireAuthorization();
                endpoints.MapHangfireDashboard("/dashboard/hangfire", new DashboardOptions()
                    {
                        // We need to pass an empty list or Hangfire will use a local authorization filter
                        Authorization = new List<IDashboardAuthorizationFilter>()
                    })
                    .RequireAuthorization("hangfire-specific-auth-scheme");
            });
```

The new extension method introduced in this PR supports passing an authorization policy name and removes the `LocalRequestsOnlyAuthorizationFilter` from the default if no `DashboardOptions` instance has been passed.