### PR TITLE
Moved from inline style to classes at Job's state indication

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -372,88 +372,87 @@ a:hover .label-hover {
 }
 
 .state-card_state_enqueued {
-    border-color: #999;
+    border-color: #999 !important;
 }
 
 .state-card_state_succeeded {
-    border-color: #5cb85c;
+    border-color: #5cb85c !important;
 }
 
 .state-card_state_failed {
-    border-color: #d9534f;
+    border-color: #d9534f !important;
 }
 
 .state-card_state_processing {
-    border-color: #f0ad4e;
+    border-color: #f0ad4e !important;
 }
 
 .state-card_state_scheduled {
-    border-color: #5bc0de;
+    border-color: #5bc0de !important;
 }
 
 .state-card_state_deleted {
-    border-color: #777;
+    border-color: #777 !important;
 }
 
 .state-card_state_awaiting {
-    border-color: #999;
+    border-color: #999 !important;
 }
 
 .state-card_state_enqueued .state-card-title {
-    color: #999;
+    color: #999 !important;
 }
 
 .state-card_state_succeeded .state-card-title {
-    color: #5cb85c;
+    color: #5cb85c !important;
 }
 
 .state-card_state_failed .state-card-title {
-    color: #d9534f;
+    color: #d9534f !important;
 }
 
 .state-card_state_processing .state-card-title {
-    color: #f0ad4e;
+    color: #f0ad4e !important;
 }
 
 .state-card_state_scheduled .state-card-title {
-    color: #5bc0de;
+    color: #5bc0de !important;
 }
 
 .state-card_state_deleted .state-card-title {
-    color: #777;
+    color: #777 !important;
 }
 
 .state-card_state_awaiting .state-card-title {
-    color: #999;
+    color: #999 !important;
 }
 
-
 .state-card_state_enqueued .state-card-body {
-    background-color: #F5F5F5;
+    background-color: #F5F5F5 !important;
 }
 
 .state-card_state_succeeded .state-card-body {
-    background-color: #EDF7ED;
+    background-color: #EDF7ED !important;
 }
 
 .state-card_state_failed .state-card-body {
-    background-color: #FAEBEA;
+    background-color: #FAEBEA !important;
 }
 
 .state-card_state_processing .state-card-body {
-    background-color: #FCEFDC;
+    background-color: #FCEFDC !important;
 }
 
 .state-card_state_scheduled .state-card-body {
-    background-color: #E0F3F8;
+    background-color: #E0F3F8 !important;
 }
 
 .state-card_state_deleted .state-card-body {
-    background-color: #ddd;
+    background-color: #ddd !important;
 }
 
 .state-card_state_awaiting .state-card-body {
-    background-color: #F5F5F5;
+    background-color: #F5F5F5 !important;
 }
 
 /* Job History styles */
