### PR TITLE
Check if response `HasStarted` before changing it.

### DIFF
--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardResponse.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardResponse.cs
@@ -35,25 +35,45 @@ namespace Hangfire.Dashboard
         public override string ContentType
         {
             get { return _context.Response.ContentType; }
-            set { _context.Response.ContentType = value; }
+            set
+            {
+                if (!_context.Response.HasStarted)
+                {
+                    _context.Response.ContentType = value;
+                }
+            }
         }
 
         public override int StatusCode
         {
             get { return _context.Response.StatusCode; }
-            set { _context.Response.StatusCode = value; }
+            set
+            {
+                if (!_context.Response.HasStarted)
+                {
+                    _context.Response.StatusCode = value;
+                }
+            }
         }
 
         public override Stream Body => _context.Response.Body;
 
         public override Task WriteAsync(string text)
         {
-            return _context.Response.WriteAsync(text);
+            if (!_context.Response.HasStarted)
+            {
+                return _context.Response.WriteAsync(text);
+            }
+
+            return Task.CompletedTask;;
         }
 
         public override void SetExpire(DateTimeOffset? value)
         {
-            _context.Response.Headers["Expires"] = value?.ToString("r", CultureInfo.InvariantCulture);
+            if (!_context.Response.HasStarted)
+            {
+                _context.Response.Headers["Expires"] = value?.ToString("r", CultureInfo.InvariantCulture);
+            }
         }
     }
 }

--- a/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardResponse.cs
+++ b/src/Hangfire.AspNetCore/Dashboard/AspNetCoreDashboardResponse.cs
@@ -65,7 +65,7 @@ namespace Hangfire.Dashboard
                 return _context.Response.WriteAsync(text);
             }
 
-            return Task.CompletedTask;;
+            return Task.FromResult(true);
         }
 
         public override void SetExpire(DateTimeOffset? value)


### PR DESCRIPTION
ASP.NET Core does not buffer the http response body. This means that the very first time the response is written, the headers are sent along with that chunk of the body to the client. When this happens, it's no longer possible to change response headers.

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md#avoid-adding-headers-after-the-httpresponse-has-started