### PR TITLE
state-card-state-active not very dark

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire-dark.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire-dark.css
@@ -194,7 +194,7 @@
     */
 
     .state-card-state-active .state-card-body {
-        background-color: #F5F5F5 !important;
+        background-color: #333 !important;
     }
 
     /* Stats */

--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire-dark.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire-dark.css
@@ -191,12 +191,11 @@
     .state-card-state-active .state-card-title {
         color: #999 !important;
     }
+    */
 
     .state-card-state-active .state-card-body {
         background-color: #F5F5F5 !important;
     }
-
-    */
 
     /* Stats */
 


### PR DESCRIPTION
Fix when state-card is active. It retained the light background color. The other card states appear to override to transparent.

Before:
![image](https://user-images.githubusercontent.com/700740/236992722-8247b28e-2e23-45dc-8812-3e78969cf9b2.png)

After:
![image](https://user-images.githubusercontent.com/700740/236992739-0f6e13a8-a575-4ccc-8746-22d1a4d05c79.png)
