### PR TITLE
Support async DashboardAuthorization in AspNetCore for Hangfire 1.x

### DIFF
--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardMiddleware.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardMiddleware.cs
@@ -1,5 +1,5 @@
 // This file is part of Hangfire.
-// Copyright © 2016 Sergey Odinokov.
+// Copyright ï¿½ 2016 Sergey Odinokov.
 // 
 // Hangfire is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as 
@@ -64,11 +64,17 @@ namespace Hangfire.Dashboard
             {
                 if (!filter.Authorize(context))
                 {
-                    var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated;
+                    SetStatusCode(httpContext);
 
-                    httpContext.Response.StatusCode = isAuthenticated == true
-                        ? (int) HttpStatusCode.Forbidden
-                        : (int) HttpStatusCode.Unauthorized;
+                    return;
+                }
+            }
+
+            foreach (var filter in _options.AsyncAuthorization)
+            {
+                if (!await filter.AuthorizeAsync(context))
+                {
+                    SetStatusCode(httpContext);
 
                     return;
                 }
@@ -94,6 +100,15 @@ namespace Hangfire.Dashboard
             context.UriMatch = findResult.Item2;
 
             await findResult.Item1.Dispatch(context);
+        }
+
+        private static void SetStatusCode(HttpContext httpContext)
+        {
+            var isAuthenticated = httpContext.User?.Identity?.IsAuthenticated;
+
+            httpContext.Response.StatusCode = isAuthenticated == true
+                ? (int)HttpStatusCode.Forbidden
+                : (int)HttpStatusCode.Unauthorized;
         }
     }
 }

--- a/src/Hangfire.Core/Dashboard/IDashboardAsyncAuthorizationFilter.cs
+++ b/src/Hangfire.Core/Dashboard/IDashboardAsyncAuthorizationFilter.cs
@@ -1,0 +1,26 @@
+﻿// This file is part of Hangfire.
+// Copyright © 2016 Sergey Odinokov.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+using Hangfire.Annotations;
+
+namespace Hangfire.Dashboard
+{
+    public interface IDashboardAsyncAuthorizationFilter
+    {
+        Task<bool> AuthorizeAsync([NotNull] DashboardContext context);
+    }
+}

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -52,6 +52,7 @@ namespace Hangfire
 #endif
 
         public IEnumerable<IDashboardAuthorizationFilter> Authorization { get; set; }
+        public IEnumerable<IDashboardAsyncAuthorizationFilter> AsyncAuthorization { get; set; }
 
         public Func<DashboardContext, bool> IsReadOnlyFunc { get; set; }
         

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -28,6 +28,7 @@ namespace Hangfire
             AppPath = "/";
             PrefixPath = string.Empty;
             Authorization = new[] { new LocalRequestsOnlyAuthorizationFilter() };
+            AsyncAuthorization = new IDashboardAsyncAuthorizationFilter[0];
             IsReadOnlyFunc = _ => false;
             StatsPollingInterval = 2000;
             DisplayStorageConnectionString = true;


### PR DESCRIPTION
Safe and backwards compatible support for async dashboard authorization in when using AspNetCore dashboard middleware.
Only negative thing is that the `AsyncAuthorization` prop can even when not using AspNetCore

I'm not sure if this is intentionally not supported?