### PR TITLE
Add JobCount method to MonitoringApi to get count of jobs in any state

### DIFF
--- a/src/Hangfire.Core/Storage/IMonitoringApi.cs
+++ b/src/Hangfire.Core/Storage/IMonitoringApi.cs
@@ -35,6 +35,7 @@ namespace Hangfire.Storage
         JobList<FailedJobDto> FailedJobs(int from, int count);
         JobList<DeletedJobDto> DeletedJobs(int from, int count);
 
+        long JobCount(string stateName);
         long ScheduledCount();
         long EnqueuedCount(string queue);
         long FetchedCount(string queue);

--- a/src/Hangfire.Core/Storage/JobStorageMonitor.cs
+++ b/src/Hangfire.Core/Storage/JobStorageMonitor.cs
@@ -39,6 +39,7 @@ namespace Hangfire.Storage
             throw JobStorageFeatures.GetNotSupportedException(JobStorageFeatures.Monitoring.AwaitingJobs);
         }
 
+        public abstract long JobCount(string stateName);
         public abstract long ScheduledCount();
         public abstract long EnqueuedCount(string queue);
         public abstract long FetchedCount(string queue);

--- a/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
+++ b/src/Hangfire.SqlServer/SqlServerMonitoringApi.cs
@@ -42,6 +42,11 @@ namespace Hangfire.SqlServer
             _jobListLimit = jobListLimit;
         }
 
+        public override long JobCount(string stateName)
+        {
+            return UseConnection(connection => GetNumberOfJobsByStateName(connection, stateName));
+        }
+
         public override long ScheduledCount()
         {
             return UseConnection(connection => 


### PR DESCRIPTION
Currently monitoring API only supports getting job count for the given states (e.g. processing, scheduled, failed)
Useful for developers who create jobs with custom states.
Signed commits now.