### PR TITLE
Added the possibility to inform a FaviconPath on DashboardOptions

### DIFF
--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -26,7 +26,16 @@
         }
     }
     @{ var version = GetType().GetTypeInfo().Assembly.GetName().Version; }
-    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
+
+    @if(!string.IsNullOrWithSpace(DashboardOptions.FaviconPath))
+    {
+        @: <link rel="shortcut icon" href="@DashboardOptions.FaviconPath" type="image/x-icon">
+    }
+    else
+    {
+        @: <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
+    }
+    
     <link rel="stylesheet" href="@Url.To($"/css{version.Major}{version.Minor}{version.Build}0{Math.Abs(DashboardRoutes.StylesheetsHashCode)}")">
     @if (DashboardOptions.DarkModeEnabled)
     {

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -107,5 +107,10 @@ namespace Hangfire
         /// or excluding the corresponding CSS files.
         /// </summary>
         public bool DarkModeEnabled { get; set; }
+
+        /// <summary>
+        /// Optional favicon path
+        /// </summary>
+        public string FaviconPath { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
I added a new property called FaviconPath inside DashboardOptions, and also added the implementation that uses it whenever the property is not null or whitespace inside the LayoutPage.cshtml