### PR TITLE
Support for providing job parameters at job creation time

### DIFF
--- a/src/Hangfire.Core/BackgroundJobClient.cs
+++ b/src/Hangfire.Core/BackgroundJobClient.cs
@@ -137,7 +137,7 @@ namespace Hangfire
         }
 
         /// <inheritdoc />
-        public string Create(Job job, IState state)
+        public string Create(Job job, IState state, params Tuple<string, object>[] parameters)
         {
             if (job == null) throw new ArgumentNullException(nameof(job));
             if (state == null) throw new ArgumentNullException(nameof(state));
@@ -147,6 +147,11 @@ namespace Hangfire
                 using (var connection = _storage.GetConnection())
                 {
                     var context = new CreateContext(_storage, connection, job, state);
+                    foreach (var parameter in parameters)
+                    {
+                        context.Parameters[parameter.Item1] = parameter.Item2;
+                    }
+
                     var backgroundJob = _factory.Create(context);
 
                     return backgroundJob?.Id;

--- a/src/Hangfire.Core/IBackgroundJobClient.cs
+++ b/src/Hangfire.Core/IBackgroundJobClient.cs
@@ -62,7 +62,7 @@ namespace Hangfire
         /// election filters.</para>
         /// </remarks>
         [CanBeNull]
-        string Create([NotNull] Job job, [NotNull] IState state);
+        string Create([NotNull] Job job, [NotNull] IState state, params Tuple<string, object>[] parameters);
 
         /// <summary>
         /// Attempts to change a state of a background job with a given


### PR DESCRIPTION
Couldn't find a way to add job parameters at job creation time, through a IBackgroundJobClient