### PR TITLE
Update System.Data.SqlClient to 4.8.5 (fixes  GHSA-8g2p-5pqh-5jmc)

### DIFF
--- a/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
+++ b/src/Hangfire.SqlServer/Hangfire.SqlServer.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Dapper" Version="2.0.4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">


### PR DESCRIPTION
Update `System.Data.SqlClient` to 4.8.5
This should fix vulnerability GHSA-8g2p-5pqh-5jmc
Fixes #2123