### PR TITLE
  Implemented fixed-top behaviour for error alerts

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -301,6 +301,11 @@ a:hover .label-hover {
     border-color: rgb(229, 220, 195);
 }
 
+.alert-fixed {
+    border-radius: 0;
+    margin-bottom: 0;
+}
+
 .state-card {
     position: relative;
     display: block;

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -17,7 +17,13 @@
         ErrorAlert.prototype.show = function() {
             this._errorAlertTitle.html(this._title);
             this._errorAlertMessage.html(this._message);
-            $('#errorAlert').slideDown('fast');
+
+            $('#errorAlert').show();
+            var alertHeight = $('#errorAlert').outerHeight();
+            $('#errorAlert').hide();
+
+            $('#errorAlert').slideDown("fast");
+            $('.js-page-container').animate({ 'margin-top': alertHeight + 'px' }, "fast");
         };
 
         return ErrorAlert;

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -58,13 +58,12 @@
                     </div>
                     <!--/.nav-collapse -->
                 </div>
+                <!-- Error alert when polling fails -->
+                @Html.RenderPartial(new ErrorAlert())
             </div>
 
             <!-- Begin page content -->
-            <div class="container" style="margin-bottom: 20px;">
-                <!-- Error alert when polling fails -->
-                @Html.RenderPartial(new ErrorAlert())
-
+            <div class="container js-page-container" style="margin-bottom: 20px;">
                 @RenderBody()
             </div>
         </div>

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
@@ -268,29 +268,25 @@ WriteLiteral("\r\n                                    </a>\r\n                  
             
             #line default
             #line hidden
-WriteLiteral(@"                    </div>
-                    <!--/.nav-collapse -->
-                </div>
-            </div>
-
-            <!-- Begin page content -->
-            <div class=""container"" style=""margin-bottom: 20px;"">
-                <!-- Error alert when polling fails -->
-                ");
+WriteLiteral("                    </div>\r\n                    <!--/.nav-collapse -->\r\n         " +
+"       </div>\r\n                <!-- Error alert when polling fails -->\r\n        " +
+"        ");
 
 
             
-            #line 66 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 62 "..\..\Dashboard\Pages\LayoutPage.cshtml"
            Write(Html.RenderPartial(new ErrorAlert()));
 
             
             #line default
             #line hidden
-WriteLiteral("\r\n\r\n                ");
+WriteLiteral("\r\n            </div>\r\n\r\n            <!-- Begin page content -->\r\n            <div" +
+" class=\"container js-page-container\" style=\"margin-bottom: 20px;\">\r\n            " +
+"    ");
 
 
             
-            #line 68 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 67 "..\..\Dashboard\Pages\LayoutPage.cshtml"
            Write(RenderBody());
 
             
@@ -308,7 +304,7 @@ WriteLiteral(@"
 
 
             
-            #line 76 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 75 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                                                                           Write($"{version.Major}.{version.Minor}.{version.Build}");
 
             
@@ -318,7 +314,7 @@ WriteLiteral("\r\n                        </a>\r\n                    </li>\r\n"
 
 
             
-            #line 79 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 78 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                      if(DashboardOptions.DisplayStorageConnectionString){
 
             
@@ -328,7 +324,7 @@ WriteLiteral("                    <li>");
 
 
             
-            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 79 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Storage);
 
             
@@ -338,7 +334,7 @@ WriteLiteral("</li>\r\n");
 
 
             
-            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                     }
 
             
@@ -348,7 +344,7 @@ WriteLiteral("                    <li>");
 
 
             
-            #line 82 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Strings.LayoutPage_Footer_Time);
 
             
@@ -358,7 +354,7 @@ WriteLiteral(" ");
 
 
             
-            #line 82 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                    Write(Html.LocalTime(DateTime.UtcNow));
 
             
@@ -368,7 +364,7 @@ WriteLiteral("</li>\r\n                    <li>");
 
 
             
-            #line 83 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 82 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(String.Format(Strings.LayoutPage_Footer_Generatedms, GenerationTime.Elapsed.TotalMilliseconds.ToString("N")));
 
             
@@ -379,7 +375,7 @@ WriteLiteral("</li>\r\n                </ul>\r\n            </div>\r\n        </
 
 
             
-            #line 89 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 88 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                            Write(DashboardOptions.StatsPollingInterval);
 
             
@@ -389,7 +385,7 @@ WriteLiteral("\"\r\n             data-pollurl=\"");
 
 
             
-            #line 90 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 89 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                        Write(Url.To("/stats"));
 
             
@@ -399,7 +395,7 @@ WriteLiteral("\">\r\n        </div>\r\n\r\n        <script src=\"");
 
 
             
-            #line 93 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 92 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                 Write(Url.To($"/js{version.Major}{version.Minor}{version.Build}0"));
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/_ErrorAlert.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/_ErrorAlert.cshtml
@@ -2,6 +2,9 @@
 @using Hangfire.Dashboard
 @inherits RazorPage
 
-<div id="errorAlert" class="alert alert-danger" role="alert" style="display: none;">
-    <strong id="errorAlertTitle"></strong> <span id="errorAlertMessage"></span>
+<div id="errorAlert" class="alert alert-danger alert-fixed" role="alert" style="display: none;">
+    <div class="container">
+        <strong id="errorAlertTitle"></strong> 
+        <span id="errorAlertMessage"></span>
+    </div>
 </div>

--- a/src/Hangfire.Core/Dashboard/Pages/_ErrorAlert.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/_ErrorAlert.cshtml.cs
@@ -35,9 +35,10 @@ WriteLiteral("\r\n");
 
 
 
-WriteLiteral("\r\n<div id=\"errorAlert\" class=\"alert alert-danger\" role=\"alert\" style=\"display: no" +
-"ne;\">\r\n    <strong id=\"errorAlertTitle\"></strong> <span id=\"errorAlertMessage\"><" +
-"/span>\r\n</div>\r\n");
+WriteLiteral("\r\n<div id=\"errorAlert\" class=\"alert alert-danger alert-fixed\" role=\"alert\" style=" +
+"\"display: none;\">\r\n    <div class=\"container\">\r\n        <strong id=\"errorAlertTi" +
+"tle\"></strong> \r\n        <span id=\"errorAlertMessage\"></span>\r\n    </div>\r\n</div" +
+">");
 
 
         }


### PR DESCRIPTION
Before: alerts are not visible after scrolling, sidebar has excess margin

![image](https://user-images.githubusercontent.com/6246972/120633486-e14a7080-c472-11eb-8947-cc7eed051e4e.png)


![image](https://user-images.githubusercontent.com/6246972/120633298-a8aa9700-c472-11eb-97b8-1feef8732f81.png)

After: alerts are fixed to top and always visible. Sidebar has proper margin

![fixed-1](https://user-images.githubusercontent.com/6246972/120633609-02ab5c80-c473-11eb-93c0-6cfdb8cd89c5.png)

![fixed-2](https://user-images.githubusercontent.com/6246972/120633656-0f2fb500-c473-11eb-9fb4-031773d5c9c5.png)