### PR TITLE
Remove System.Data.SqlClient from the NuGet dependency graph

### DIFF
--- a/nuspecs/Hangfire.SqlServer.nuspec
+++ b/nuspecs/Hangfire.SqlServer.nuspec
@@ -42,13 +42,11 @@
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Data.Common" version="4.1.0" />
-        <dependency id="System.Data.SqlClient" version="4.1.0" />
         <dependency id="Hangfire.Core" version="[0.0.0]" />
       </group>
 
       <group targetFramework="netstandard2.0">
         <dependency id="Hangfire.Core" version="[0.0.0]" />
-        <dependency id="System.Data.SqlClient" version="4.4.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
+++ b/src/Hangfire.SqlServer/SqlServerStorageOptions.cs
@@ -196,7 +196,8 @@ namespace Hangfire.SqlServer
         /// </summary>
         public DbProviderFactory SqlClientFactory
         {
-            get => _sqlClientFactory ?? throw new InvalidOperationException("A reference to either Microsoft.Data.SqlClient or System.Data.SqlClient must exist.");
+            get => _sqlClientFactory ?? throw new InvalidOperationException("Please add a NuGet package reference to either 'Microsoft.Data.SqlClient' or 'System.Data.SqlClient' in your application project. " +
+                                                                            "Hangfire.SqlServer supports both providers but let the consumer decide which one should be used.");
             set => _sqlClientFactory = value ?? throw new ArgumentNullException(nameof(value));
         }
 


### PR DESCRIPTION
Commit cff3c5b39d47aed9323976da5ef30a9196770d9e made it possible for the consumer to choose between System.Data.SqlClient or Microsoft.Data.SqlClient in order to avoid taking a hard dependency on either one.

So the System.Data.SqlClient dependency must also be removed from the nuspec else it will be used anyway.