### PR TITLE
Added JobId property to JobPerformanceException for error logging purposes

### DIFF
--- a/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
+++ b/src/Hangfire.Core/Obsolete/Job.Obsolete.cs
@@ -125,7 +125,7 @@ namespace Hangfire.Common
             }
             catch (TargetInvocationException ex)
             {
-                CoreBackgroundJobPerformer.HandleJobPerformanceException(ex.InnerException, cancellationToken);
+                CoreBackgroundJobPerformer.HandleJobPerformanceException(ex.InnerException, cancellationToken, null);
                 throw;
             }
         }

--- a/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/BackgroundJobPerformer.cs
@@ -140,7 +140,7 @@ namespace Hangfire.Server
             {
                 CoreBackgroundJobPerformer.HandleJobPerformanceException(
                     filterException,
-                    preContext.CancellationToken);
+                    preContext.CancellationToken, preContext.BackgroundJob);
                 throw;
             }
             
@@ -173,7 +173,7 @@ namespace Hangfire.Server
                 {
                     CoreBackgroundJobPerformer.HandleJobPerformanceException(
                         filterException,
-                        postContext.CancellationToken);
+                        postContext.CancellationToken, postContext.BackgroundJob);
 
                     throw;
                 }
@@ -197,7 +197,7 @@ namespace Hangfire.Server
                 {
                     CoreBackgroundJobPerformer.HandleJobPerformanceException(
                         filterException,
-                        postContext.CancellationToken);
+                        postContext.CancellationToken, postContext.BackgroundJob);
 
                     throw;
                 }

--- a/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
+++ b/src/Hangfire.Core/Server/CoreBackgroundJobPerformer.cs
@@ -74,7 +74,7 @@ namespace Hangfire.Server
             }
         }
 
-        internal static void HandleJobPerformanceException(Exception exception, IJobCancellationToken cancellationToken)
+        internal static void HandleJobPerformanceException(Exception exception, IJobCancellationToken cancellationToken, [CanBeNull] BackgroundJob job)
         {
             if (exception is JobAbortedException)
             {
@@ -105,7 +105,7 @@ namespace Hangfire.Server
             // shallow stack trace without Hangfire methods.
             throw new JobPerformanceException(
                 "An exception occurred during performance of the job.",
-                exception);
+                exception, job?.Id);
         }
 
         private object InvokeMethod(PerformContext context, object instance, object[] arguments)
@@ -132,22 +132,22 @@ namespace Hangfire.Server
             }
             catch (ArgumentException ex)
             {
-                HandleJobPerformanceException(ex, context.CancellationToken);
+                HandleJobPerformanceException(ex, context.CancellationToken, context.BackgroundJob);
                 throw;
             }
             catch (AggregateException ex)
             {
-                HandleJobPerformanceException(ex.InnerException, context.CancellationToken);
+                HandleJobPerformanceException(ex.InnerException, context.CancellationToken, context.BackgroundJob);
                 throw;
             }
             catch (TargetInvocationException ex)
             {
-                HandleJobPerformanceException(ex.InnerException, context.CancellationToken);
+                HandleJobPerformanceException(ex.InnerException, context.CancellationToken, context.BackgroundJob);
                 throw;
             }
             catch (Exception ex)
             {
-                HandleJobPerformanceException(ex, context.CancellationToken);
+                HandleJobPerformanceException(ex, context.CancellationToken, context.BackgroundJob);
                 throw;
             }
         }

--- a/src/Hangfire.Core/Server/JobPerformanceException.cs
+++ b/src/Hangfire.Core/Server/JobPerformanceException.cs
@@ -23,10 +23,15 @@ namespace Hangfire.Server
 #endif
     public class JobPerformanceException : Exception
     {
-        public JobPerformanceException(string message, Exception innerException, string jobId = null)
+        public JobPerformanceException(string message, Exception innerException)
+            : this(message, innerException, null)
+        {
+        }
+    
+        public JobPerformanceException(string message, Exception innerException, string jobId)
             : base(message, innerException)
         {
-	        JobId = jobId;
+            JobId = jobId;
         }
 
         /// <summary>

--- a/src/Hangfire.Core/Server/JobPerformanceException.cs
+++ b/src/Hangfire.Core/Server/JobPerformanceException.cs
@@ -23,9 +23,15 @@ namespace Hangfire.Server
 #endif
     public class JobPerformanceException : Exception
     {
-        public JobPerformanceException(string message, Exception innerException)
+        public JobPerformanceException(string message, Exception innerException, string jobId = null)
             : base(message, innerException)
         {
+	        JobId = jobId;
         }
+
+        /// <summary>
+        /// The Background Job Id of the Job instance this exception has been raised for
+        /// </summary>
+        public string JobId { get; private set; }
     }
 }

--- a/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
+++ b/tests/Hangfire.Core.Tests/Server/CoreBackgroundJobPerformerFacts.cs
@@ -318,6 +318,21 @@ namespace Hangfire.Core.Tests.Server
         }
 
         [Fact]
+        public void ThrowsJobPerformanceException_DoesInclude_JobId()
+        {
+	        // Arrange
+	        _context.BackgroundJob.Job = Job.FromExpression(() => CancelableJob(JobCancellationToken.Null));
+	        _context.CancellationToken.Setup(x => x.ShutdownToken).Returns(CancellationToken.None);
+	        _context.CancellationToken.Setup(x => x.ThrowIfCancellationRequested()).Throws<OperationCanceledException>();
+
+	        var performer = CreatePerformer();
+
+	        // Act & Assert
+	        var exception = Assert.Throws<JobPerformanceException>(() => performer.Perform(_context.Object));
+	        Assert.Equal(_context.BackgroundJob.Id, exception.JobId);
+        }
+
+        [Fact]
         public void Run_ThrowsJobPerformanceException_InsteadOfOperationCanceled_WhenShutdownWasNOTInitiated()
         {
             // Arrange


### PR DESCRIPTION
## Overview
This PR adds a `string JobId` property to the `JobPerformanceException` class so that error logging code (exception handlers, etc) can access the `JobId` that was running that caused this issue.

## Notes
Initially I was going to provide a `BackgroundJob Job` property instead of a `string JobId` property, but that would not let the exception class be `Serializable` any more.

There is also a few `Obsolete` call code paths I do not pass in the `JobId` so this property could be `null`.