### PR TITLE
Un-reverse the sense of window arguments in TrimList()

### DIFF
--- a/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
+++ b/src/Hangfire.SqlServer/SqlServerWriteOnlyTransaction.cs
@@ -391,7 +391,7 @@ insert into [{_storage.SchemaName}].List ([Key], Value) values (@key, @value);",
 
             string trimSql =
 $@";with cte as (
-    select row_number() over (order by Id desc) as row_num
+    select row_number() over (order by Id) as row_num
     from [{_storage.SchemaName}].List with (xlock, forceseek)
     where [Key] = @key)
 delete from cte where row_num not between @start and @end";

--- a/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.SqlServer.Tests/SqlServerWriteOnlyTransactionFacts.cs
@@ -1234,6 +1234,7 @@ select scope_identity() as Id";
                     x.InsertToList("my-key", "1");
                     x.InsertToList("my-key", "2");
                     x.InsertToList("my-key", "3");
+                    x.InsertToList("my-key", "4");
                     x.TrimList("my-key", 1, 2);
                 }, useMicrosoftDataSqlClient, useBatching);
 


### PR DESCRIPTION
Description:
The SQL Server list trimming doesn't work as expected as it counts from the back of the list, not the front. That's not the intended behaviour, and it means (in my case) a shared lock is needed when trimming from the front, to prevent items being added concurrently to the back (affecting the count). Fixes #2364 


Changes:
- When trimming list items, don't reverse the item order before working out which ones to keep. 
- Update one unit test to make it fail/pass based on this change.
 
