### PR TITLE
Implemented full-width support

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -552,3 +552,33 @@ div.metric-null {
     white-space: normal;
     word-break: break-word;
 }
+
+/* Full width styles */
+
+@media (min-width: 768px) {
+    .container {
+        width: 100%;
+        padding-left: 25px;
+        padding-right: 25px;
+    }
+}
+
+@media (min-width: 992px) {
+    #wrap > .container > .row > .col-md-3 {
+        width: 251px;
+    }
+
+    #wrap > .container > .row > .col-md-9 {
+        width: calc(100% - 251px);
+    }
+}
+
+@media (min-width: 1200px) {
+    #wrap > .container > .row > .col-md-3 {
+        width: 293px;
+    }
+
+    #wrap > .container > .row > .col-md-9 {
+        width: calc(100% - 293px);
+    }
+}


### PR DESCRIPTION
 Before:
 
 Fixed width, even when screen width is wider than 1200px
 
 
![full-screen-before](https://user-images.githubusercontent.com/6246972/120997918-44e4de80-c790-11eb-8688-50e30950aad6.png)

After:

For screens of all sizes container width is now relative.

**Wider than 1200px**

![full-width-L](https://user-images.githubusercontent.com/6246972/122761586-1513fb80-d2a5-11eb-92fe-16d9acd2f93a.png)

**992px - 1200px**

![full-width-M](https://user-images.githubusercontent.com/6246972/122761594-16452880-d2a5-11eb-93bb-7532cc70c7bb.png)

**768 - 992px**

![full-width-S](https://user-images.githubusercontent.com/6246972/122761595-16ddbf00-d2a5-11eb-9b62-ed3283afd1e5.png)

**Narrower than 768px**

![full-width-XS](https://user-images.githubusercontent.com/6246972/122761598-16ddbf00-d2a5-11eb-9dc6-eb8b29043759.png)




