### PR TITLE
Add a Russian translation for a Hangfire Dashboard

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.ru.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.ru.resx
@@ -1,0 +1,534 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AwaitingJobsPage_ContinuationsWarning_Text" xml:space="preserve">
+    <value>Не волнуйтесь, продолжения работают как положено. Но ваше текущее хранилище заданий не поддерживает некоторые запросы, требуемые для отображения данной страницы. Пожалуйста, попробуйте обновить ваше хранилище или подождите, пока не будет реализован полный набор инструкций.</value>
+  </data>
+  <data name="AwaitingJobsPage_ContinuationsWarning_Title" xml:space="preserve">
+    <value>Продолжения работают, но данная страница не может быть отображена</value>
+  </data>
+  <data name="AwaitingJobsPage_NoJobs" xml:space="preserve">
+    <value>Ожидающих выполнения заданий не найдено.</value>
+  </data>
+  <data name="AwaitingJobsPage_Table_Options" xml:space="preserve">
+    <value>Настройки</value>
+  </data>
+  <data name="AwaitingJobsPage_Table_Parent" xml:space="preserve">
+    <value>Родитель</value>
+  </data>
+  <data name="AwaitingJobsPage_Title" xml:space="preserve">
+    <value>Ожидающие выполнения задания</value>
+  </data>
+  <data name="Common_Created" xml:space="preserve">
+    <value>Создано</value>
+  </data>
+  <data name="Common_Delete" xml:space="preserve">
+    <value>Удалить</value>
+  </data>
+  <data name="Common_DeleteConfirm" xml:space="preserve">
+    <value>Вы действительно хотите УДАЛИТЬ ВСЕ выбранные задания?</value>
+  </data>
+  <data name="Common_Deleting" xml:space="preserve">
+    <value>Удаление...</value>
+  </data>
+  <data name="Common_DeleteSelected" xml:space="preserve">
+    <value>Удалить выбранные</value>
+  </data>
+  <data name="Common_EnqueueButton_Text" xml:space="preserve">
+    <value>Поместить задания в очередь</value>
+  </data>
+  <data name="Common_Enqueueing" xml:space="preserve">
+    <value>Размещение в очереди...</value>
+  </data>
+  <data name="Common_Fetched" xml:space="preserve">
+    <value>Получено</value>
+  </data>
+  <data name="Common_Id" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Common_Job" xml:space="preserve">
+    <value>Задание</value>
+  </data>
+  <data name="Common_JobExpired" xml:space="preserve">
+    <value>Срок действия задания истёк.</value>
+  </data>
+  <data name="Common_JobStateChanged_Text" xml:space="preserve">
+    <value>Состояние задания изменилось во время получения данных.</value>
+  </data>
+  <data name="Common_LessDetails" xml:space="preserve">
+    <value>Меньше деталей...</value>
+  </data>
+  <data name="Common_MoreDetails" xml:space="preserve">
+    <value>Больше деталей...</value>
+  </data>
+  <data name="Common_NotAvailable" xml:space="preserve">
+    <value>Н/Д</value>
+  </data>
+  <data name="Common_PeriodDay" xml:space="preserve">
+    <value>День</value>
+  </data>
+  <data name="Common_PeriodWeek" xml:space="preserve">
+    <value>Неделя</value>
+  </data>
+  <data name="Common_Reason" xml:space="preserve">
+    <value>Причина</value>
+  </data>
+  <data name="Common_RequeueJobs" xml:space="preserve">
+    <value>Заново поместить в очередь</value>
+  </data>
+  <data name="Common_Retry" xml:space="preserve">
+    <value>Попробовать снова</value>
+  </data>
+  <data name="Common_Server" xml:space="preserve">
+    <value>Сервер</value>
+  </data>
+  <data name="Common_State" xml:space="preserve">
+    <value>Статус</value>
+  </data>
+  <data name="Common_Unknown" xml:space="preserve">
+    <value>Неизвестно</value>
+  </data>
+  <data name="DeletedJobsPage_NoJobs" xml:space="preserve">
+    <value>Удалённых заданий не найдено.</value>
+  </data>
+  <data name="DeletedJobsPage_Table_Deleted" xml:space="preserve">
+    <value>Удалено</value>
+  </data>
+  <data name="DeletedJobsPage_Title" xml:space="preserve">
+    <value>Удалённые задания</value>
+  </data>
+  <data name="EnqueuedJobsPage_NoJobs" xml:space="preserve">
+    <value>Очередь пуста.</value>
+  </data>
+  <data name="EnqueuedJobsPage_Title" xml:space="preserve">
+    <value>Задания в очереди</value>
+  </data>
+  <data name="FailedJobsPage_NoJobs" xml:space="preserve">
+    <value>У вас нет завершённых с ошибкой заданий.</value>
+  </data>
+  <data name="FailedJobsPage_Table_Failed" xml:space="preserve">
+    <value>Завершены с ошибкой</value>
+  </data>
+  <data name="FailedJobsPage_Title" xml:space="preserve">
+    <value>Завершённые с ошибкой задания</value>
+  </data>
+  <data name="FetchedJobsPage_NoJobs" xml:space="preserve">
+    <value>Очередь пуста.</value>
+  </data>
+  <data name="FetchedJobsPage_Title" xml:space="preserve">
+    <value>Полученные задания</value>
+  </data>
+  <data name="HomePage_HistoryGraph" xml:space="preserve">
+    <value>Граф истории</value>
+  </data>
+  <data name="HomePage_RealtimeGraph" xml:space="preserve">
+    <value>Граф реального времени</value>
+  </data>
+  <data name="HomePage_Title" xml:space="preserve">
+    <value>Обзор</value>
+  </data>
+  <data name="JobDetailsPage_Created" xml:space="preserve">
+    <value>Создано</value>
+  </data>
+  <data name="JobDetailsPage_DeleteConfirm" xml:space="preserve">
+    <value>Вы действительно хотите удалить данное задание?</value>
+  </data>
+  <data name="JobDetailsPage_State" xml:space="preserve">
+    <value>Состояние</value>
+  </data>
+  <data name="JobDetailsPage_JobAbortedWithHeartbeat_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;Кажется, выполнение задания было прервано&lt;/strong&gt; – оно выполняется сервером &lt;code&gt;{0}&lt;/code&gt;, который последний раз отправлял heartbeat-сообщение более минуты назад. Задание будет запущено повторно после периода невидимости, но вы можете перезапустить или удалить его вручную.</value>
+  </data>
+  <data name="JobDetailsPage_JobExpired" xml:space="preserve">
+    <value>Фоновое задание '{0}' не может быть найдено на сервере, либо срок его действия истёк.</value>
+  </data>
+  <data name="JobDetailsPage_JobFinished_Warning_Html" xml:space="preserve">
+    <value>&lt;strong&gt;Задание завершено&lt;/strong&gt;. Оно будет удалено автоматически &lt;em&gt;&lt;abbr data-moment="{0}"&gt;{1}&lt;/abbr&gt;&lt;/em&gt;.</value>
+  </data>
+  <data name="JobDetailsPage_JobId" xml:space="preserve">
+    <value>ID задания</value>
+  </data>
+  <data name="JobDetailsPage_Requeue" xml:space="preserve">
+    <value>Заново поместить в очередь</value>
+  </data>
+  <data name="LayoutPage_Back" xml:space="preserve">
+    <value>Обратно на сайт</value>
+  </data>
+  <data name="LayoutPage_Footer_Generatedms" xml:space="preserve">
+    <value>Сгенерировано за {0}мс</value>
+  </data>
+  <data name="LayoutPage_Footer_Time" xml:space="preserve">
+    <value>Время приложения:</value>
+  </data>
+  <data name="LayoutPage_Footer_TimeIsOutOfSync" xml:space="preserve">
+    <value>Время приложения отличается от времени хранилища</value>
+  </data>
+  <data name="LayoutPage_Footer_StorageTime" xml:space="preserve">
+    <value>Время хранилища:</value>
+  </data>
+  <data name="Paginator_Next" xml:space="preserve">
+    <value>Далее</value>
+  </data>
+  <data name="Paginator_Prev" xml:space="preserve">
+    <value>Назад</value>
+  </data>
+  <data name="Paginator_TotalItems" xml:space="preserve">
+    <value>Всего элементов</value>
+  </data>
+  <data name="PerPageSelector_ItemsPerPage" xml:space="preserve">
+    <value>Элементов на странице</value>
+  </data>
+  <data name="ProcessingJobsPage_Aborted" xml:space="preserve">
+    <value>Кажется, выполнение задания было прервано</value>
+  </data>
+  <data name="ProcessingJobsPage_NoJobs" xml:space="preserve">
+    <value>Нет выполняемых в данный момент заданий.</value>
+  </data>
+  <data name="ProcessingJobsPage_Table_Started" xml:space="preserve">
+    <value>Запущено</value>
+  </data>
+  <data name="ProcessingJobsPage_Title" xml:space="preserve">
+    <value>Выполняемые задания</value>
+  </data>
+  <data name="QueuesPage_NoJobs" xml:space="preserve">
+    <value>Нет заданий в очереди.</value>
+  </data>
+  <data name="QueuesPage_NoQueues" xml:space="preserve">
+    <value>Не найдено заданий в очереди. Попробуйте поместить задание в очередь.</value>
+  </data>
+  <data name="QueuesPage_Table_Length" xml:space="preserve">
+    <value>Длина</value>
+  </data>
+  <data name="QueuesPage_Table_NextsJobs" xml:space="preserve">
+    <value>Следующие задания</value>
+  </data>
+  <data name="QueuesPage_Table_Queue" xml:space="preserve">
+    <value>Очередь</value>
+  </data>
+  <data name="QueuesPage_Title" xml:space="preserve">
+    <value>Задания в очереди</value>
+  </data>
+  <data name="RecurringJobsPage_Canceled" xml:space="preserve">
+    <value>Отменено</value>
+  </data>
+  <data name="RecurringJobsPage_NoJobs" xml:space="preserve">
+    <value>Регламентных заданий не найдено.</value>
+  </data>
+  <data name="RecurringJobsPage_Table_Cron" xml:space="preserve">
+    <value>Шаблон CRON</value>
+  </data>
+  <data name="RecurringJobsPage_Table_LastExecution" xml:space="preserve">
+    <value>Последнее выполнение</value>
+  </data>
+  <data name="RecurringJobsPage_Table_NextExecution" xml:space="preserve">
+    <value>Следующее выполнение</value>
+  </data>
+  <data name="RecurringJobsPage_Table_TimeZone" xml:space="preserve">
+    <value>Часовой пояс</value>
+  </data>
+  <data name="RecurringJobsPage_Title" xml:space="preserve">
+    <value>Регламентные задания</value>
+  </data>
+  <data name="RecurringJobsPage_Triggering" xml:space="preserve">
+    <value>Запуск...</value>
+  </data>
+  <data name="RecurringJobsPage_TriggerNow" xml:space="preserve">
+    <value>Запустить сейчас</value>
+  </data>
+  <data name="RetriesPage_NoJobs" xml:space="preserve">
+    <value>Всё в порядке – у вас нет запущенных повторно заданий.</value>
+  </data>
+  <data name="RetriesPage_Title" xml:space="preserve">
+    <value>Повторные запуски</value>
+  </data>
+  <data name="ScheduledJobsPage_EnqueueNow" xml:space="preserve">
+    <value>Поместить в очередь сейчас</value>
+  </data>
+  <data name="ScheduledJobsPage_NoJobs" xml:space="preserve">
+    <value>Нет запланированных заданий.</value>
+  </data>
+  <data name="ScheduledJobsPage_Table_Enqueue" xml:space="preserve">
+    <value>Поместить в очередь</value>
+  </data>
+  <data name="ScheduledJobsPage_Table_Scheduled" xml:space="preserve">
+    <value>Запланировано</value>
+  </data>
+  <data name="ScheduledJobsPage_Title" xml:space="preserve">
+    <value>Запланированные задания</value>
+  </data>
+  <data name="ServersPage_NoServers" xml:space="preserve">
+    <value>Нет активных серверов. Фоновые задания не будут выполняться.</value>
+  </data>
+  <data name="ServersPage_Table_Heartbeat" xml:space="preserve">
+    <value>Heartbeat-сообщения</value>
+  </data>
+  <data name="ServersPage_Table_Name" xml:space="preserve">
+    <value>Название</value>
+  </data>
+  <data name="ServersPage_Table_Queues" xml:space="preserve">
+    <value>Очереди</value>
+  </data>
+  <data name="ServersPage_Table_Started" xml:space="preserve">
+    <value>Запущен</value>
+  </data>
+  <data name="ServersPage_Table_Workers" xml:space="preserve">
+    <value>Рабочие узлы</value>
+  </data>
+  <data name="ServersPage_Title" xml:space="preserve">
+    <value>Серверы</value>
+  </data>
+  <data name="SucceededJobsPage_NoJobs" xml:space="preserve">
+    <value>Выполненные задания не найдены.</value>
+  </data>
+  <data name="SucceededJobsPage_Table_Succeeded" xml:space="preserve">
+    <value>Выполнено</value>
+  </data>
+  <data name="SucceededJobsPage_Table_TotalDuration" xml:space="preserve">
+    <value>Общая длительность</value>
+  </data>
+  <data name="SucceededJobsPage_Table_Latency" xml:space="preserve">
+    <value>Задержка</value>
+  </data>
+  <data name="SucceededJobsPage_Table_Duration" xml:space="preserve">
+    <value>Длительность</value>
+  </data>
+  <data name="SucceededJobsPage_Title" xml:space="preserve">
+    <value>Выполненные задания</value>
+  </data>
+  <data name="JobsSidebarMenu_Awaiting" xml:space="preserve">
+    <value>Ожидают выполнения</value>
+  </data>
+  <data name="JobsSidebarMenu_Deleted" xml:space="preserve">
+    <value>Удалены</value>
+  </data>
+  <data name="JobsSidebarMenu_Failed" xml:space="preserve">
+    <value>Завершены с ошибкой</value>
+  </data>
+  <data name="JobsSidebarMenu_Processing" xml:space="preserve">
+    <value>Выполняются</value>
+  </data>
+  <data name="JobsSidebarMenu_Scheduled" xml:space="preserve">
+    <value>Запланированы</value>
+  </data>
+  <data name="JobsSidebarMenu_Succeeded" xml:space="preserve">
+    <value>Выполнены</value>
+  </data>
+  <data name="NavigationMenu_Jobs" xml:space="preserve">
+    <value>Задания</value>
+  </data>
+  <data name="NavigationMenu_RecurringJobs" xml:space="preserve">
+    <value>Регламентные задания</value>
+  </data>
+  <data name="NavigationMenu_Retries" xml:space="preserve">
+    <value>Повторные запуски</value>
+  </data>
+  <data name="NavigationMenu_Servers" xml:space="preserve">
+    <value>Серверы</value>
+  </data>
+  <data name="Common_CannotFindTargetMethod" xml:space="preserve">
+    <value>Не удалось найти целевой метод. </value>
+  </data>
+  <data name="Common_Enqueued" xml:space="preserve">
+    <value>Помещено в очередь</value>
+  </data>
+  <data name="Common_NoState" xml:space="preserve">
+    <value>Нет состояния</value>
+  </data>
+  <data name="JobsSidebarMenu_Enqueued" xml:space="preserve">
+    <value>Помещены в очередь</value>
+  </data>
+  <data name="Metrics_ActiveConnections" xml:space="preserve">
+    <value>Текущие подключения</value>
+  </data>
+  <data name="Metrics_DeletedJobs" xml:space="preserve">
+    <value>Удалённые задания</value>
+  </data>
+  <data name="Metrics_FailedJobs" xml:space="preserve">
+    <value>Завершённые с ошибкой задания</value>
+  </data>
+  <data name="Metrics_ProcessingJobs" xml:space="preserve">
+    <value>Выполняемые задания.</value>
+  </data>
+  <data name="Metrics_RecurringJobs" xml:space="preserve">
+    <value>Регламентные задания</value>
+  </data>
+  <data name="Metrics_Retries" xml:space="preserve">
+    <value>Повторные запуски</value>
+  </data>
+  <data name="Metrics_ScheduledJobs" xml:space="preserve">
+    <value>Запланированные задания</value>
+  </data>
+  <data name="Metrics_Servers" xml:space="preserve">
+    <value>Серверы</value>
+  </data>
+  <data name="Metrics_SucceededJobs" xml:space="preserve">
+    <value>Успешно выполненные задания</value>
+  </data>
+  <data name="Metrics_TotalConnections" xml:space="preserve">
+    <value>Всего подключений</value>
+  </data>
+  <data name="Common_Condition" xml:space="preserve">
+    <value>Условие</value>
+  </data>
+  <data name="Common_Continuations" xml:space="preserve">
+    <value>Продолжения</value>
+  </data>
+  <data name="Metrics_AwaitingCount" xml:space="preserve">
+    <value>В ожидании</value>
+  </data>
+  <data name="Metrics_EnqueuedCountOrNull" xml:space="preserve">
+    <value>В очереди</value>
+  </data>
+  <data name="Metrics_EnqueuedQueuesCount" xml:space="preserve">
+    <value>В очереди / Очередей</value>
+  </data>
+  <data name="Metrics_FailedCountOrNull" xml:space="preserve">
+    <value>Найдено {0} завершённых с ошибкой заданий. Запустите их заново, либо удалите их вручную.</value>
+  </data>
+  <data name="HomePage_GraphHover_Failed" xml:space="preserve">
+    <value>Завершено с ошибкой</value>
+  </data>
+  <data name="HomePage_GraphHover_Succeeded" xml:space="preserve">
+    <value>Выполнено</value>
+  </data>
+  <data name="Common_Disabled" xml:space="preserve">
+    <value>Отключено</value>
+  </data>
+  <data name="RecurringJobsPage_RecurringJobDisabled_Tooltip" xml:space="preserve">
+    <value>Шаблон CRON некорректен, либо он ни разу не будет выполнен в следующие сто лет.</value>
+  </data>
+  <data name="ServersPage_Note_Text" xml:space="preserve">
+    <value>Некоторые серверы могут быть остановленными, т.к. они не отправляли heartbeat-сообщения более минуты. Если они не отправят heartbeat-сообщения в ближайшем будущем, дополнительных действий не потребуется - эти серверы будут автоматически удалены после отсечки. Незавершённые фоновые задания, выполняемые на этих серверах, будут автоматически заново добавлены в очередь, но вы можете ускорить процесс с помощью страницы &lt;a href="{0}"&gt;Выполняемые задания&lt;/a&gt;.</value>
+  </data>
+  <data name="ServersPage_Note_Title" xml:space="preserve">
+    <value>Остановленные серверы будут удалены автоматически.</value>
+  </data>
+  <data name="ServersPage_Active" xml:space="preserve">
+    <value>Активны</value>
+  </data>
+  <data name="ServersPage_Possibly_Aborted" xml:space="preserve">
+    <value>Предположительно остановлены</value>
+  </data>
+  <data name="Common_Error" xml:space="preserve">
+    <value>Ошибка</value>
+  </data>
+  <data name="JobDetailsPage_Parameters" xml:space="preserve">
+    <value>Параметры</value>
+  </data>
+</root>


### PR DESCRIPTION
Implements #2548.

Note that some texts in the selected task's details are not covered by resource system-based translations at all. 

Also date and time texts (like "a minute ago") respected current locale with Hangfire 1.7.x, but do not in upstream code. This issue presumably is caused by commit 061999aacd226faf253b3ee91f8541cdee28af2e. To solve it, I need to return a Russian locale definition to the custom `moment-with-locales.min.js`. It will be done in the follow-up PR.

<details>
<summary>Some screenshots</summary>

<img width="1910" height="374" alt="image" src="https://github.com/user-attachments/assets/8be0b3ca-c204-47df-906d-24468cbf2cd8" />

<img width="1916" height="359" alt="image" src="https://github.com/user-attachments/assets/dc96490e-3985-4b84-8fe0-5305888effbc" />

<img width="1895" height="339" alt="image" src="https://github.com/user-attachments/assets/66cd3618-4162-4de1-a67e-3e9df40662a7" />

<img width="1595" height="432" alt="image" src="https://github.com/user-attachments/assets/e92cc5b8-305a-4d99-a49c-0c0b4338088b" />
</details>