### PR TITLE
Avoid memory leak in AppBuilderExtensions

### DIFF
--- a/src/Hangfire.Core/AppBuilderExtensions.cs
+++ b/src/Hangfire.Core/AppBuilderExtensions.cs
@@ -132,9 +132,9 @@ namespace Hangfire
     public static class AppBuilderExtensions
     {
         // Prevent GC to collect background processing servers in hosts that do
-        // not support shutdown notifications.
-        private static readonly ConcurrentBag<BackgroundJobServer> Servers
-            = new ConcurrentBag<BackgroundJobServer>();
+        // not support shutdown notifications. Dictionary is used as a Set.
+        private static readonly ConcurrentDictionary<BackgroundJobServer, object> Servers
+            = new ConcurrentDictionary<BackgroundJobServer, object>();
 
         /// <summary>
         /// Creates a new instance of the <see cref="BackgroundJobServer"/> class
@@ -293,7 +293,7 @@ namespace Hangfire
             if (additionalProcesses == null) throw new ArgumentNullException(nameof(additionalProcesses));
 
             var server = new BackgroundJobServer(options, storage, additionalProcesses);
-            Servers.Add(server);
+            Servers.TryAdd(server, null);
 
             var context = new OwinContext(builder.Properties);
             var token = context.Get<CancellationToken>("host.OnAppDisposing");
@@ -319,6 +319,9 @@ namespace Hangfire
             var logger = LogProvider.GetLogger(typeof(AppBuilderExtensions));
             logger.Info("Web application is shutting down via OWIN's host.OnAppDisposing callback.");
             ((IDisposable) state).Dispose();
+            var server = state as BackgroundJobServer;
+            if (server != null)
+                Servers.TryRemove(server, out _);
         }
 
         /// <summary>


### PR DESCRIPTION
Since ConcurrentBag does not support removal of a specific object, and there is no thread-safe set class, here ConcurrentDictionary is used as a Set. Fixes #1877