### PR TITLE
Remove dependency on System.Data.SqlClient for Hangfire.SqlServer

### DIFF
--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Dapper" Version="2.0.4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">

--- a/src/Hangfire.SqlServer/SqlCommandBatch.cs
+++ b/src/Hangfire.SqlServer/SqlCommandBatch.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 
 namespace Hangfire.SqlServer
 {
@@ -33,11 +32,11 @@ namespace Hangfire.SqlServer
             Connection = connection;
             Transaction = transaction;
 
-            if (connection is SqlConnection && SqlCommandSet.IsAvailable && preferBatching)
+            if (preferBatching)
             {
                 try
                 {
-                    _commandSet = new SqlCommandSet();
+                    _commandSet = new SqlCommandSet(connection);
                     _defaultTimeout = _commandSet.BatchCommand.CommandTimeout;
                 }
                 catch (Exception)
@@ -78,9 +77,9 @@ namespace Hangfire.SqlServer
 
         public void Append(DbCommand command)
         {
-            if (_commandSet != null && command is SqlCommand)
+            if (_commandSet != null)
             {
-                _commandSet.Append((SqlCommand)command);
+                _commandSet.Append(command);
             }
             else
             {
@@ -92,8 +91,8 @@ namespace Hangfire.SqlServer
         {
             if (_commandSet != null && _commandSet.CommandCount > 0)
             {
-                _commandSet.Connection = Connection as SqlConnection;
-                _commandSet.Transaction = Transaction as SqlTransaction;
+                _commandSet.Connection = Connection;
+                _commandSet.Transaction = Transaction;
 
                 var batchTimeout = CommandTimeout ?? _defaultTimeout;
 

--- a/src/Hangfire.SqlServer/SqlCommandSet.cs
+++ b/src/Hangfire.SqlServer/SqlCommandSet.cs
@@ -15,7 +15,9 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Data.SqlClient;
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -23,89 +25,122 @@ namespace Hangfire.SqlServer
 {
     internal class SqlCommandSet : IDisposable
     {
-        public  static readonly bool IsAvailable;
+        private static readonly ConcurrentDictionary<Assembly, Type> SqlCommandSetType = new ConcurrentDictionary<Assembly, Type>();
+        private static readonly ConcurrentDictionary<Type, Action<object, DbConnection>> SetConnection = new ConcurrentDictionary<Type, Action<object, DbConnection>>();
+        private static readonly ConcurrentDictionary<Type, Action<object, DbTransaction>> SetTransaction = new ConcurrentDictionary<Type, Action<object, DbTransaction>>();
+        private static readonly ConcurrentDictionary<Type, Func<object, DbCommand>> GetBatchCommand = new ConcurrentDictionary<Type, Func<object, DbCommand>>();
+        private static readonly ConcurrentDictionary<Type, PropertyInfo> BatchCommandProperty = new ConcurrentDictionary<Type, PropertyInfo>();
+        private static readonly ConcurrentDictionary<Type, Action<object, DbCommand>> AppendMethod = new ConcurrentDictionary<Type, Action<object, DbCommand>>();
+        private static readonly ConcurrentDictionary<Type, Func<object, int>> ExecuteNonQueryMethod = new ConcurrentDictionary<Type, Func<object, int>>();
+        private static readonly ConcurrentDictionary<Type, Action<object>> DisposeMethod = new ConcurrentDictionary<Type, Action<object>>();
 
-        private static readonly Type SqlCommandSetType = null;
         private readonly object _instance;
 
-        private static readonly Action<object, SqlConnection> SetConnection = null;
-        private static readonly Action<object, SqlTransaction> SetTransaction = null;
-        private static readonly Func<object, SqlCommand> GetBatchCommand = null;
-        private static readonly Action<object, SqlCommand> AppendMethod = null;
-        private static readonly Func<object, int> ExecuteNonQueryMethod = null;
-        private static readonly Action<object> DisposeMethod = null;
+        private readonly Action<object, DbConnection> _setConnection;
+        private readonly Action<object, DbTransaction> _setTransaction;
+        private readonly Func<object, DbCommand> _getBatchCommand;
+        private readonly Action<object, DbCommand> _appendMethod;
+        private readonly Func<object, int> _executeNonQueryMethod;
+        private readonly Action<object> _disposeMethod;
 
-        static SqlCommandSet()
+        public SqlCommandSet(DbConnection connection)
         {
+            Type sqlCommandSetType;
             try
             {
-                var typeAssembly = typeof(SqlCommand).GetTypeInfo().Assembly;
-                var version = typeAssembly.GetName().Version;
-
-                if (Version.Parse("4.0.0.0") < version && version < Version.Parse("4.6.0.0"))
+                sqlCommandSetType = SqlCommandSetType.GetOrAdd(connection.GetType().GetTypeInfo().Assembly, sqlClientAssembly =>
                 {
-                    // .NET Core version of the System.Data.SqlClient package below 4.7.0 (which
-                    // has assembly version 4.6.0.0) doesn't properly implement the SqlCommandSet
-                    // class, throwing the following exception in run-time:
-                    // ArgumentException: Specified parameter name 'Parameter1' is not valid.
-                    // GitHub Issue: https://github.com/dotnet/corefx/issues/29391
+                    var assemblyName = sqlClientAssembly.GetName();
+                    var version = assemblyName.Version;
 
-                    IsAvailable = false;
-                    return;
-                }
+                    if (assemblyName.Name == "System.Data.SqlClient" && Version.Parse("4.0.0.0") < version && version < Version.Parse("4.6.0.0"))
+                    {
+                        // .NET Core version of the System.Data.SqlClient package below 4.7.0 (which
+                        // has assembly version 4.6.0.0) doesn't properly implement the SqlCommandSet
+                        // class, throwing the following exception in run-time:
+                        // ArgumentException: Specified parameter name 'Parameter1' is not valid.
+                        // GitHub Issue: https://github.com/dotnet/corefx/issues/29391
+                        throw new NotSupportedException(".NET Core version of the System.Data.SqlClient package below 4.7.0 (which has assembly version 4.6.0.0) doesn't properly implement the SqlCommandSet class.");
+                    }
 
-                SqlCommandSetType = typeAssembly.GetType("System.Data.SqlClient.SqlCommandSet");
+                    var type = sqlClientAssembly.GetTypes().FirstOrDefault(x => x.Name == "SqlCommandSet");
 
-                if (SqlCommandSetType == null) return;
+                    if (type == null)
+                        throw new TypeLoadException($"Could not load type 'SqlCommandSet' from assembly '{sqlClientAssembly}'.");
 
-                var p = Expression.Parameter(typeof(object));
-                var converted = Expression.Convert(p, SqlCommandSetType);
+                    return type;
+                });
 
-                var connectionParameter = Expression.Parameter(typeof(SqlConnection));
-                var transactionParameter = Expression.Parameter(typeof(SqlTransaction));
-                var commandParameter = Expression.Parameter(typeof(SqlCommand));
-
-                SetConnection = Expression.Lambda<Action<object, SqlConnection>>(Expression.Call(converted, "set_Connection", null, connectionParameter), p, connectionParameter).Compile();
-                SetTransaction = Expression.Lambda<Action<object, SqlTransaction>>(Expression.Call(converted, "set_Transaction", null, transactionParameter), p, transactionParameter).Compile();
-                GetBatchCommand = Expression.Lambda<Func<object, SqlCommand>>(Expression.Call(converted, "get_BatchCommand", null), p).Compile();
-                AppendMethod = Expression.Lambda<Action<object, SqlCommand>>(Expression.Call(converted, "Append", null, commandParameter), p, commandParameter).Compile();
-                ExecuteNonQueryMethod = Expression.Lambda<Func<object, int>>(Expression.Call(converted, "ExecuteNonQuery", null), p).Compile();
-                DisposeMethod = Expression.Lambda<Action<object>>(Expression.Call(converted, "Dispose", null), p).Compile();
-
-                IsAvailable = true;
+                _setConnection = SetConnection.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    var connectionParameter = Expression.Parameter(typeof(DbConnection));
+                    var connectionProperty = type.GetProperty("Connection", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) ?? throw new MissingMemberException($"Property '{type.FullName}.Connection' not found.");
+                    return Expression.Lambda<Action<object, DbConnection>>(Expression.Assign(Expression.Property(converted, connectionProperty), Expression.Convert(connectionParameter, connectionProperty.PropertyType)), p, connectionParameter).Compile();
+                });
+                _setTransaction = SetTransaction.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    var transactionParameter = Expression.Parameter(typeof(DbTransaction));
+                    var transactionProperty = type.GetProperty("Transaction", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) ?? throw new MissingMemberException($"Property '{type.FullName}.Transaction' not found.");
+                    return Expression.Lambda<Action<object, DbTransaction>>(Expression.Assign(Expression.Property(converted, transactionProperty), Expression.Convert(transactionParameter, transactionProperty.PropertyType)), p, transactionParameter).Compile();
+                });
+                var batchCommandProperty = BatchCommandProperty.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    return type.GetProperty("BatchCommand", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) ?? throw new MissingMemberException($"Property '{type.FullName}.BatchCommand' not found.");
+                });
+                _getBatchCommand = GetBatchCommand.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    return Expression.Lambda<Func<object, DbCommand>>(Expression.Property(converted, batchCommandProperty), p).Compile();
+                });
+                _appendMethod = AppendMethod.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    var batchCommandParameter = Expression.Parameter(typeof(DbCommand));
+                    return Expression.Lambda<Action<object, DbCommand>>(Expression.Call(converted, "Append", null, Expression.Convert(batchCommandParameter, batchCommandProperty.PropertyType)), p, batchCommandParameter).Compile();
+                });
+                _executeNonQueryMethod = ExecuteNonQueryMethod.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    return Expression.Lambda<Func<object, int>>(Expression.Call(converted, "ExecuteNonQuery", null), p).Compile();
+                });
+                _disposeMethod = DisposeMethod.GetOrAdd(sqlCommandSetType, type =>
+                {
+                    var p = Expression.Parameter(typeof(object));
+                    var converted = Expression.Convert(p, type);
+                    return Expression.Lambda<Action<object>>(Expression.Call(converted, "Dispose", null), p).Compile();
+                });
             }
