### PR TITLE
Remove excess paddings of alert

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -304,6 +304,8 @@ a:hover .label-hover {
 .alert-fixed {
     border-radius: 0;
     margin-bottom: 0;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .state-card {

--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -303,7 +303,7 @@ a:hover .label-hover {
 
 .alert-fixed {
     border-radius: 0;
-    margin-bottom: 0;
+    margin-bottom: -1px;
     padding-left: 0;
     padding-right: 0;
 }


### PR DESCRIPTION
Implemented fixed-top behaviour for error alerts 

**Before**
![2](https://user-images.githubusercontent.com/6246972/123328356-2b8bb280-d544-11eb-8ff8-87e79ff99abd.PNG)

**After**
![1](https://user-images.githubusercontent.com/6246972/123328342-275f9500-d544-11eb-9daf-f5171f840e6a.PNG)