### PR TITLE
Add an overload for AddHangfireServer utilizing IServiceProvider

### DIFF
--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -139,6 +139,24 @@ namespace Hangfire
 
             return services;
         }
+        
+        public static IServiceCollection AddHangfireServer(
+            [NotNull] this IServiceCollection services,
+            [NotNull] Action<IServiceProvider, BackgroundJobServerOptions> optionsAction)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (optionsAction == null) throw new ArgumentNullException(nameof(optionsAction));
+
+            services.AddTransient<IHostedService, BackgroundJobServerHostedService>(provider =>
+            {
+                var options = new BackgroundJobServerOptions();
+                optionsAction(provider, options);
+
+                return CreateBackgroundJobServerHostedService(provider, options);
+            });
+
+            return services;
+        }
 
         public static IServiceCollection AddHangfireServer([NotNull] this IServiceCollection services)
         {


### PR DESCRIPTION
This allows the configuration of `BackgroundJobServerOptions` to be based on other services, options, etc..

While there exists the workaround of registering the `BackgroundJobServerOptions` manually
```
services.AddSingleton(provider => {
var other = provider.getRequiredService<OtherOptions>();
return new BackgroundJobServerOptions
{
    Queues = new[] { "default", "misc", other.SomeQueueName},
    WorkerCount = 1,
};
});
services.AddHangfireServer();
```
This fails if one wants to register multiple HangfireServer with differing configurations (all based on some other service/options).