### PR TITLE
Fix UrlHelper.To in Obsolete case

### DIFF
--- a/src/Hangfire.Core/Dashboard/UrlHelper.cs
+++ b/src/Hangfire.Core/Dashboard/UrlHelper.cs
@@ -48,8 +48,7 @@ namespace Hangfire.Dashboard
                        _owinContext?.Request.PathBase.Value ??
 #endif
                        _context.Request.PathBase
-                       + relativePath
-                   );
+                   ) + relativePath;
         }
 
         public string Home()


### PR DESCRIPTION
The piece of code in question:
```C#
        public string To(string relativePath)
        {
            return _context.Options.PrefixPath +
                   (
#if FEATURE_OWIN
                       _owinContext?.Request.PathBase.Value ??
#endif
                       _context.Request.PathBase
                       + relativePath
                   );
        }

```

With FEATURE_OWIN this compiles to the following:
```C#
return _context.Options.PrefixPath +
    (_owinContext?.Request.PathBase.Value ??
        (_context.Request.PathBase + relativePath));
```

Note how in the Owin case the `relativePath` value is lost.

Not a big deal since the Owin case is deprecated via constructor attribute.