### PR TITLE
TypeNameAssemblyFormat is obsolete from .NET6

### DIFF
--- a/tests/Hangfire.Core.Tests/Utils/SerializerSettingsHelper.cs
+++ b/tests/Hangfire.Core.Tests/Utils/SerializerSettingsHelper.cs
@@ -8,7 +8,12 @@ namespace Hangfire.Core.Tests
         public static JsonSerializerSettings DangerousSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All,
+
+#if NET452 || NET461 || NETCOREAPP3_1
             TypeNameAssemblyFormat = FormatterAssemblyStyle.Full,
+#else
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full,
+#endif
 
             DateFormatHandling = DateFormatHandling.MicrosoftDateFormat,
 

--- a/tests/Hangfire.SqlServer.Tests/Utils/SerializerSettingsHelper.cs
+++ b/tests/Hangfire.SqlServer.Tests/Utils/SerializerSettingsHelper.cs
@@ -8,7 +8,12 @@ namespace Hangfire.SqlServer.Tests
         public static JsonSerializerSettings DangerousSettings = new JsonSerializerSettings
         {
             TypeNameHandling = TypeNameHandling.All,
+
+#if NET452 || NET461 || NETCOREAPP3_1
             TypeNameAssemblyFormat = FormatterAssemblyStyle.Full,
+#else
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full,
+#endif
 
             DateFormatHandling = DateFormatHandling.MicrosoftDateFormat,
 


### PR DESCRIPTION
TypeNameAssemblyFormat is obsolete from .NET6. 
https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonSerializerSettings_TypeNameAssemblyFormat.htm

Using TypeNameAssemblyFormatHandling instead from .NET6