### PR TITLE
Fixed footer shift when fixed-alert is shown

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -23,7 +23,7 @@
             $('#errorAlert').hide();
 
             $('#errorAlert').slideDown("fast");
-            $('.js-page-container').animate({ 'margin-top': alertHeight + 'px' }, "fast");
+            $('.js-page-container').animate({ 'padding-top': alertHeight + 'px' }, "fast");
         };
 
         return ErrorAlert;


### PR DESCRIPTION
Footer shifts down, when fixed-alert is shown

![image](https://user-images.githubusercontent.com/6246972/123423835-b615f580-d5c8-11eb-8d74-e6e90d937960.png)

With this PR it is fixed:

![image](https://user-images.githubusercontent.com/6246972/123423947-da71d200-d5c8-11eb-8414-d4f3276e9314.png)
