### PR TITLE
#7895: Hangfire Dashboard does not know job names of missing assemblies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level.
 
 # Don't edit manually! Use `build.bat version` command instead!
-version: 1.7.11-build-0{build}
+version: 1.7.12-build-0{build}
 
 os: Visual Studio 2019
 

--- a/src/Hangfire.Core/Common/TypeHelper.cs
+++ b/src/Hangfire.Core/Common/TypeHelper.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -228,5 +229,46 @@ namespace Hangfire.Common
             assembly = assembly ?? typeof(int).GetTypeInfo().Assembly;
             return assembly.GetType(typeName, true, ignoreCase);
         }
+
+        #region Text
+
+        public const string AssemblySeparator = ", ";
+        public const char NamespaceSeparator = '.';
+        public const char GenericArgumentsEnd = ']';
+        public const string GenericArgumentSeparator = ", ";
+        public const char MemberSeparator = '.';
+
+        public static void Split(string type, out string @namespace, out string name, out string assembly)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                @namespace = name = assembly = null;
+            else
+            {
+                // assembly
+                int index = type.IndexOf(GenericArgumentsEnd) + 1; // after generic arguments
+                index = type.IndexOf(AssemblySeparator, index);
+                if (index >= 0)
+                {
+                    assembly = type.Substring(index + AssemblySeparator.Length);
+                    type = type.Substring(0, index);
+                }
+                else
+                    assembly = null;
+                // namespace/name
+                index = type.LastIndexOf(NamespaceSeparator);
+                if (index >= 0)
+                {
+                    @namespace = type.Substring(0, index);
+                    name = type.Substring(index + 1);
+                }
+                else
+                {
+                    @namespace = null;
+                    name = type;
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -28,6 +28,7 @@ using System.Text.RegularExpressions;
 using Hangfire.Annotations;
 using Hangfire.Dashboard.Pages;
 using Hangfire.Dashboard.Resources;
+using Hangfire.Storage;
 
 namespace Hangfire.Dashboard
 {
@@ -126,11 +127,14 @@ namespace Hangfire.Dashboard
                 : $"#{jobId}"));
         }
 
-        public string JobName(Job job)
+        public string JobName(Job job, InvocationData invocationData)
         {
             if (job == null)
             {
-                return Strings.Common_CannotFindTargetMethod;
+                string name = invocationData?.TypeMethodName;
+                return name is null ?
+                    Strings.Common_CannotFindTargetMethod :
+                    $"({name})";
             }
 
             var jobDisplayNameAttribute = job.Method.GetCustomAttribute<JobDisplayNameAttribute>();
@@ -194,9 +198,9 @@ namespace Hangfire.Dashboard
             return Raw($"<a href=\"{HtmlEncode(_page.Url.JobDetails(jobId))}\">{JobId(jobId)}</a>");
         }
 