-            catch (Exception)
+            catch (Exception exception)
             {
-                IsAvailable = false;
-            }
-        }
-
-        public SqlCommandSet()
-        {
-            if (!IsAvailable)
-            {
-                throw new PlatformNotSupportedException("SqlCommandSet is not supported on this platform, use regular commands instead");
+                throw new NotSupportedException($"SqlCommandSet for {connection.GetType().FullName} is not supported, use regular commands instead", exception);
             }
 
-            _instance = Activator.CreateInstance(SqlCommandSetType, true);
+            _instance = Activator.CreateInstance(sqlCommandSetType, true);
         }
 
-        public SqlConnection Connection
+        public DbConnection Connection
         {
-            set { SetConnection(_instance, value); }
+            set => _setConnection(_instance, value);
         }
 
-        public SqlTransaction Transaction
+        public DbTransaction Transaction
         {
-            set { SetTransaction(_instance, value); }
+            set => _setTransaction(_instance, value);
         }
 
-        public SqlCommand BatchCommand => GetBatchCommand(_instance);
+        public DbCommand BatchCommand => _getBatchCommand(_instance);
         public int CommandCount { get; private set; }
 
-        public void Append(SqlCommand command)
+        public void Append(DbCommand command)
         {
-            AppendMethod(_instance, command);
+            _appendMethod(_instance, command);
             CommandCount++;
         }
 
