### PR TITLE
Changed service registration from Transient to Singleton to able consume it

### DIFF
--- a/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
+++ b/src/Hangfire.AspNetCore/HangfireServiceCollectionExtensions.cs
@@ -182,7 +182,7 @@ namespace Hangfire
             [CanBeNull] JobStorage storage,
             [CanBeNull] IEnumerable<IBackgroundProcess> additionalProcesses)
         {
-            services.AddTransient<IHostedService, BackgroundJobServerHostedService>(provider =>
+            services.AddSingleton<IHostedService, BackgroundJobServerHostedService>(provider =>
             {
                 var options = provider.GetService<BackgroundJobServerOptions>() ?? new BackgroundJobServerOptions();
                 return CreateBackgroundJobServerHostedService(provider, storage, additionalProcesses, options);
@@ -197,7 +197,7 @@ namespace Hangfire
             [CanBeNull] IEnumerable<IBackgroundProcess> additionalProcesses,
             [NotNull] Action<IServiceProvider, BackgroundJobServerOptions> optionsAction)
         {
-            services.AddTransient<IHostedService, BackgroundJobServerHostedService>(provider =>
+            services.AddSingleton<IHostedService, BackgroundJobServerHostedService>(provider =>
             {
                 var options = new BackgroundJobServerOptions();
                 optionsAction(provider, options);


### PR DESCRIPTION
Seems like it makes more sense to register the service as Singleton to allow any consumer inject it into its classes rather than having this transient and not being able to consume it at all.