### PR TITLE
Replace deprecated PerformContext ctor usage

### DIFF
--- a/tests/Hangfire.Core.Tests/Mocks/PerformContextMock.cs
+++ b/tests/Hangfire.Core.Tests/Mocks/PerformContextMock.cs
@@ -11,14 +11,16 @@ namespace Hangfire.Core.Tests
 
         public PerformContextMock()
         {
+            Storage = new Mock<JobStorage>();
             Connection = new Mock<IStorageConnection>();
             BackgroundJob = new BackgroundJobMock();
             CancellationToken = new Mock<IJobCancellationToken>();
 
             _context = new Lazy<PerformContext>(
-                () => new PerformContext(Connection.Object, BackgroundJob.Object, CancellationToken.Object));
+                () => new PerformContext(Storage.Object, Connection.Object, BackgroundJob.Object, CancellationToken.Object));
         }
         
+        public Mock<JobStorage> Storage { get; set; }
         public Mock<IStorageConnection> Connection { get; set; }
         public BackgroundJobMock BackgroundJob { get; set; }
         public Mock<IJobCancellationToken> CancellationToken { get; set; } 


### PR DESCRIPTION
The `PerformContext(IStorageConnection, BackgroundJob, IJobCancellationToken)` constructor is deprecated, but used in the `PerformContextMock` class. Code does build and run, but throws an error when running a code validator like SonarQube.

Update code to use other ctor and add mock for `JobStorage`