### PR TITLE
DisableConcurrentExecution demo improvement: logging with timestamp and thread ID

### DIFF
--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo.csproj
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.20" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1" />
+  </ItemGroup>
+
+</Project>

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Program.cs
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Program.cs
@@ -1,0 +1,36 @@
+using Hangfire;
+using Hangfire.MemoryStorage;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHangfire(config =>
+    config.UseMemoryStorage());
+builder.Services.AddHangfireServer();
+
+var app = builder.Build();
+
+app.UseHangfireDashboard();
+
+RecurringJob.AddOrUpdate<MyJob>(
+    "simple-job",
+    job => job.Run(),
+    Cron.Minutely());
+
+app.Run();
+
+public class MyJob
+{
+    [DisableConcurrentExecution(timeoutInSeconds: 60)]
+    public void Run()
+    {
+        var now = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        var threadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
+
+        Console.WriteLine($"[{now}] [Thread {threadId}] Job started.");
+
+        Thread.Sleep(10000); // Simula job lento
+
+        now = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+        Console.WriteLine($"[{now}] [Thread {threadId}] Job completed.");
+    }
+}

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Properties/launchSettings.json
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:56575",
+      "sslPort": 44346
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5137",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7152;http://localhost:5137",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/README.txt
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/README.txt
@@ -1,0 +1,5 @@
+Per eseguire il progetto (altrimenti problema con firma pacchetto):
+	dotnet restore --configfile nuget-noverify.config
+	dotnet build --no-restore
+	"C:\Users\PC\source\repos\Hangfire\samples\DisableConcurrentExecutionDemo\Hangfire.DisableConcurrentExecutionDemo\bin\Debug\net8.0\Hangfire.DisableConcurrentExecutionDemo.exe"
+

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/appsettings.Development.json
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/appsettings.json
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/nuget-noverify.config
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/nuget-noverify.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="signatureValidationMode" value="accept" />
+  </config>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/packages.lock.json
+++ b/samples/DisableConcurrentExecutionDemo/Hangfire.DisableConcurrentExecutionDemo/packages.lock.json
@@ -1,0 +1,91 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Hangfire.AspNetCore": {
+        "type": "Direct",
+        "requested": "[1.8.20, )",
+        "resolved": "1.8.20",
+        "contentHash": "OoVxOZanKlnpyAuCAYWKGztQHYw6GTQxQD/W3bfOfFsD+8fYp7FEDKbMEsrrMvAtF+gLiY1HNk9xYjUpNnSxGA==",
+        "dependencies": {
+          "Hangfire.NetCore": "[1.8.20]"
+        }
+      },
+      "Hangfire.MemoryStorage": {
+        "type": "Direct",
+        "requested": "[1.8.1, )",
+        "resolved": "1.8.1",
+        "contentHash": "/9qgmdJpiR6eT4PGZFhZMl3e+CR43QS94q8ijz8IqwtCYfRupNHXbq/mBaM3gPrIfOMMTa5MwPEveOU29bqFnw==",
+        "dependencies": {
+          "Hangfire.Core": "1.7.35"
+        }
+      },
+      "Hangfire.Core": {
+        "type": "Transitive",
+        "resolved": "1.8.20",
+        "contentHash": "PSk0daUo3WCcnh89Bydj/xJ+M7GA+eR4nXXD5v/CIBOTCAx+oa3/DNjqLJPC9QHojsKXt0DO6u87aGxCQZ78Og==",
+        "dependencies": {
+          "Newtonsoft.Json": "11.0.1"
+        }
+      },
+      "Hangfire.NetCore": {
+        "type": "Transitive",
+        "resolved": "1.8.20",
+        "contentHash": "QCMoUaOokUsScJIyyo9SDVaAOpPIaIpBhGzN7M9GgZI9Kzetd7Y+hmFlQUTpROi7bcASIGoTOPnPoqdNA///Rw==",
+        "dependencies": {
+          "Hangfire.Core": "[1.8.20]",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "3.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "Lge/PbXC53jI1MF2J92X5EZOeKV8Q/rlB1aV3H9I/ZTDyQGOyBcL03IAvnviWpHKj43BDkNy6kU2KKoh8kAS0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "ofQRroDlzJ0xKOtzNuaVt6QKNImFkhkG0lIMpGl7PtXnIf5SuLWBeiQZAP8DNSxDBJJdcsPkiJiMYK2WA5H8dQ=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "kahEeykb6FyQytoZNNXuz74X85B4weIEt8Kd+0klK48bkXDWOIHAOvNjlGsPMcS9CL935Te8QGQS83JqCbpdHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "qeDWS5ErmkUN96BdQqpmeCmLk5HJWQ/SPw3ux5v5/Qb0hKZS5wojBMulnBC7JUEiBwg7Ir71Yjf1lFiRT5MdtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "+PsosTYZn+omucI0ff9eywo9QcPLwcbIWf7dz7ZLM1zGR8gVZXJ3wo6+tkuIedUNW5iWENlVJPEvrGjiVeoNNQ=="
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "6gwewTbmOh+ZVBicVkL1XRp79sx4O7BVY6Yy+7OYZdwn3pyOKe9lOam+3gXJ3TZMjhJZdV0Ub8hxHt2vkrmN5Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "11.0.1",
+        "contentHash": "pNN4l+J6LlpIvHOeNdXlwxv39NPJ2B5klz+Rd2UQZIx30Squ5oND1Yy3wEAUoKn0GPUj6Yxt9lxlYWQqfZcvKg=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces an improvement to the `DisableConcurrentExecutionDemo` demo by adding detailed logging that includes:

- Job start and end timestamps (`DateTime.Now:HH:mm:ss`)
- Thread ID (`Thread.CurrentThread.ManagedThreadId`)

This helps to clearly visualize the effect of `[DisableConcurrentExecution]`, showing that jobs are not running in parallel.

Terminal output example:
[2025-08-06 18:08:03.292] [Thread 36] Job started.
[2025-08-06 18:08:13.317] [Thread 36] Job completed.

The change is purely educational and does not impact the core of the library.
