### PR TITLE
Document the exception for the Job Cancellation Token

### DIFF
--- a/src/Hangfire.Core/IJobCancellationToken.cs
+++ b/src/Hangfire.Core/IJobCancellationToken.cs
@@ -21,6 +21,18 @@ namespace Hangfire
     {
         CancellationToken ShutdownToken { get; }
 
+        /// <summary>
+        /// Throws a <see cref="System.OperationCanceledException">OperationCanceledException</see> if
+        /// this token has had cancellation requested.
+        /// </summary>
+        /// <remarks>
+        /// This method provides functionality equivalent to:
+        /// <code>
+        /// if (token.ShutdownToken.IsCancellationRequested)
+        ///    throw new OperationCanceledException(token);
+        /// </code>
+        /// </remarks>
+        /// <exception cref="System.OperationCanceledException">The token has had cancellation requested.</exception>
         void ThrowIfCancellationRequested();
     }
 }

--- a/src/Hangfire.Core/JobCancellationToken.cs
+++ b/src/Hangfire.Core/JobCancellationToken.cs
@@ -31,18 +31,7 @@ namespace Hangfire
 
         public static IJobCancellationToken Null => null;
 
-        /// <summary>
-        /// Throws a <see cref="System.OperationCanceledException">OperationCanceledException</see> if
-        /// this token has had cancellation requested.
-        /// </summary>
-        /// <remarks>
-        /// This method provides functionality equivalent to:
-        /// <code>
-        /// if (token.ShutdownToken.IsCancellationRequested)
-        ///    throw new OperationCanceledException(token);
-        /// </code>
-        /// </remarks>
-        /// <exception cref="System.OperationCanceledException">The token has had cancellation requested.</exception>
+        /// <inheritdoc cref="IJobCancellationToken.ThrowIfCancellationRequested" />
         public void ThrowIfCancellationRequested()
         {
             ShutdownToken.ThrowIfCancellationRequested();

--- a/src/Hangfire.Core/JobCancellationToken.cs
+++ b/src/Hangfire.Core/JobCancellationToken.cs
@@ -31,6 +31,18 @@ namespace Hangfire
 
         public static IJobCancellationToken Null => null;
 
+        /// <summary>
+        /// Throws a <see cref="System.OperationCanceledException">OperationCanceledException</see> if
+        /// this token has had cancellation requested.
+        /// </summary>
+        /// <remarks>
+        /// This method provides functionality equivalent to:
+        /// <code>
+        /// if (token.ShutdownToken.IsCancellationRequested)
+        ///    throw new OperationCanceledException(token);
+        /// </code>
+        /// </remarks>
+        /// <exception cref="System.OperationCanceledException">The token has had cancellation requested.</exception>
         public void ThrowIfCancellationRequested()
         {
             ShutdownToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Updates the `JobCancellationToken` to include intellisense hints for the exception it throws for `ThrowIfCancellationRequested()`.

These comments were taken from CancellationToken comments.