@@ -641,29 +640,29 @@ div.metric-null {
 /* State labels */
 
 .label_state_enqueued {
-    background-color: #999;
+    background-color: #999 !importan !importantt;
 }
 
 .label_state_succeeded {
-    background-color: #5cb85c;
+    background-color: #5cb85c !importan !importantt;
 }
 
 .label_state_failed {
-    background-color: #d9534f;
+    background-color: #d9534f !importan !importantt;
 }
 
 .label_state_processing {
-    background-color: #f0ad4e;
+    background-color: #f0ad4e !importan !importantt;
 }
 
 .label_state_scheduled {
-    background-color: #5bc0de;
+    background-color: #5bc0de !importan !importantt;
 }
 
 .label_state_deleted {
-    background-color: #777;
+    background-color: #777 !importan !importantt;
 }
 
 .label_state_awaiting {
-    background-color: #999;
+    background-color: #999 !importan !importantt;
 }

--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -371,6 +371,91 @@ a:hover .label-hover {
     margin-top: 0;
 }
 
+.state-card_state_enqueued {
+    border-color: #999;
+}
+
+.state-card_state_succeeded {
+    border-color: #5cb85c;
+}
+
+.state-card_state_failed {
+    border-color: #d9534f;
+}
+
+.state-card_state_processing {
+    border-color: #f0ad4e;
+}
+
+.state-card_state_scheduled {
+    border-color: #5bc0de;
+}
+
+.state-card_state_deleted {
+    border-color: #777;
+}
+
+.state-card_state_awaiting {
+    border-color: #999;
+}
+
+.state-card_state_enqueued .state-card-title {
+    color: #999;
+}
+
+.state-card_state_succeeded .state-card-title {
+    color: #5cb85c;
+}
+
+.state-card_state_failed .state-card-title {
+    color: #d9534f;
+}
+
+.state-card_state_processing .state-card-title {
+    color: #f0ad4e;
+}
+
+.state-card_state_scheduled .state-card-title {
+    color: #5bc0de;
+}
+
+.state-card_state_deleted .state-card-title {
+    color: #777;
+}
+
+.state-card_state_awaiting .state-card-title {
+    color: #999;
+}
+
+
+.state-card_state_enqueued .state-card-body {
+    background-color: #F5F5F5;
+}
+
+.state-card_state_succeeded .state-card-body {
+    background-color: #EDF7ED;
+}
+
+.state-card_state_failed .state-card-body {
+    background-color: #FAEBEA;
+}
+
+.state-card_state_processing .state-card-body {
+    background-color: #FCEFDC;
+}
+
+.state-card_state_scheduled .state-card-body {
+    background-color: #E0F3F8;
+}
+
+.state-card_state_deleted .state-card-body {
+    background-color: #ddd;
+}
+
+.state-card_state_awaiting .state-card-body {
+    background-color: #F5F5F5;
+}
+
 /* Job History styles */
 
 .job-history {
@@ -551,4 +636,34 @@ div.metric-null {
     max-width: 125px;
     white-space: normal;
     word-break: break-word;
+}
+
+/* State labels */
+
+.label_state_enqueued {
+    background-color: #999;
+}
+
+.label_state_succeeded {
+    background-color: #5cb85c;
+}
+
+.label_state_failed {
+    background-color: #d9534f;
+}
+
+.label_state_processing {
+    background-color: #f0ad4e;
+}
+
+.label_state_scheduled {
+    background-color: #5bc0de;
+}
+
+.label_state_deleted {
+    background-color: #777;
+}
+
+.label_state_awaiting {
+    background-color: #999;
 }

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -176,7 +176,7 @@ namespace Hangfire.Dashboard
             }
 
             return job.ToString();
-        } 
+        }
 
         public NonEscapedString StateLabel(string stateName)
         {
@@ -187,7 +187,7 @@ namespace Hangfire.Dashboard
 
             var style = $"background-color: {JobHistoryRenderer.GetForegroundStateColor(stateName)};";
             return Raw($"<span class=\"label label-default label_state_{stateName}\" style=\"{HtmlEncode(style)}\">{HtmlEncode(stateName)}</span>");
-        } 
+        }
 
         public NonEscapedString JobIdLink(string jobId)
         {

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -185,7 +185,8 @@ namespace Hangfire.Dashboard
                 return Raw($"<em>{HtmlEncode(Strings.Common_NoState)}</em>");
             }
 
-            return Raw($"<span class=\"label label-default label_state_{stateName}\">{HtmlEncode(stateName)}</span>");
+            var style = $"background-color: {JobHistoryRenderer.GetForegroundStateColor(stateName)};";
+            return Raw($"<span class=\"label label-default label_state_{stateName}\" style=\"{HtmlEncode(style)}\">{HtmlEncode(stateName)}</span>");
         } 
 
         public NonEscapedString JobIdLink(string jobId)

--- a/src/Hangfire.Core/Dashboard/HtmlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/HtmlHelper.cs
@@ -176,7 +176,7 @@ namespace Hangfire.Dashboard
             }
 
             return job.ToString();
-        }
+        } 
 
         public NonEscapedString StateLabel(string stateName)
         {
@@ -185,9 +185,8 @@ namespace Hangfire.Dashboard
                 return Raw($"<em>{HtmlEncode(Strings.Common_NoState)}</em>");
             }
 