@@ -116,12 +151,12 @@ namespace Hangfire.SqlServer
                 return 0;
             }
 
-            return ExecuteNonQueryMethod(_instance);
+            return _executeNonQueryMethod(_instance);
         }
 
         public void Dispose()
         {
-            DisposeMethod(_instance);
+            _disposeMethod(_instance);
         }
     }
 }

--- a/src/Hangfire.SqlServer/SqlServerStorage.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorage.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 #if FEATURE_CONFIGURATIONMANAGER
@@ -390,13 +389,9 @@ namespace Hangfire.SqlServer
         
         private DbConnection DefaultConnectionFactory()
         {
-            if (_options.PreferMicrosoftDataSqlClient)
-            {
-                var connection = Activator.CreateInstance(_microsoftDataSqlClientType, new object[] { _connectionString });
-                if (connection is DbConnection dbConnection) return dbConnection;
-            }
-
-            return new SqlConnection(_connectionString);
+            var connection = _options.SqlClientFactory.CreateConnection() ?? throw new InvalidOperationException($"The provider factory ({_options.SqlClientFactory}) returned a null DbConnection.");
+            connection.ConnectionString = _connectionString;
+            return connection;
         }
 
         private static bool IsRunningOnWindows()

--- a/tests/Hangfire.SqlServer.Tests/SqlServerStorageFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerStorageFacts.cs
@@ -105,9 +105,9 @@ namespace Hangfire.SqlServer.Tests
 
 #if !NET452
         [Fact, CleanDatabase]
-        public void UseConnection_UsesMicrosoftDataSqlClient_WhenCorrespondingOptionIsSet()
+        public void UseConnection_UsesMicrosoftDataSqlClient_WhenSqlClientFactoryIsSet()
         {
-            _options.PreferMicrosoftDataSqlClient = true;
+            _options.SqlClientFactory = Microsoft.Data.SqlClient.SqlClientFactory.Instance;
             var storage = CreateStorage();
             storage.UseConnection(null, connection =>
             {


### PR DESCRIPTION
Use reflection to use either System.Data.SqlClient or Microsoft.Data.SqlClient in order to avoid taking a hard dependency on either one.

It also replaces the `PreferMicrosoftDataSqlClient` boolean property introduced in 751833bb80203710cf20c8d414733fa31d9e88e4 with a `DbProviderFactory` property that is automatically detected with reflection with a preference for System.Data.SqlClient over Microsoft.Data.SqlClient.

Fixes #1735