### PR TITLE
Implemented back-to-site link responsiveness

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -50,7 +50,9 @@
                                 <li>
                                     <a href="@AppPath">
                                         <span class="glyphicon glyphicon-log-out"></span>
-                                        @Strings.LayoutPage_Back
+                                        <span class="hidden-sm">
+                                            @Strings.LayoutPage_Back
+                                        </span>
                                     </a>
                                 </li>
                             </ul>

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
@@ -247,22 +247,24 @@ WriteLiteral("                            <ul class=\"nav navbar-nav navbar-righ
             #line default
             #line hidden
 WriteLiteral("\">\r\n                                        <span class=\"glyphicon glyphicon-log-" +
-"out\"></span>\r\n                                        ");
+"out\"></span>\r\n                                        <span class=\"hidden-sm\">\r\n" +
+"                                            ");
 
 
             
-            #line 53 "..\..\Dashboard\Pages\LayoutPage.cshtml"
-                                   Write(Strings.LayoutPage_Back);
+            #line 54 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                                       Write(Strings.LayoutPage_Back);
 
             
             #line default
             #line hidden
-WriteLiteral("\r\n                                    </a>\r\n                                </li>" +
-"\r\n                            </ul>\r\n");
+WriteLiteral("\r\n                                        </span>\r\n                              " +
+"      </a>\r\n                                </li>\r\n                            <" +
+"/ul>\r\n");
 
 
             
-            #line 57 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 59 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                         }
 
             
@@ -274,7 +276,7 @@ WriteLiteral("                    </div>\r\n                    <!--/.nav-collap
 
 
             
-            #line 62 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 64 "..\..\Dashboard\Pages\LayoutPage.cshtml"
            Write(Html.RenderPartial(new ErrorAlert()));
 
             
@@ -286,7 +288,7 @@ WriteLiteral("\r\n            </div>\r\n\r\n            <!-- Begin page content 
 
 
             
-            #line 67 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 69 "..\..\Dashboard\Pages\LayoutPage.cshtml"
            Write(RenderBody());
 
             
@@ -304,7 +306,7 @@ WriteLiteral(@"
 
 
             
-            #line 75 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 77 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                                                                           Write($"{version.Major}.{version.Minor}.{version.Build}");
 
             
@@ -314,7 +316,7 @@ WriteLiteral("\r\n                        </a>\r\n                    </li>\r\n"
 
 
             
-            #line 78 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                      if(DashboardOptions.DisplayStorageConnectionString){
 
             
@@ -324,7 +326,7 @@ WriteLiteral("                    <li>");
 
 
             
-            #line 79 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Storage);
 
             
@@ -334,7 +336,7 @@ WriteLiteral("</li>\r\n");
 
 
             
-            #line 80 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 82 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                     }
 
             
@@ -344,7 +346,7 @@ WriteLiteral("                    <li>");
 
 
             
-            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 83 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(Strings.LayoutPage_Footer_Time);
 
             
@@ -354,7 +356,7 @@ WriteLiteral(" ");
 
 
             
-            #line 81 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 83 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                                                    Write(Html.LocalTime(DateTime.UtcNow));
 
             
@@ -364,7 +366,7 @@ WriteLiteral("</li>\r\n                    <li>");
 
 
             
-            #line 82 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 84 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                    Write(String.Format(Strings.LayoutPage_Footer_Generatedms, GenerationTime.Elapsed.TotalMilliseconds.ToString("N")));
 
             
@@ -375,7 +377,7 @@ WriteLiteral("</li>\r\n                </ul>\r\n            </div>\r\n        </
 
 
             
-            #line 88 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 90 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                            Write(DashboardOptions.StatsPollingInterval);
 
             
@@ -385,7 +387,7 @@ WriteLiteral("\"\r\n             data-pollurl=\"");
 
 
             
-            #line 89 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 91 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                        Write(Url.To("/stats"));
 
             
@@ -395,7 +397,7 @@ WriteLiteral("\">\r\n        </div>\r\n\r\n        <script src=\"");
 
 
             
-            #line 92 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 94 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                 Write(Url.To($"/js{version.Major}{version.Minor}{version.Build}0"));
 
             


### PR DESCRIPTION
Make back-to-site button from image below collapse, for saving space on narrow screens like at the last image of the PR

**Default**

![back-to-site 1](https://user-images.githubusercontent.com/6246972/123326015-650eee80-d541-11eb-9891-01fe2bc0e749.PNG)

**Collapsed at 768-992px**

![back-to-site 2](https://user-images.githubusercontent.com/6246972/123326038-693b0c00-d541-11eb-91b2-67921007aeb2.PNG)