-        public NonEscapedString JobNameLink(string jobId, Job job)
+        public NonEscapedString JobNameLink(string jobId, Job job, InvocationData invocationData)
         {
-            return Raw($"<a class=\"job-method\" href=\"{HtmlEncode(_page.Url.JobDetails(jobId))}\">{HtmlEncode(JobName(job))}</a>");
+            return Raw($"<a class=\"job-method\" href=\"{HtmlEncode(_page.Url.JobDetails(jobId))}\">{HtmlEncode(JobName(job, invocationData))}</a>");
         }
 
         public NonEscapedString RelativeTime(DateTime value)

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
@@ -123,7 +123,7 @@
                                     else
                                     {
                                         <td class="word-break">
-                                            @Html.JobNameLink(jobId, jobData.Job)
+                                            @Html.JobNameLink(jobId, jobData.Job, jobData.InvocationData)
                                         </td>
                                         <td class="min-width">
                                             @if (stateData != null && stateData.Data.ContainsKey("Options") && !String.IsNullOrWhiteSpace(stateData.Data["Options"]))

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
@@ -494,7 +494,7 @@ WriteLiteral("                                        <td class=\"word-break\">\
 
             
             #line 126 "..\..\Dashboard\Pages\AwaitingJobsPage.cshtml"
-                                       Write(Html.JobNameLink(jobId, jobData.Job));
+                                       Write(Html.JobNameLink(jobId, jobData.Job, jobData.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml
@@ -89,7 +89,7 @@
                                     else
                                     {
                                         <td class="word-break">
-                                            @Html.JobNameLink(job.Key, job.Value.Job)
+                                            @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                         </td>
                                         <td class="align-right">
                                             @if (job.Value.DeletedAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml.cs
@@ -414,7 +414,7 @@ WriteLiteral("                                        <td class=\"word-break\">\
 
             
             #line 92 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
-                                       Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                       Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/EnqueuedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/EnqueuedJobsPage.cshtml
@@ -101,7 +101,7 @@
                                         @Html.StateLabel(job.Value.State)
                                     </td>
                                     <td class="word-break">
-                                        @Html.JobNameLink(job.Key, job.Value.Job)
+                                        @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                     </td>
                                     <td class="align-right">
                                         @if (job.Value.EnqueuedAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/EnqueuedJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/EnqueuedJobsPage.cshtml.cs
@@ -475,7 +475,7 @@ WriteLiteral("                                    <td class=\"word-break\">\r\n 
 
             
             #line 104 "..\..\Dashboard\Pages\EnqueuedJobsPage.cshtml"
-                                   Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                   Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml
@@ -108,7 +108,7 @@
                                     {
                                         <td>
                                             <div class="word-break">
-                                                @Html.JobNameLink(job.Key, job.Value.Job)
+                                                @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                             </div>
                                             @if (!String.IsNullOrEmpty(job.Value.ExceptionMessage))
                                             {

--- a/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml.cs
@@ -530,7 +530,7 @@ WriteLiteral("                                        <td>\r\n                  
 
             
             #line 111 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
-                                           Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                           Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/FetchedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/FetchedJobsPage.cshtml
@@ -110,7 +110,7 @@
                                         @Html.StateLabel(job.Value.State)
                                     </td>
                                     <td class="word-break">
-                                        @Html.JobNameLink(job.Key, job.Value.Job)
+                                        @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                     </td>
                                     <td class="align-right">
                                         @if (job.Value.FetchedAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/FetchedJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/FetchedJobsPage.cshtml.cs
@@ -495,7 +495,7 @@ WriteLiteral("                                    <td class=\"word-break\">\r\n 
 
             
             #line 113 "..\..\Dashboard\Pages\FetchedJobsPage.cshtml"
-                                   Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                   Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
@@ -14,16 +14,16 @@
 @{
     var monitor = Storage.GetMonitoringApi();
     var job = monitor.JobDetails(JobId);
-    
-    string title = null;
 
+    string title =
+        job.Job is null &&
+        job.InvocationData is null ?
+            Strings.Common_Job :
+            Html.JobName(job.Job, job.InvocationData);
     if (job != null)
     {
-        title = job.Job != null ? Html.JobName(job.Job) : null;
         job.History.Add(new StateHistoryDto { StateName = "Created", CreatedAt = job.CreatedAt ?? default(DateTime) });
     }
-
-    title = title ?? Strings.Common_Job;
     Layout = new LayoutPage(title);
 }
 
@@ -70,7 +70,7 @@
             <div class="job-snippet">
                 <div class="job-snippet-code">
                     <pre><code><span class="comment">// @Strings.JobDetailsPage_JobId: @Html.JobId(JobId.ToString(), false)</span>
-@JobMethodCallRenderer.Render(job.Job)
+@JobMethodCallRenderer.Render(job.Job, job.InvocationData)
 </code></pre>
                 </div>
 
@@ -104,39 +104,39 @@
                     <div class="table-responsive">
                         <table class="table">
                             <thead>
-                            <tr>
-                                <th class="min-width">@Strings.Common_Id</th>
-                                <th class="min-width">@Strings.Common_Condition</th>
-                                <th class="min-width">@Strings.Common_State</th>
-                                <th>@Strings.Common_Job</th>
-                                <th class="align-right">@Strings.Common_Created</th>
-                            </tr>
+                                <tr>
+                                    <th class="min-width">@Strings.Common_Id</th>
+                                    <th class="min-width">@Strings.Common_Condition</th>
+                                    <th class="min-width">@Strings.Common_State</th>
+                                    <th>@Strings.Common_Job</th>
+                                    <th class="align-right">@Strings.Common_Created</th>
+                                </tr>
                             </thead>
                             <tbody>
-                            @foreach (var continuation in continuations)
-                            {
-                                JobData jobData;
-
-                                using (var connection = Storage.GetConnection())
+                                @foreach (var continuation in continuations)
                                 {
-                                    jobData = connection.GetJobData(continuation.JobId);
-                                }
+                                    JobData jobData;
 
-                                <tr>
-                                    @if (jobData == null)
+                                    using (var connection = Storage.GetConnection())
                                     {
-                                        <td colspan="5"><em>@String.Format(Strings.JobDetailsPage_JobExpired, continuation.JobId)</em></td>
+                                        jobData = connection.GetJobData(continuation.JobId);
                                     }
-                                    else
-                                    {
-                                        <td class="min-width">@Html.JobIdLink(continuation.JobId)</td>
-                                        <td class="min-width"><code>@continuation.Options.ToString("G")</code></td>
-                                        <td class="min-width">@Html.StateLabel(jobData.State)</td>
-                                        <td class="word-break">@Html.JobNameLink(continuation.JobId, jobData.Job)</td>
-                                        <td class="align-right">@Html.RelativeTime(jobData.CreatedAt)</td>
-                                    }
-                                </tr>
-                            }
+
+                                    <tr>
+                                        @if (jobData == null)
+                                        {
+                                            <td colspan="5"><em>@String.Format(Strings.JobDetailsPage_JobExpired, continuation.JobId)</em></td>
+                                        }
+                                        else
+                                        {
+                                            <td class="min-width">@Html.JobIdLink(continuation.JobId)</td>
+                                            <td class="min-width"><code>@continuation.Options.ToString("G")</code></td>
+                                            <td class="min-width">@Html.StateLabel(jobData.State)</td>
+                                            <td class="word-break">@Html.JobNameLink(continuation.JobId, jobData.Job, jobData.InvocationData)</td>
+                                            <td class="align-right">@Html.RelativeTime(jobData.CreatedAt)</td>
+                                        }
+                                    </tr>
+                                }
                             </tbody>
                         </table>
                     </div>

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
@@ -108,16 +108,16 @@ WriteLiteral("\r\n");
   
     var monitor = Storage.GetMonitoringApi();
     var job = monitor.JobDetails(JobId);
-    
-    string title = null;
 
+    string title =
+        job.Job is null &&
+        job.InvocationData is null ?
+            Strings.Common_Job :
+            Html.JobName(job.Job, job.InvocationData);
     if (job != null)
     {
-        title = job.Job != null ? Html.JobName(job.Job) : null;
         job.History.Add(new StateHistoryDto { StateName = "Created", CreatedAt = job.CreatedAt ?? default(DateTime) });
     }
-
-    title = title ?? Strings.Common_Job;
     Layout = new LayoutPage(title);
 
 
@@ -276,7 +276,7 @@ WriteLiteral("</span>\r\n");
 
             
             #line 73 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-Write(JobMethodCallRenderer.Render(job.Job));
+Write(JobMethodCallRenderer.Render(job.Job, job.InvocationData));
 
             
             #line default
@@ -386,92 +386,92 @@ WriteLiteral("</h3>\r\n");
 
 WriteLiteral("                    <div class=\"table-responsive\">\r\n                        <tabl" +
 "e class=\"table\">\r\n                            <thead>\r\n                         " +
-"   <tr>\r\n                                <th class=\"min-width\">");
+"       <tr>\r\n                                    <th class=\"min-width\">");
 
 
             
             #line 108 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                 Write(Strings.Common_Id);
+                                                     Write(Strings.Common_Id);
 
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                                <th class=\"min-width\">");
+WriteLiteral("</th>\r\n                                    <th class=\"min-width\">");
 
 
             
             #line 109 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                 Write(Strings.Common_Condition);
+                                                     Write(Strings.Common_Condition);
 
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                                <th class=\"min-width\">");
+WriteLiteral("</th>\r\n                                    <th class=\"min-width\">");
 
 
             
             #line 110 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                 Write(Strings.Common_State);
+                                                     Write(Strings.Common_State);
 
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                                <th>");
+WriteLiteral("</th>\r\n                                    <th>");
 
 
             
             #line 111 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                               Write(Strings.Common_Job);
+                                   Write(Strings.Common_Job);
 
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                                <th class=\"align-right\">");
+WriteLiteral("</th>\r\n                                    <th class=\"align-right\">");
 
 
             
             #line 112 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                   Write(Strings.Common_Created);
+                                                       Write(Strings.Common_Created);
 
             
             #line default
             #line hidden
-WriteLiteral("</th>\r\n                            </tr>\r\n                            </thead>\r\n " +
-"                           <tbody>\r\n");
+WriteLiteral("</th>\r\n                                </tr>\r\n                            </thead" +
+">\r\n                            <tbody>\r\n");
 
 
             
             #line 116 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                             foreach (var continuation in continuations)
-                            {
-                                JobData jobData;
-
-                                using (var connection = Storage.GetConnection())
+                                 foreach (var continuation in continuations)
                                 {
-                                    jobData = connection.GetJobData(continuation.JobId);
-                                }
+                                    JobData jobData;
+
+                                    using (var connection = Storage.GetConnection())
+                                    {
+                                        jobData = connection.GetJobData(continuation.JobId);
+                                    }
 
 
             
             #line default
             #line hidden
-WriteLiteral("                                <tr>\r\n");
+WriteLiteral("                                    <tr>\r\n");
 
 
             
             #line 126 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                     if (jobData == null)
-                                    {
+                                         if (jobData == null)
+                                        {
 
             
             #line default
             #line hidden
-WriteLiteral("                                        <td colspan=\"5\"><em>");
+WriteLiteral("                                            <td colspan=\"5\"><em>");
 
 
             
             #line 128 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                       Write(String.Format(Strings.JobDetailsPage_JobExpired, continuation.JobId));
+                                                           Write(String.Format(Strings.JobDetailsPage_JobExpired, continuation.JobId));
 
             
             #line default
@@ -481,19 +481,19 @@ WriteLiteral("</em></td>\r\n");
 
             
             #line 129 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                    }
-                                    else
-                                    {
+                                        }
+                                        else
+                                        {
 
             
             #line default
             #line hidden
-WriteLiteral("                                        <td class=\"min-width\">");
+WriteLiteral("                                            <td class=\"min-width\">");
 
 
             
             #line 132 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                         Write(Html.JobIdLink(continuation.JobId));
+                                                             Write(Html.JobIdLink(continuation.JobId));
 
             
             #line default
@@ -502,12 +502,12 @@ WriteLiteral("</td>\r\n");
 
 
 
-WriteLiteral("                                        <td class=\"min-width\"><code>");
+WriteLiteral("                                            <td class=\"min-width\"><code>");
 
 
             
             #line 133 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                               Write(continuation.Options.ToString("G"));
+                                                                   Write(continuation.Options.ToString("G"));
 
             
             #line default
@@ -516,12 +516,12 @@ WriteLiteral("</code></td>\r\n");
 
 
 
-WriteLiteral("                                        <td class=\"min-width\">");
+WriteLiteral("                                            <td class=\"min-width\">");
 
 
             
             #line 134 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                         Write(Html.StateLabel(jobData.State));
+                                                             Write(Html.StateLabel(jobData.State));
 
             
             #line default
@@ -530,12 +530,12 @@ WriteLiteral("</td>\r\n");
 
 
 
-WriteLiteral("                                        <td class=\"word-break\">");
+WriteLiteral("                                            <td class=\"word-break\">");
 
 
             
             #line 135 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                          Write(Html.JobNameLink(continuation.JobId, jobData.Job));
+                                                              Write(Html.JobNameLink(continuation.JobId, jobData.Job, jobData.InvocationData));
 
             
             #line default
@@ -544,12 +544,12 @@ WriteLiteral("</td>\r\n");
 
 
 
-WriteLiteral("                                        <td class=\"align-right\">");
+WriteLiteral("                                            <td class=\"align-right\">");
 
 
             
             #line 136 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                           Write(Html.RelativeTime(jobData.CreatedAt));
+                                                               Write(Html.RelativeTime(jobData.CreatedAt));
 
             
             #line default
@@ -559,17 +559,17 @@ WriteLiteral("</td>\r\n");
 
             
             #line 137 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                    }
+                                        }
 
             
             #line default
             #line hidden
-WriteLiteral("                                </tr>\r\n");
+WriteLiteral("                                    </tr>\r\n");
 
 
             
             #line 139 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                            }
+                                }
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml
@@ -112,7 +112,7 @@
                                                 <span title="@Strings.ProcessingJobsPage_Aborted" class="glyphicon glyphicon-warning-sign" style="font-size: 10px;"></span>
                                             }
 
-                                            @Html.JobNameLink(job.Key, job.Value.Job)
+                                            @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                         </td>
                                         <td class="align-right">
                                             @if (job.Value.StartedAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml.cs
@@ -544,7 +544,7 @@ WriteLiteral("\r\n                                            ");
 
             
             #line 115 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
-                                       Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                       Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/QueuesPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/QueuesPage.cshtml
@@ -93,7 +93,7 @@
                                                                 @Html.StateLabel(job.Value.State)
                                                             </td>
                                                             <td class="word-break">
-                                                                @Html.JobNameLink(job.Key, job.Value.Job)
+                                                                @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                                             </td>
                                                             <td class="align-right min-width">
                                                                 @if (job.Value.EnqueuedAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/QueuesPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/QueuesPage.cshtml.cs
@@ -456,7 +456,7 @@ WriteLiteral("                                                            <td cl
 
             
             #line 96 "..\..\Dashboard\Pages\QueuesPage.cshtml"
-                                                           Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                                           Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
@@ -182,23 +182,23 @@
                                         }
                                     </td>
                                     <td class="word-break width-30">
-                                        @if (job.Job != null)
+                                        @Html.JobName(job.Job, job.InvocationData)
+                                        @if (job.Job is null)
                                         {
-                                            @: @Html.JobName(job.Job)
+                                            var error = job.LoadException?.InnerException ??
+                                                job.LoadException;
+                                            if (error != null)
+                                            {
+                                                <br />
+                                                <em>@error.Message</em>
+                                            }
+                                            else
+                                            {
+                                                <br />
+                                                <em>@Strings.Common_NotAvailable</em>
+                                            }
                                         }
-                                        else if (job.LoadException != null && job.LoadException.InnerException != null)
-                                        {
-                                            <em>@job.LoadException.InnerException.Message</em>
-                                        }
-                                        else if (job.LoadException != null)
-                                        {
-                                            <em>@job.LoadException.Message</em>
-                                        }
-                                        else
-                                        {
-                                            <em>@Strings.Common_NotAvailable</em>
-                                        }
-                                    </td>
+                                        </td>
                                     <td class="align-right min-width">
                                         @if (!job.NextExecution.HasValue)
                                         {

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
@@ -697,25 +697,12 @@ WriteLiteral(" UTC\r\n");
             #line default
             #line hidden
 WriteLiteral("                                    </td>\r\n                                    <t" +
-"d class=\"word-break width-30\">\r\n");
+"d class=\"word-break width-30\">\r\n                                        ");
 
 
             
             #line 185 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                         if (job.Job != null)
-                                        {
-
-            
-            #line default
-            #line hidden
-WriteLiteral("                                            ");
-
-WriteLiteral(" ");
-
-
-            
-            #line 187 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                          Write(Html.JobName(job.Job));
+                                   Write(Html.JobName(job.Job, job.InvocationData));
 
             
             #line default
@@ -724,20 +711,27 @@ WriteLiteral("\r\n");
 
 
             
-            #line 188 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                        }
-                                        else if (job.LoadException != null && job.LoadException.InnerException != null)
+            #line 186 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                         if (job.Job is null)
                                         {
+                                            var error = job.LoadException?.InnerException ??
+                                                job.LoadException;
+                                            if (error != null)
+                                            {
 
             
             #line default
             #line hidden
-WriteLiteral("                                            <em>");
+WriteLiteral("                                                <br />\r\n");
+
+
+
+WriteLiteral("                                                <em>");
 
 
             
-            #line 191 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                           Write(job.LoadException.InnerException.Message);
+            #line 193 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                               Write(error.Message);
 
             
             #line default
@@ -746,58 +740,41 @@ WriteLiteral("</em>\r\n");
 
 
             
-            #line 192 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                        }
-                                        else if (job.LoadException != null)
-                                        {
+            #line 194 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                            }
+                                            else
+                                            {
 
             
             #line default
             #line hidden
-WriteLiteral("                                            <em>");
+WriteLiteral("                                                <br />\r\n");
+
+
+
+WriteLiteral("                                                <em>");
 
 
             
-            #line 195 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                           Write(job.LoadException.Message);
+            #line 198 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                               Write(Strings.Common_NotAvailable);
 
             
             #line default
             #line hidden
 WriteLiteral("</em>\r\n");
-
-
-            
-            #line 196 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                        }
-                                        else
-                                        {
-
-            
-            #line default
-            #line hidden
-WriteLiteral("                                            <em>");
 
 
             
             #line 199 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                           Write(Strings.Common_NotAvailable);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("</em>\r\n");
-
-
-            
-            #line 200 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                            }
                                         }
 
             
             #line default
             #line hidden
-WriteLiteral("                                    </td>\r\n                                    <t" +
-"d class=\"align-right min-width\">\r\n");
+WriteLiteral("                                        </td>\r\n                                  " +
+"  <td class=\"align-right min-width\">\r\n");
 
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/RetriesPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RetriesPage.cshtml
@@ -126,7 +126,7 @@ else
                                                 @Html.StateLabel(jobData.State)
                                             </td>
                                             <td class="word-break">
-                                                @Html.JobNameLink(jobId, jobData.Job)
+                                                @Html.JobNameLink(jobId, jobData.Job, jobData.InvocationData)
                                             </td>
                                             <td>
                                                 @(stateData?.Reason)

--- a/src/Hangfire.Core/Dashboard/Pages/RetriesPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/RetriesPage.cshtml.cs
@@ -520,7 +520,7 @@ WriteLiteral("                                            <td class=\"word-break
 
             
             #line 129 "..\..\Dashboard\Pages\RetriesPage.cshtml"
-                                           Write(Html.JobNameLink(jobId, jobData.Job));
+                                           Write(Html.JobNameLink(jobId, jobData.Job, jobData.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml
@@ -97,7 +97,7 @@
                                     @Html.RelativeTime(job.Value.EnqueueAt)
                                 </td>
                                 <td class="word-break">
-                                    @Html.JobNameLink(job.Key, job.Value.Job)
+                                    @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                 </td>
                                 <td class="align-right">
                                     @if (job.Value.ScheduledAt.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/ScheduledJobsPage.cshtml.cs
@@ -463,7 +463,7 @@ WriteLiteral("\r\n                                </td>\r\n                     
 
             
             #line 100 "..\..\Dashboard\Pages\ScheduledJobsPage.cshtml"
-                               Write(Html.JobNameLink(job.Key, job.Value.Job));
+                               Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml
@@ -94,7 +94,7 @@
                                     else
                                     {
                                         <td class="word-break">
-                                            @Html.JobNameLink(job.Key, job.Value.Job)
+                                            @Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData)
                                         </td>
                                         <td class="min-width align-right">
                                             @if (job.Value.TotalDuration.HasValue)

--- a/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml.cs
@@ -431,7 +431,7 @@ WriteLiteral("                                        <td class=\"word-break\">\
 
             
             #line 97 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
-                                       Write(Html.JobNameLink(job.Key, job.Value.Job));
+                                       Write(Html.JobNameLink(job.Key, job.Value.Job, job.Value.InvocationData));
 
             
             #line default

--- a/src/Hangfire.Core/Storage/InvocationData.JobPayload.cs
+++ b/src/Hangfire.Core/Storage/InvocationData.JobPayload.cs
@@ -14,19 +14,25 @@
 // You should have received a copy of the GNU Lesser General Public 
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
-using Hangfire.Common;
+using Newtonsoft.Json;
 
-namespace Hangfire.Storage.Monitoring
+namespace Hangfire.Storage
 {
-    public class JobDetailsDto
+    public partial class InvocationData
     {
-        public Job Job { get; set; }
-        public DateTime? CreatedAt { get; set; }
-        public IDictionary<string, string> Properties { get; set; }
-        public IList<StateHistoryDto> History { get; set; }
-        public DateTime? ExpireAt { get; set; }
-        public InvocationData InvocationData { get; set; }
+        private class JobPayload
+        {
+            [JsonProperty("t")]
+            public string TypeName { get; set; }
+
+            [JsonProperty("m")]
+            public string MethodName { get; set; }
+
+            [JsonProperty("p", NullValueHandling = NullValueHandling.Ignore)]
+            public string[] ParameterTypes { get; set; }
+
+            [JsonProperty("a", NullValueHandling = NullValueHandling.Ignore)]
+            public string[] Arguments { get; set; }
+        }
     }
 }

--- a/src/Hangfire.Core/Storage/JobData.cs
+++ b/src/Hangfire.Core/Storage/JobData.cs
@@ -26,6 +26,7 @@ namespace Hangfire.Storage
         public DateTime CreatedAt { get; set; }
 
         public JobLoadException LoadException { get; set; }
+        public InvocationData InvocationData { get; set; }
 
         public void EnsureLoaded()
         {

--- a/src/Hangfire.Core/Storage/Monitoring/DeletedJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/DeletedJobDto.cs
@@ -13,5 +13,6 @@ namespace Hangfire.Storage.Monitoring
         public Job Job { get; set; }
         public DateTime? DeletedAt { get; set; }
         public bool InDeletedState { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/EnqueuedJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/EnqueuedJobDto.cs
@@ -30,5 +30,6 @@ namespace Hangfire.Storage.Monitoring
         public string State { get; set; }
         public DateTime? EnqueuedAt { get; set; }
         public bool InEnqueuedState { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/FailedJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/FailedJobDto.cs
@@ -33,5 +33,6 @@ namespace Hangfire.Storage.Monitoring
         public string ExceptionMessage { get; set; }
         public string ExceptionDetails { get; set; }
         public bool InFailedState { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/FetchedJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/FetchedJobDto.cs
@@ -24,5 +24,6 @@ namespace Hangfire.Storage.Monitoring
         public Job Job { get; set; }
         public string State { get; set; }
         public DateTime? FetchedAt { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/ProcessingJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/ProcessingJobDto.cs
@@ -30,5 +30,6 @@ namespace Hangfire.Storage.Monitoring
         public bool InProcessingState { get; set; }
         public string ServerId { get; set; }
         public DateTime? StartedAt { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/ScheduledJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/ScheduledJobDto.cs
@@ -30,5 +30,6 @@ namespace Hangfire.Storage.Monitoring
         public DateTime EnqueueAt { get; set; }
         public DateTime? ScheduledAt { get; set; }
         public bool InScheduledState { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/Monitoring/SucceededJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/SucceededJobDto.cs
@@ -31,5 +31,6 @@ namespace Hangfire.Storage.Monitoring
         public long? TotalDuration { get; set; }
         public DateTime? SucceededAt { get; set; }
         public bool InSucceededState { get; set; }
+        public InvocationData InvocationData { get; set; }
     }
 }

--- a/src/Hangfire.Core/Storage/RecurringJobDto.cs
+++ b/src/Hangfire.Core/Storage/RecurringJobDto.cs
@@ -35,5 +35,6 @@ namespace Hangfire.Storage
         public string TimeZoneId { get; set; }
         public string Error { get; set; }
         public int RetryAttempt { get; set; }
+        public InvocationData InvocationData { get; internal set; }
     }
 }

--- a/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
+++ b/src/Hangfire.Core/Storage/StorageConnectionExtensions.cs
@@ -86,6 +86,7 @@ namespace Hangfire.Storage
                     {
                         var invocationData = InvocationData.DeserializePayload(payload);
                         dto.Job = invocationData.DeserializeJob();
+                        dto.InvocationData = invocationData;
                     }
                 }
                 catch (JobLoadException ex)

--- a/src/Hangfire.SqlServer/SqlServerConnection.cs
+++ b/src/Hangfire.SqlServer/SqlServerConnection.cs
@@ -208,6 +208,7 @@ $@"select InvocationData, StateName, Arguments, CreatedAt from [{_storage.Schema
                 return new JobData
                 {
                     Job = job,
+                    InvocationData = invocationData,
                     State = jobData.StateName,
                     CreatedAt = jobData.CreatedAt,
                     LoadException = loadException

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -9,4 +9,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // Don't edit manually! Use `build.bat version` command instead!
-[assembly: AssemblyVersion("1.7.11")]
+[assembly: AssemblyVersion("1.7.12")]


### PR DESCRIPTION
I have started to use Hangfire for some of our applications. Thank You for the work.
One of applications is UWP one which cannot host Hangfire Dashboard itself. So I have created Windows service Hangfire Dashboard server monitoring the application externally via shared SQLite database.
To see actions in the Dashboard instead of "Missing type etc." messages, I have augmented it to load akction information from InvocationData when Type cannot be found/loaded.
This allows me to manage jobs even without action assemblies.