### PR TITLE
Add ActivitySource to start producer and consumer activities (spans) to support OpenTelemetry observability

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,7 @@
 
   <trustedSigners> 
     <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-      <owners>Microsoft;aspnet;dotnetframework;HangfireIO;xunit;jamesnk;kzu;castleproject;psake;ILRepack;davidebbo;StackExchange;Dapper;brady.holt;dwhelan;raboof;damianh;</owners>
+      <owners>Microsoft;aspnet;dotnetframework;HangfireIO;xunit;jamesnk;kzu;castleproject;psake;ILRepack;davidebbo;StackExchange;Dapper;brady.holt;dwhelan;raboof;damianh;OpenTelemetry;</owners>
       <certificate fingerprint="5a2901d6ada3d18260b9c6dfe2133c95d74b9eef6ae0e5dc334c8454d1477df4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <certificate fingerprint="1f4b311d9acc115c8dc8018b5a49e00fce6da8e2855f9f014ca6f34570bc482d" hashAlgorithm="SHA256" allowUntrustedRoot="false" /> 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,37 @@ using (new BackgroundJobServer())
 }
 ```
 
+Observability
+-------------
+
+**Open Telemetry**
+
+OpenTelemetry is an open-source standard for distributed tracing, which allows you to collect and analyze data about the performance of your systems. Hangfire can be configured to use OpenTelemetry to instrument message handling, so that you can collect telemetry data about messages as they flow through your system.
+
+Hangfire has a default filter that starts a Producer activity when a background job is scheduled, and start a Consumer activity when a job is performed. The distributed trace correlation information of the creation context is persisted with the job and used for the consumer (even if run on a different server), allows jobs to be correlated. Note that a recurring job creates a new activity each time it runs.
+
+For more information see: <https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/>
+
+**Tracing**
+
+This example is using following packages:
+- `OpenTelemetry.Extensions.Hosting`
+- `OpenTelemetry.Exporter.Console`
+
+```csharp
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(b => b
+        .AddSource(DiagnosticsActivityFilter.DefaultListenerName) // Hangfire ActivitySource
+        .AddConsoleExporter() // Any OTEL suportable exporter can be used here
+    );
+```
+
+That's it, your application will start exporting Hangfire related traces within your application.
+
 Questions? Problems?
 ---------------------
 

--- a/samples/NetCoreSample/NetCoreSample.csproj
+++ b/samples/NetCoreSample/NetCoreSample.csproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/NetCoreSample/Program.cs
+++ b/samples/NetCoreSample/Program.cs
@@ -1,27 +1,42 @@
 ﻿using System;
 using System.Data;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.Annotations;
 using Hangfire.Client;
 using Hangfire.Common;
+using Hangfire.InMemory;
 using Hangfire.Server;
 using Hangfire.SqlServer;
 using Hangfire.States;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace;
 
 namespace NetCoreSample
 {
     class Program
     {
+        // To use in-memory store instead of database:
+        //   dotnet run -- --UseInMemory true
+
+        // To show trace console exporter output: 
+        //   dotnet run -- --TraceConsoleExporter true
+
+        public static readonly ActivitySource ActivitySource = new ActivitySource(nameof(NetCoreSample));
+
         static async Task Main(string[] args)
         {
-            var host = new HostBuilder()
-                .ConfigureLogging(x => x.AddConsole().SetMinimumLevel(LogLevel.Information))
+            var host = Host.CreateDefaultBuilder(args)
+                .ConfigureLogging(x => x
+                    .AddSimpleConsole()
+                    .SetMinimumLevel(LogLevel.Information))
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.Configure<HostOptions>(option =>
@@ -49,19 +64,40 @@ namespace NetCoreSample
                     services.TryAddSingleton<IBackgroundJobStateChanger>(x => new CustomBackgroundJobStateChanger(
                             new BackgroundJobStateChanger(x.GetRequiredService<IJobFilterProvider>())));
 
-                    services.AddHangfire((provider, configuration) => configuration
+                    var useInMemory = hostContext.Configuration.GetValue<bool>("UseInMemory");
+                    services.AddHangfire((provider, configuration) => {
+                        configuration
                         .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
-                        .UseSimpleAssemblyNameTypeSerializer()
-                        .UseSqlServerStorage(
-                            @"Server=.\;Database=Hangfire.Sample;Trusted_Connection=True;", 
-                            provider.GetRequiredService<SqlServerStorageOptions>()));
+                        .UseSimpleAssemblyNameTypeSerializer();
+                        if (useInMemory) {
+                            configuration.UseInMemoryStorage();
+                        }
+                        else
+                        {
+                            configuration.UseSqlServerStorage(
+                                @"Server=.\;Database=Hangfire.Sample;Trusted_Connection=True;", 
+                                provider.GetRequiredService<SqlServerStorageOptions>());
+                        }
+                    });
 
                     services.AddHostedService<RecurringJobsService>();
+                    services.AddHostedService<BackgroundJobsService>();
                     services.AddHangfireServer(options =>
                     {
                         options.StopTimeout = TimeSpan.FromSeconds(15);
                         options.ShutdownTimeout = TimeSpan.FromSeconds(30);
                     });
+
+                    var traceConsoleExporter = hostContext.Configuration.GetValue<bool>("TraceConsoleExporter");
+                    services.AddOpenTelemetry()
+                        .WithTracing(tracing => {
+                            tracing.AddSource(DiagnosticsActivityFilter.DefaultListenerName);
+                            tracing.AddSource(nameof(NetCoreSample));
+                            if (traceConsoleExporter)
+                            {
+                                tracing.AddConsoleExporter();
+                            }
+                        });
                 })
                 .Build();
 
@@ -123,24 +159,39 @@ namespace NetCoreSample
     {
         private readonly IBackgroundJobClient _backgroundJobs;
         private readonly IRecurringJobManager _recurringJobs;
-        private readonly ILogger<RecurringJobScheduler> _logger;
+        private readonly ILogger<RecurringJobsService> _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
         public RecurringJobsService(
             [NotNull] IBackgroundJobClient backgroundJobs,
             [NotNull] IRecurringJobManager recurringJobs,
-            [NotNull] ILogger<RecurringJobScheduler> logger)
+            [NotNull] ILogger<RecurringJobsService> logger,
+            ILoggerFactory loggerFactory)
         {
             _backgroundJobs = backgroundJobs ?? throw new ArgumentNullException(nameof(backgroundJobs));
             _recurringJobs = recurringJobs ?? throw new ArgumentNullException(nameof(recurringJobs));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _loggerFactory = loggerFactory;
         }
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
             try
             {
-                _recurringJobs.AddOrUpdate("seconds", () => Console.WriteLine("Hello, seconds!"), "*/15 * * * * *");
-                _recurringJobs.AddOrUpdate("minutely", () => Console.WriteLine("Hello, world!"), Cron.Minutely);
+                _logger.LogInformation("Creating recurring jobs");
+
+                using (var activity =  Program.ActivitySource.StartActivity("enqueue seconds"))
+                {
+                    _logger.LogInformation("Creating job seconds, trace_id={ActivityTraceId}", activity.TraceId);
+                    _recurringJobs.AddOrUpdate("seconds", () => Hello("seconds"), "*/15 * * * * *");
+                }
+
+                using (var activity =  Program.ActivitySource.StartActivity("enqueue minutely"))
+                {
+                    _logger.LogInformation("Creating job minutely (hello world), trace_id={ActivityTraceId}", activity.TraceId);
+                    _recurringJobs.AddOrUpdate("minutely", () => Hello("world"), Cron.Minutely);
+                }
+
                 _recurringJobs.AddOrUpdate("hourly", () => Console.WriteLine("Hello"), "25 15 * * *");
                 _recurringJobs.AddOrUpdate("neverfires", () => Console.WriteLine("Can only be triggered"), "0 0 31 2 *");
 
@@ -161,5 +212,71 @@ namespace NetCoreSample
 
             return Task.CompletedTask;
         }
+
+        public void Hello(string name)
+        {
+            Console.WriteLine($"Hello, {name}!");
+            var logger = _loggerFactory.CreateLogger<RecurringJobsService>();
+            logger.LogInformation("Hello, {Name}! trace_id={ActivityTraceId}", name, Activity.Current?.TraceId);
+        }
     }
+
+    internal class BackgroundJobsService : BackgroundService
+    {
+        private readonly IBackgroundJobClient _backgroundJobs;
+        private readonly ILogger _logger;
+        private readonly ILoggerFactory _loggerFactory;
+
+        public BackgroundJobsService(
+            [NotNull] IBackgroundJobClient backgroundJobs,
+            [NotNull] ILogger<BackgroundJobsService> logger,
+            ILoggerFactory loggerFactory)
+        {
+            _backgroundJobs = backgroundJobs ?? throw new ArgumentNullException(nameof(backgroundJobs));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _loggerFactory = loggerFactory;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                _logger.LogInformation("Creating backgriound jobs");
+
+                using (var activity =  Program.ActivitySource.StartActivity("enqueue"))
+                {
+                    _logger.LogInformation("Creating job 10, trace_id={ActivityTraceId}", activity.TraceId);
+                    var jobId1 = _backgroundJobs.Enqueue(() => Job(10));
+                }
+                using (var activity =  Program.ActivitySource.StartActivity("schedule"))
+                {
+                    _logger.LogInformation("Scheduling job 20, continue with 30, trace_id={ActivityTraceId}", activity.TraceId);
+                    var jobId2 = _backgroundJobs.Schedule(() => Job(20), TimeSpan.FromSeconds(30));
+                    var jobId3 = _backgroundJobs.ContinueJobWith(jobId2, () => Job(30));
+                }
+                using (var activity =  Program.ActivitySource.StartActivity("error"))
+                {
+                    _logger.LogInformation("Scheduling error job 40, trace_id={ActivityTraceId}", activity.TraceId);
+                    var jobId4 = _backgroundJobs.Schedule(() => Job(40), TimeSpan.FromSeconds(60));
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "An exception occurred while creating recurring jobs.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Job(int counter) {
+            Console.WriteLine("Hello, job {0}!", counter);
+            var logger = _loggerFactory.CreateLogger<BackgroundJobsService>();
+            logger.LogInformation("Hello, job {Counter} trace_id={ActivityTraceId}", counter, Activity.Current?.TraceId);
+            if (counter == 40)
+            {
+                throw new InvalidOperationException("Counter 40 is invalid.");
+            }
+        }
+    }
+
 }

--- a/samples/NetCoreSample/packages.lock.json
+++ b/samples/NetCoreSample/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net6.0": {
+      "Hangfire.InMemory": {
+        "type": "Direct",
+        "requested": "[1.0.0, )",
+        "resolved": "1.0.0",
+        "contentHash": "56H71lfcqn5sN/8Bjj9hOLGTG5HIERLRuMsRJTFpw0Tsq5ck5OUkNvtUw92s7bwD3PRKOo4PkDGqNs9KugaqoQ==",
+        "dependencies": {
+          "Hangfire.Core": "1.8.0"
+        }
+      },
       "Microsoft.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[8.0.1, )",
@@ -45,6 +54,25 @@
           "Microsoft.Extensions.Options": "8.0.2",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Json": "8.0.5"
+        }
+      },
+      "OpenTelemetry.Exporter.Console": {
+        "type": "Direct",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "TbScDLSc6kcji+/wZYIf8/HBV2SnttzN7PNxr3TYczlmGlU4K2ugujp6seSktEO4OaAvKRd7Y3CG3SKNj0C+1Q==",
+        "dependencies": {
+          "OpenTelemetry": "1.9.0"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "Direct",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "QBQPrKDVCXxTBE+r8tgjmFNKKHi4sKyczmip2XGUcjy8kk3quUNhttnjiMqC4sU50Hemmn4i5752Co26pnKe3A==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.0",
+          "OpenTelemetry": "1.9.0"
         }
       },
       "Cronos": {
@@ -311,6 +339,33 @@
         "type": "Transitive",
         "resolved": "11.0.1",
         "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
+        "dependencies": {
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        }
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.9.0",
+        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "OpenTelemetry.Api": "1.9.0"
+        }
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",

--- a/samples/NetCoreSample/packages.lock.json
+++ b/samples/NetCoreSample/packages.lock.json
@@ -358,7 +358,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       },
       "hangfire.netcore": {

--- a/src/Hangfire.AspNetCore/packages.lock.json
+++ b/src/Hangfire.AspNetCore/packages.lock.json
@@ -85,12 +85,18 @@
         "resolved": "11.0.1",
         "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
+      },
       "hangfire.core": {
         "type": "Project",
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       },
       "hangfire.netcore": {
@@ -2163,13 +2169,37 @@
       },
       "System.Buffers": {
         "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
         "resolved": "4.4.0",
-        "contentHash": "AwarXzzoDwX6BgrhjoJsk6tUezZEozOT5Y9QKF94Gl4JK91I4PIIBkBco9068Y9/Dra8Dkbie99kXB8+1BaYKw=="
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "9dLLuBxr5GNmOfl2jSMcsHuteEg32BEfUotmmUkmZjpR3RpVHE8YQwt0ow3p6prwA1ME8WqDVZqrr8z6H8G+Kw=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -2199,7 +2229,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       },
       "hangfire.netcore": {

--- a/src/Hangfire.Core/DiagnosticsActivityFilter.cs
+++ b/src/Hangfire.Core/DiagnosticsActivityFilter.cs
@@ -1,0 +1,161 @@
+#if NETSTANDARD2_0
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using Hangfire.Client;
+using Hangfire.Server;
+using Hangfire.States;
+using Hangfire.Storage;
+
+namespace Hangfire
+{
+    public sealed class DiagnosticsActivityFilter : IClientFilter, IServerFilter, IDisposable
+    {
+        public const string DefaultListenerName = "Hangfire";
+
+        private static readonly ActivitySource DefaultActivitySource = new ActivitySource(DefaultListenerName);
+
+        private const string ActivityItemsKeyName = "Diagnostics.Activity";
+
+        private const string ExceptionEventName = "exception";
+        private const string ExceptionMessageTag = "exception.message";
+        private const string ExceptionStackTraceTag = "exception.stacktrace";
+        private const string ExceptionTypeTag = "exception.type";
+
+        private const string MessagingDestinationNameTag = "messaging.destination.name";
+        private const string MessagingMessageId = "messaging.message.id";
+        private const string MessagingOperationName = "messaging.operation.name";
+        private const string MessagingOperationType = "messaging.operation.type";
+
+        private const string TraceParentParameterName = "traceparent";
+        private const string TraceStateParameterName = "tracestate";
+
+        private readonly ActivitySource _activitySource;
+
+        public DiagnosticsActivityFilter()
+        {
+            _activitySource = DefaultActivitySource;
+        }
+
+        public DiagnosticsActivityFilter(string? activitySourceName)
+        {
+            var name = activitySourceName ?? throw new ArgumentNullException(nameof(activitySourceName));
+            _activitySource = new ActivitySource(name);
+        }
+
+        public void OnCreating(CreatingContext context)
+        {
+            var activity = _activitySource.StartActivity(
+                $"create_job {context.Job.Type.Name}.{context.Job.Method.Name}",
+                ActivityKind.Producer);
+
+            if (activity != null)
+            {
+                activity.SetTag(MessagingOperationName, "create_job");
+                activity.SetTag(MessagingDestinationNameTag, $"{context.Job.Type.Name}.{context.Job.Method.Name}");
+                activity.SetTag(MessagingOperationType, "create");
+
+                activity.SetTag("job.type", context.Job.Type.FullName);
+                activity.SetTag("job.method", context.Job.Method.Name);
+                activity.SetTag("job.state", context.InitialState?.Name);
+                activity.SetTag("job.storage", context.Storage.ToString());
+
+                context.SetJobParameter(TraceParentParameterName, activity.Id);
+                context.SetJobParameter(TraceStateParameterName, activity.TraceStateString);
+
+                context.Items[ActivityItemsKeyName] = activity;
+            }
+        }
+
+        public void OnCreated(CreatedContext context)
+        {
+            if (context.Items.TryGetValue(ActivityItemsKeyName, out var item) &&
+                item is Activity activity)
+            {
+                if (context.Exception == null)
+                {
+                    // NOTE: Need library 6.0 for SetStatus(ActivityStatusCode.Ok) (use tags instead)
+                    activity.SetTag("otel.status_code", "OK");
+
+                    activity.SetTag(MessagingMessageId, context.BackgroundJob.Id);
+                    activity.SetTag("job.id", context.BackgroundJob.Id);
+                }
+                else
+                {
+                    // NOTE: Library 9.0 has AddException (manually add event instead)
+                    var exceptionTags = new ActivityTagsCollection
+                    {
+                        { ExceptionMessageTag, context.Exception.Message },
+                        { ExceptionTypeTag, context.Exception.GetType().ToString() },
+                        { ExceptionStackTraceTag, context.Exception.ToString() }
+                    };
+                    activity.AddEvent(new ActivityEvent(ExceptionEventName, tags: exceptionTags));
+
+                    // NOTE: Need library 6.0 for SetStatus(ActivityStatusCode.Error, "Exception") (use tags instead)
+                    activity.SetTag("otel.status_code", "ERROR");
+                    activity.SetTag("otel.status_description", "Exception");
+                }
+
+                activity.Dispose();
+            }
+        }
+
+        public void OnPerforming(PerformingContext context)
+        {
+            var parentId = context.GetJobParameter<string>(TraceParentParameterName);
+            var parentState = context.GetJobParameter<string>(TraceStateParameterName);
+            ActivityContext.TryParse(parentId, parentState, out var parentCtx);
+
+            var activity = _activitySource.StartActivity(
+                $"perform_job {context.BackgroundJob.Job.Type.Name}.{context.BackgroundJob.Job.Method.Name}",
+                ActivityKind.Consumer,
+                parentCtx);
+
+            if (activity != null)
+            {
+                activity.SetTag(MessagingOperationName, "perform_job");
+                activity.SetTag(MessagingDestinationNameTag, $"{context.BackgroundJob.Job.Type.Name}.{context.BackgroundJob.Job.Method.Name}");
+                activity.SetTag(MessagingOperationType, "process");
+                activity.SetTag(MessagingMessageId, context.BackgroundJob.Id);
+
+                context.Items[ActivityItemsKeyName] = activity;
+            }
+        }
+
+        public void OnPerformed(PerformedContext context)
+        {
+            if (context.Items.TryGetValue(ActivityItemsKeyName, out var item) && item is Activity activity)
+            {
+                if (context.Exception == null)
+                {
+                    // NOTE: Need library 6.0 for SetStatus(ActivityStatusCode.Ok) (use tags instead)
+                    activity.SetTag("otel.status_code", "OK");
+                }
+                else
+                {
+                    // NOTE: Library 9.0 has AddException (manually add event instead)
+                    var exceptionTags = new ActivityTagsCollection
+                    {
+                        { ExceptionMessageTag, context.Exception.Message },
+                        { ExceptionTypeTag, context.Exception.GetType().ToString() },
+                        { ExceptionStackTraceTag, context.Exception.ToString() }
+                    };
+                    activity.AddEvent(new ActivityEvent(ExceptionEventName, tags: exceptionTags));
+
+                    // NOTE: Need library 6.0 for SetStatus(ActivityStatusCode.Error, "Exception") (use tags instead)
+                    activity.SetTag("otel.status_code", "ERROR");
+                    activity.SetTag("otel.status_description", "Exception");
+                }
+
+                activity.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            _activitySource?.Dispose();
+        }
+    }
+}
+#endif

--- a/src/Hangfire.Core/GlobalJobFilters.cs
+++ b/src/Hangfire.Core/GlobalJobFilters.cs
@@ -34,6 +34,9 @@ namespace Hangfire
             Filters.Add(new AutomaticRetryAttribute());
             Filters.Add(new StatisticsHistoryAttribute());
             Filters.Add(new ContinuationsSupportAttribute());
+#if NETSTANDARD2_0
+            Filters.Add(new DiagnosticsActivityFilter());
+#endif
         }
 
         /// <summary>

--- a/src/Hangfire.Core/Hangfire.Core.csproj
+++ b/src/Hangfire.Core/Hangfire.Core.csproj
@@ -34,6 +34,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" NoWarn="NU1903" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3' or '$(TargetFramework)'=='netstandard2.0'">

--- a/src/Hangfire.Core/packages.lock.json
+++ b/src/Hangfire.Core/packages.lock.json
@@ -1185,6 +1185,16 @@
         "resolved": "1.3.0",
         "contentHash": "tOdf1XpHE2YQJpBERplZA2kMTJQtJnKzSc7GMO/yeNNGuXNueVqySfIr/gfU1vx9k2FO8u0zD4mtnZGwKQM+Zg=="
       },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Direct",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -1199,6 +1209,31 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       }
     }
   }

--- a/src/Hangfire.NetCore/packages.lock.json
+++ b/src/Hangfire.NetCore/packages.lock.json
@@ -1264,12 +1264,47 @@
         "resolved": "11.0.1",
         "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
       },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
+      },
       "hangfire.core": {
         "type": "Project",
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       }
     },
@@ -1366,17 +1401,26 @@
       },
       "System.Buffers": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "AwarXzzoDwX6BgrhjoJsk6tUezZEozOT5Y9QKF94Gl4JK91I4PIIBkBco9068Y9/Dra8Dkbie99kXB8+1BaYKw=="
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "fvq1GNmUFwbKv+aLVYYdgu/+gc8Nu9oFujOxIjPrsf+meis9JBzTPDL6aP/eeGOz9yPj6rRLUbOjKMpsMEWpNg==",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
         "dependencies": {
-          "System.Buffers": "4.4.0",
+          "System.Buffers": "4.5.1",
           "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
       "System.Numerics.Vectors": {
@@ -1386,15 +1430,16 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.6.0",
-        "contentHash": "HxozeSlipUK7dAroTYwIcGwKDeOVpQnJlpVaOkBz7CM4TsE5b/tKlQBZecTjh6FzcSbxndYaxxpsBMz+wMJeyw=="
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
       },
       "hangfire.core": {
         "type": "Project",
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       }
     }

--- a/src/Hangfire.SqlServer/packages.lock.json
+++ b/src/Hangfire.SqlServer/packages.lock.json
@@ -1294,6 +1294,35 @@
         "resolved": "11.0.1",
         "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
       },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+      },
       "System.Reflection.Emit.ILGeneration": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -1307,12 +1336,18 @@
           "System.Reflection.Emit.ILGeneration": "4.7.0"
         }
       },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
+      },
       "hangfire.core": {
         "type": "Project",
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       }
     }

--- a/tests/Hangfire.Core.Tests/DiagnosticsActivityFilterFacts.cs
+++ b/tests/Hangfire.Core.Tests/DiagnosticsActivityFilterFacts.cs
@@ -1,0 +1,83 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Diagnostics;
+using Hangfire;
+using Moq;
+using Xunit;
+
+namespace Hangfire.Core.Tests
+{
+    public class DiagnosticsActivityFilterFacts
+    {
+        // dotnet test -f net6.0 -l "console;verbosity=detailed" --filter "FullyQualifiedName~Hangfire.Core.Tests.DiagnosticsActivityFilterFacts"
+
+        private readonly CreateContextMock _createContext;
+        private readonly PerformContextMock _performContext;
+
+        public DiagnosticsActivityFilterFacts()
+        {
+            _createContext = new CreateContextMock();
+            _performContext = new PerformContextMock();
+        }
+
+        [Fact]
+        public void OnCreating_WhenActivityIsConfigured_CreationContextIsStored()
+        {
+            // Arrange
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => {},
+                ActivityStopped = activity => {}
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var testActivity = new Activity("test");
+            testActivity.Start();
+            var expectedTraceId = testActivity.TraceId.ToHexString();
+
+            var filter = CreateFilter();
+
+            // Act
+            filter.OnCreating(_createContext.GetCreatingContext());
+
+            // Assert
+            Assert.Equal(((string)_createContext.Object.Parameters["traceparent"]).Substring(3,32), expectedTraceId);
+        }
+
+        [Fact]
+        public void OnPerforming_WhenActivityParametersExist_CreationContextIsUsed()
+        {
+            // Arrange
+            using var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+                ActivityStarted = activity => {},
+                ActivityStopped = activity => {}
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            var expectedTraceId = "abcdef0123456789abcdef0123456789";
+            var traceParent = $"00-{expectedTraceId}-123456789abcdef0-01";
+            _performContext.Connection
+                .Setup(x => x.GetJobParameter(_performContext.BackgroundJob.Id, "traceparent"))
+                .Returns($"\"{traceParent}\"");
+
+            var filter = CreateFilter();
+
+            // Act
+            filter.OnPerforming(_performContext.GetPerformingContext());
+
+            // Assert
+            Assert.Equal(Activity.Current.TraceId.ToHexString(), expectedTraceId);
+        }
+
+        private DiagnosticsActivityFilter CreateFilter()
+        {
+            return new DiagnosticsActivityFilter();
+        }
+    }
+}
+#endif

--- a/tests/Hangfire.Core.Tests/packages.lock.json
+++ b/tests/Hangfire.Core.Tests/packages.lock.json
@@ -434,15 +434,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
       },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
@@ -1207,7 +1200,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       }
     },
@@ -1950,15 +1944,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "tD6kosZnTAGdrEa0tZSuFyunMbt/5KYDnHdndJYGqZoNy00XVXyACd5d6KnE1YgYv3ne2CjtAfNXo/fwEhnKUA==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
       },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
@@ -2723,7 +2710,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       }
     }

--- a/tests/Hangfire.SqlServer.Tests/packages.lock.json
+++ b/tests/Hangfire.SqlServer.Tests/packages.lock.json
@@ -601,8 +601,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "oJjw3uFuVDJiJNbCD8HB4a2p3NYLdt1fiT5OGsPLw+WTOuG0KpP4OXelMmmVKpClueMsit6xOlzy4wNKQFiBLg=="
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
       },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
@@ -1433,7 +1433,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       },
       "hangfire.sqlserver": {
@@ -3233,7 +3234,8 @@
         "dependencies": {
           "Cronos": "[0.8.3, )",
           "Microsoft.CSharp": "[4.4.0, )",
-          "Newtonsoft.Json": "[11.0.1, )"
+          "Newtonsoft.Json": "[11.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[5.0.0, )"
         }
       },
       "hangfire.sqlserver": {


### PR DESCRIPTION
OpenTelemetry is a cross-platform open-source standard for distributed tracing, which allows you to collect and analyze data about the performance of your systems.

OpenTelemetry is now the default for new .NET applications: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/observability-with-otel

These changes add a Hangfire ActivitySource to start a Producer activity (span) when a job (either background or recurring) is created, and then a Consumer activity when it is processed.

It addresses part of the integration to Aspire, requested in https://github.com/HangfireIO/Hangfire/issues/2408

It also provides a built in core solution, compared to using filters discussed in https://github.com/HangfireIO/Hangfire/issues/2017

The creation context information is persisted with the job, so that the distributed activities can be correlated, even if processed on a different server.

No library user involvement or changes are needed except to register a listener for the ActivitySource, such as via OpenTelemetry. The Producer activity will pick up any existing context (such as from an ASP.NET request), or create a new one as needed.

The NetCore example has been updated to show how TraceId is correlated between job creation and execution. The PR also includes unit tests and a brief mention in the Readme.

Note: Some of the work has been based on the MassTransit implementation of ActivitySource.



