### PR TITLE
Add PerformanceDuration to SucceededJobDto

### DIFF
--- a/src/Hangfire.Core/Storage/Monitoring/SucceededJobDto.cs
+++ b/src/Hangfire.Core/Storage/Monitoring/SucceededJobDto.cs
@@ -30,6 +30,7 @@ namespace Hangfire.Storage.Monitoring
         public JobLoadException LoadException { get; set; }
         public InvocationData InvocationData { get; set; }
         public object Result { get; set; }
+        public long? PerformanceDuration { get; set; }
         public long? TotalDuration { get; set; }
         public DateTime? SucceededAt { get; set; }
         public bool InSucceededState { get; set; }


### PR DESCRIPTION
PerformanceDuration has been added to SucceededJobDto, to be able to distinguish performance duration from total duration including latency.