-            var style = $"background-color: {JobHistoryRenderer.GetForegroundStateColor(stateName)};";
-            return Raw($"<span class=\"label label-default\" style=\"{HtmlEncode(style)}\">{HtmlEncode(stateName)}</span>");
-        }
+            return Raw($"<span class=\"label label-default label_state_{stateName}\">{HtmlEncode(stateName)}</span>");
+        } 
 
         public NonEscapedString JobIdLink(string jobId)
         {

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
@@ -144,7 +144,7 @@
                                             @if (parentStateData != null)
                                             {
                                                 <a href="@Url.JobDetails(stateData.Data["ParentId"])">
-                                                    <span class="label label-default label-hover" style="@($"background-color: {JobHistoryRenderer.GetForegroundStateColor(parentStateData.Name)};")">
+                                                    <span class="label label-default label-hover @(parentStateData.Name != null ? $"label_state_{parentStateData.Name.ToLower()}" : null)">
                                                         @parentStateData.Name
                                                     </span>
                                                 </a>

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml
@@ -144,7 +144,7 @@
                                             @if (parentStateData != null)
                                             {
                                                 <a href="@Url.JobDetails(stateData.Data["ParentId"])">
-                                                    <span class="label label-default label-hover @(parentStateData.Name != null ? $"label_state_{parentStateData.Name.ToLower()}" : null)">
+                                                    <span class="label label-default label-hover @(parentStateData.Name != null ? $"label_state_{parentStateData.Name.ToLower()}" : null)" style="@($"background-color: {JobHistoryRenderer.GetForegroundStateColor(parentStateData.Name)};")">
                                                         @parentStateData.Name
                                                     </span>
                                                 </a>

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
@@ -597,6 +597,16 @@ WriteLiteral("\">\r\n                                                    <span c
             
             #line default
             #line hidden
+WriteLiteral("\" style=\"");
+
+
+            
+            #line 147 "..\..\Dashboard\Pages\AwaitingJobsPage.cshtml"
+                                                                                                                                                                                              Write($"background-color: {JobHistoryRenderer.GetForegroundStateColor(parentStateData.Name)};");
+
+            
+            #line default
+            #line hidden
 WriteLiteral("\">\r\n                                                        ");
 
 

--- a/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/AwaitingJobsPage.cshtml.cs
@@ -587,12 +587,12 @@ WriteLiteral("                                                <a href=\"");
             #line default
             #line hidden
 WriteLiteral("\">\r\n                                                    <span class=\"label label-" +
-"default label-hover\" style=\"");
+"default label-hover ");
 
 
             
             #line 147 "..\..\Dashboard\Pages\AwaitingJobsPage.cshtml"
-                                                                                                     Write($"background-color: {JobHistoryRenderer.GetForegroundStateColor(parentStateData.Name)};");
+                                                                                             Write(parentStateData.Name != null ? $"label_state_{parentStateData.Name.ToLower()}" : null);
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
@@ -199,8 +199,11 @@
 
             foreach (var entry in job.History)
             {
-                <div class="state-card @(index == 0 ? $"state-card_state_{entry.StateName.ToLower()}" : null)">
-                    <h4 class="state-card-title">
+                var accentColor = JobHistoryRenderer.GetForegroundStateColor(entry.StateName);
+                var backgroundColor = JobHistoryRenderer.GetBackgroundStateColor(entry.StateName);
+
+                <div class="state-card @(index == 0 ? $"state-card_state_{entry.StateName.ToLower()}" : null)" style="@(index == 0 ? $"border-color: {accentColor}" : null)">
+                    <h4 class="state-card-title" style="@(index == 0 ? $"color: {accentColor}" : null)">
                         <small class="pull-right text-muted">
                             @if (index == job.History.Count - 1)
                             {
@@ -235,7 +238,7 @@
 
                     @if (rendered != null)
                     {
-                        <div class="state-card-body">
+                        <div class="state-card-body" style="@(index == 0 ? $"background-color: {backgroundColor}" : null)">
                             @rendered
                         </div>
                     }

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml
@@ -199,11 +199,8 @@
 
             foreach (var entry in job.History)
             {
-                var accentColor = JobHistoryRenderer.GetForegroundStateColor(entry.StateName);
-                var backgroundColor = JobHistoryRenderer.GetBackgroundStateColor(entry.StateName);
-
-                <div class="state-card" style="@(index == 0 ? $"border-color: {accentColor}" : null)">
-                    <h4 class="state-card-title" style="@(index == 0 ? $"color: {accentColor}" : null)">
+                <div class="state-card @(index == 0 ? $"state-card_state_{entry.StateName.ToLower()}" : null)">
+                    <h4 class="state-card-title">
                         <small class="pull-right text-muted">
                             @if (index == job.History.Count - 1)
                             {
@@ -238,7 +235,7 @@
 
                     @if (rendered != null)
                     {
-                        <div class="state-card-body" style="@(index == 0 ? $"background-color: {backgroundColor}" : null)">
+                        <div class="state-card-body">
                             @rendered
                         </div>
                     }

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
@@ -833,6 +833,9 @@ WriteLiteral("\r\n            </h3>\r\n");
 
             foreach (var entry in job.History)
             {
+                var accentColor = JobHistoryRenderer.GetForegroundStateColor(entry.StateName);
+                var backgroundColor = JobHistoryRenderer.GetBackgroundStateColor(entry.StateName);
+
 
             
             #line default
@@ -841,18 +844,37 @@ WriteLiteral("                <div class=\"state-card ");
 
 
             
-            #line 202 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 205 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                    Write(index == 0 ? $"state-card_state_{entry.StateName.ToLower()}" : null);
 
             
             #line default
             #line hidden
-WriteLiteral("\">\r\n                    <h4 class=\"state-card-title\">\r\n                        <s" +
-"mall class=\"pull-right text-muted\">\r\n");
+WriteLiteral("\" style=\"");
 
 
             
             #line 205 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+                                                                                                                  Write(index == 0 ? $"border-color: {accentColor}" : null);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                    <h4 class=\"state-card-title\" style=\"");
+
+
+            
+            #line 206 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+                                                    Write(index == 0 ? $"color: {accentColor}" : null);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                        <small class=\"pull-right text-muted\">\r\n");
+
+
+            
+            #line 208 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                              if (index == job.History.Count - 1)
                             {
                                 
@@ -860,14 +882,14 @@ WriteLiteral("\">\r\n                    <h4 class=\"state-card-title\">\r\n    
             #line default
             #line hidden
             
-            #line 207 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 210 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                            Write(Html.RelativeTime(entry.CreatedAt));
 
             
             #line default
             #line hidden
             
-            #line 207 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 210 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                                    
                             }
                             else
@@ -886,7 +908,7 @@ WriteLiteral(" ");
 
 
             
-            #line 215 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 218 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                   Write(Html.RelativeTime(entry.CreatedAt));
 
             
@@ -896,7 +918,7 @@ WriteLiteral(" (");
 
 
             
-            #line 215 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 218 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                                        Write(duration);
 
             
@@ -906,7 +928,7 @@ WriteLiteral(")\r\n");
 
 
             
-            #line 216 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 219 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                 }
                                 else
                                 {
@@ -920,7 +942,7 @@ WriteLiteral(" ");
 
 
             
-            #line 219 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 222 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                   Write(Html.MomentTitle(entry.CreatedAt, duration));
 
             
@@ -930,7 +952,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 220 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 223 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                 }
                             }
 
@@ -941,7 +963,7 @@ WriteLiteral("                        </small>\r\n\r\n                        ")
 
 
             
-            #line 224 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 227 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                    Write(entry.StateName);
 
             
@@ -951,7 +973,7 @@ WriteLiteral("\r\n                    </h4>\r\n\r\n");
 
 
             
-            #line 227 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 230 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                      if (!String.IsNullOrWhiteSpace(entry.Reason))
                     {
 
@@ -962,7 +984,7 @@ WriteLiteral("                        <p class=\"state-card-text text-muted\">")
 
 
             
-            #line 229 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 232 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                          Write(entry.Reason);
 
             
@@ -972,7 +994,7 @@ WriteLiteral("</p>\r\n");
 
 
             
-            #line 230 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 233 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                     }
 
             
@@ -982,7 +1004,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 232 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 235 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                       
                         var rendered = Html.RenderHistory(entry.StateName, entry.Data);
                     
@@ -994,19 +1016,28 @@ WriteLiteral("\r\n");
 
 
             
-            #line 236 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 239 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                      if (rendered != null)
                     {
 
             
             #line default
             #line hidden
-WriteLiteral("                        <div class=\"state-card-body\">\r\n                          " +
-"  ");
+WriteLiteral("                        <div class=\"state-card-body\" style=\"");
 
 
             
-            #line 239 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 241 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+                                                        Write(index == 0 ? $"background-color: {backgroundColor}" : null);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                            ");
+
+
+            
+            #line 242 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                        Write(rendered);
 
             
@@ -1016,7 +1047,7 @@ WriteLiteral("\r\n                        </div>\r\n");
 
 
             
-            #line 241 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 244 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                     }
 
             
@@ -1026,7 +1057,7 @@ WriteLiteral("                </div>\r\n");
 
 
             
-            #line 243 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 246 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
 
                 index++;
             }

--- a/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/JobDetailsPage.cshtml.cs
@@ -833,38 +833,26 @@ WriteLiteral("\r\n            </h3>\r\n");
 
             foreach (var entry in job.History)
             {
-                var accentColor = JobHistoryRenderer.GetForegroundStateColor(entry.StateName);
-                var backgroundColor = JobHistoryRenderer.GetBackgroundStateColor(entry.StateName);
-
 
             
             #line default
             #line hidden
-WriteLiteral("                <div class=\"state-card\" style=\"");
+WriteLiteral("                <div class=\"state-card ");
+
+
+            
+            #line 202 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+                                   Write(index == 0 ? $"state-card_state_{entry.StateName.ToLower()}" : null);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                    <h4 class=\"state-card-title\">\r\n                        <s" +
+"mall class=\"pull-right text-muted\">\r\n");
 
 
             
             #line 205 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                           Write(index == 0 ? $"border-color: {accentColor}" : null);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\">\r\n                    <h4 class=\"state-card-title\" style=\"");
-
-
-            
-            #line 206 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                    Write(index == 0 ? $"color: {accentColor}" : null);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\">\r\n                        <small class=\"pull-right text-muted\">\r\n");
-
-
-            
-            #line 208 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                              if (index == job.History.Count - 1)
                             {
                                 
@@ -872,14 +860,14 @@ WriteLiteral("\">\r\n                        <small class=\"pull-right text-mute
             #line default
             #line hidden
             
-            #line 210 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 207 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                            Write(Html.RelativeTime(entry.CreatedAt));
 
             
             #line default
             #line hidden
             
-            #line 210 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 207 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                                    
                             }
                             else
@@ -898,7 +886,7 @@ WriteLiteral(" ");
 
 
             
-            #line 218 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 215 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                   Write(Html.RelativeTime(entry.CreatedAt));
 
             
@@ -908,7 +896,7 @@ WriteLiteral(" (");
 
 
             
-            #line 218 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 215 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                                        Write(duration);
 
             
@@ -918,7 +906,7 @@ WriteLiteral(")\r\n");
 
 
             
-            #line 219 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 216 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                 }
                                 else
                                 {
@@ -932,7 +920,7 @@ WriteLiteral(" ");
 
 
             
-            #line 222 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 219 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                   Write(Html.MomentTitle(entry.CreatedAt, duration));
 
             
@@ -942,7 +930,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 223 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 220 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                 }
                             }
 
@@ -953,7 +941,7 @@ WriteLiteral("                        </small>\r\n\r\n                        ")
 
 
             
-            #line 227 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 224 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                    Write(entry.StateName);
 
             
@@ -963,7 +951,7 @@ WriteLiteral("\r\n                    </h4>\r\n\r\n");
 
 
             
-            #line 230 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 227 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                      if (!String.IsNullOrWhiteSpace(entry.Reason))
                     {
 
@@ -974,7 +962,7 @@ WriteLiteral("                        <p class=\"state-card-text text-muted\">")
 
 
             
-            #line 232 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 229 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                                                          Write(entry.Reason);
 
             
@@ -984,7 +972,7 @@ WriteLiteral("</p>\r\n");
 
 
             
-            #line 233 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 230 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                     }
 
             
@@ -994,7 +982,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 235 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 232 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                       
                         var rendered = Html.RenderHistory(entry.StateName, entry.Data);
                     
@@ -1006,28 +994,19 @@ WriteLiteral("\r\n");
 
 
             
-            #line 239 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 236 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                      if (rendered != null)
                     {
 
             
             #line default
             #line hidden
-WriteLiteral("                        <div class=\"state-card-body\" style=\"");
+WriteLiteral("                        <div class=\"state-card-body\">\r\n                          " +
+"  ");
 
 
             
-            #line 241 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
-                                                        Write(index == 0 ? $"background-color: {backgroundColor}" : null);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\">\r\n                            ");
-
-
-            
-            #line 242 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 239 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                        Write(rendered);
 
             
@@ -1037,7 +1016,7 @@ WriteLiteral("\r\n                        </div>\r\n");
 
 
             
-            #line 244 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 241 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
                     }
 
             
@@ -1047,7 +1026,7 @@ WriteLiteral("                </div>\r\n");
 
 
             
-            #line 246 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
+            #line 243 "..\..\Dashboard\Pages\JobDetailsPage.cshtml"
 
                 index++;
             }

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
@@ -227,7 +227,7 @@
                                             if (!String.IsNullOrEmpty(job.LastJobId))
                                             {
                                                 <a href="@Url.JobDetails(job.LastJobId)" style="text-decoration: none">
-                                                    <span class="label label-default label-hover @(job.LastJobState != null ? $"label_state_{job.LastJobState.ToLower()}" : null)">
+                                                    <span class="label label-default label-hover @(job.LastJobState != null ? $"label_state_{job.LastJobState.ToLower()}" : null)" style="@($"background-color: {JobHistoryRenderer.GetForegroundStateColor(job.LastJobState ?? EnqueuedState.StateName)};")">
                                                         @Html.RelativeTime(job.LastExecution.Value)
                                                     </span>
                                                 </a>

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml
@@ -227,7 +227,7 @@
                                             if (!String.IsNullOrEmpty(job.LastJobId))
                                             {
                                                 <a href="@Url.JobDetails(job.LastJobId)" style="text-decoration: none">
-                                                    <span class="label label-default label-hover" style="@($"background-color: {JobHistoryRenderer.GetForegroundStateColor(job.LastJobState ?? EnqueuedState.StateName)};")">
+                                                    <span class="label label-default label-hover @(job.LastJobState != null ? $"label_state_{job.LastJobState.ToLower()}" : null)">
                                                         @Html.RelativeTime(job.LastExecution.Value)
                                                     </span>
                                                 </a>

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
@@ -930,12 +930,12 @@ WriteLiteral("                                                <a href=\"");
             #line default
             #line hidden
 WriteLiteral("\" style=\"text-decoration: none\">\r\n                                               " +
-"     <span class=\"label label-default label-hover\" style=\"");
+"     <span class=\"label label-default label-hover ");
 
 
             
             #line 230 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
-                                                                                                     Write($"background-color: {JobHistoryRenderer.GetForegroundStateColor(job.LastJobState ?? EnqueuedState.StateName)};");
+                                                                                             Write(job.LastJobState != null ? $"label_state_{job.LastJobState.ToLower()}" : null);
 
             
             #line default

--- a/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/RecurringJobsPage.cshtml.cs
@@ -940,6 +940,16 @@ WriteLiteral("\" style=\"text-decoration: none\">\r\n                           
             
             #line default
             #line hidden
+WriteLiteral("\" style=\"");
+
+
+            
+            #line 230 "..\..\Dashboard\Pages\RecurringJobsPage.cshtml"
+                                                                                                                                                                                      Write($"background-color: {JobHistoryRenderer.GetForegroundStateColor(job.LastJobState ?? EnqueuedState.StateName)};");
+
+            
+            #line default
+            #line hidden
 WriteLiteral("\">\r\n                                                        ");
 
 


### PR DESCRIPTION
There's someplaces, where we indicate Job's state through colors: labels and state cards

1. Job Details Page

![image](https://user-images.githubusercontent.com/6246972/124610417-28b08c00-de79-11eb-9418-2f2824dbc465.png)

2. Recurring Jobs Page

![image](https://user-images.githubusercontent.com/6246972/124610446-30703080-de79-11eb-9fa1-8d1568413062.png)

3. Awaiting Jobs Page 

4. Retries Page 

![image](https://user-images.githubusercontent.com/6246972/124611597-429e9e80-de7a-11eb-8f9d-9f54fb064921.png)

Problem: colors are applied by `styles` attribute, which is not a good practice and blocks potential features, e.g. dark theme.

Solution: move from inline style to modification classes, e.g. `.state-card_state_processing`, `.label_state_awaiting`