### PR TITLE
Fix incorrect validation for HeartbeatInterval

### DIFF
--- a/src/Hangfire.Core/BackgroundJobServerOptions.cs
+++ b/src/Hangfire.Core/BackgroundJobServerOptions.cs
@@ -126,7 +126,7 @@ namespace Hangfire
             get { return _heartbeatInterval; }
             set
             {
-                if (value < TimeSpan.Zero || value > ServerWatchdog.MaxServerCheckInterval)
+                if (value < TimeSpan.Zero || value > ServerWatchdog.MaxHeartbeatInterval)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), $"HeartbeatInterval must be either non-negative and equal to or less than {ServerWatchdog.MaxHeartbeatInterval.Hours} hours");
                 }


### PR DESCRIPTION
Fixed incorrect argument validation in `HeartbeatInterval` setter, which was checking against the wrong constant.

Actual behaviour is unchanged since their values are identical.