### PR TITLE
add infos in failed jobs logs #2454

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -254,7 +254,7 @@ namespace Hangfire
                 if (LogEvents)
                 {
                     _logger.ErrorException(
-                        $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred.",
+                        $"Failed to process the job '{context.BackgroundJob.Job?.Type.Name}' with id '{context.BackgroundJob.Id}': an exception occurred.",
                         failedState.Exception);
                 }
             }
@@ -322,7 +322,7 @@ namespace Hangfire
             if (LogEvents)
             {
                 _logger.WarnException(
-                    $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred. Retry attempt {retryAttempt} of {Attempts} will be performed in {delay}.",
+                    $"Failed to process the job '{context.BackgroundJob.Job?.Type.Name}' with id '{context.BackgroundJob.Id}': an exception occurred. Retry attempt {retryAttempt} of {Attempts} will be performed in {delay}.",
                     failedState.Exception);
             }
         }
@@ -344,7 +344,7 @@ namespace Hangfire
             if (LogEvents)
             {
                 _logger.WarnException(
-                    $"Failed to process the job '{context.BackgroundJob.Id}': an exception occured. Job was automatically deleted because the retry attempt count exceeded {Attempts}.",
+                    $"Failed to process the job '{context.BackgroundJob.Job?.Type.Name}' with id '{context.BackgroundJob.Id}': an exception occured. Job was automatically deleted because the retry attempt count exceeded {Attempts}.",
                     failedState.Exception);
             }
         }


### PR DESCRIPTION
Hello :) 

I'd like to add some info about the `Job name` in the failed jobs logs in order to create some alerting :
Something like this ⬇️ 

From : 
```csharp                
                         _logger.ErrorException(
                        $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred.",
                        failedState.Exception);
```

To : 
```csharp                   
                        _logger.ErrorException(
                        $"Failed to process the job '{context.BackgroundJob.Job?.Type.Name}' with id '{context.BackgroundJob.Id}': an exception occurred.",
                        failedState.Exception);
```


Is it possible ? I have a branch already ready in local if you want, but I can't create a PR (I'm pretty new, feel free to tell me if it's not the correct way of asking :) )


Thank you in advance
