### PR TITLE
Improve a support for locales with region subtags

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -49,7 +49,8 @@
     hangfire.config = {
         pollInterval: $("#hangfireConfig").data("pollinterval"),
         pollUrl: $("#hangfireConfig").data("pollurl"),
-        locale: document.documentElement.lang,
+        lang: document.documentElement.lang,
+        locale: $("#hangfireConfig").data("locale"),
         darkMode: $("#hangfireConfig").data("darkmode")
     };
 
@@ -337,7 +338,7 @@
                 config.pollUrl,
                 config.pollInterval);
 
-            this._initialize(config.locale);
+            this._initialize(config.lang, config.locale);
 
             this.realtimeGraph = this._createRealtimeGraph('realtimeGraph', config.pollInterval);
             this.historyGraph = this._createHistoryGraph('historyGraph');
@@ -396,8 +397,10 @@
             return null;
         };
 
-        Page.prototype._initialize = function (locale) {
-            moment.locale(locale);
+        Page.prototype._initialize = function (lang, locale) {
+            if (moment.locale(locale) !== locale)
+                moment.locale(lang);
+
             var updateRelativeDates = function () {
                 $('*[data-moment]').each(function () {
                     var $this = $(this);

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml
@@ -121,6 +121,7 @@
         <div id="hangfireConfig"
              data-pollinterval="@DashboardOptions.StatsPollingInterval"
              data-pollurl="@(Url.To("/stats"))"
+             data-locale="@CultureInfo.CurrentUICulture.Name.ToLowerInvariant()"
              data-darkmode="@(DashboardOptions.DarkModeEnabled.ToString().ToLowerInvariant())">
         </div>
 

--- a/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/LayoutPage.cshtml.cs
@@ -587,11 +587,21 @@ WriteLiteral("\"\r\n             data-pollurl=\"");
             
             #line default
             #line hidden
-WriteLiteral("\"\r\n             data-darkmode=\"");
+WriteLiteral("\"\r\n             data-locale=\"");
 
 
             
             #line 124 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+                     Write(CultureInfo.CurrentUICulture.Name.ToLowerInvariant());
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n             data-darkmode=\"");
+
+
+            
+            #line 125 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                         Write(DashboardOptions.DarkModeEnabled.ToString().ToLowerInvariant());
 
             
@@ -601,7 +611,7 @@ WriteLiteral("\">\r\n        </div>\r\n\r\n        <script src=\"");
 
 
             
-            #line 127 "..\..\Dashboard\Pages\LayoutPage.cshtml"
+            #line 128 "..\..\Dashboard\Pages\LayoutPage.cshtml"
                 Write(Url.To($"/js{version.Major}{version.Minor}{version.Build}0{Math.Abs(DashboardRoutes.JavaScriptsHashCode)}"));
 
             


### PR DESCRIPTION
A follow-up work for #2574.

In upstream Hangfire, locale name is passed to Hangfire Dashboard HTML as a two-letter language name:
```
<html lang="@CultureInfo.CurrentUICulture.TwoLetterISOLanguageName">
```

This tag is used as a locale name for Moment.js:

<img width="483" height="120" alt="image" src="https://github.com/user-attachments/assets/9b9863aa-1241-4e79-b2c9-a1b361f4b550" />

As a result, some supported locales become unused in Moment.js:
1. `pt-br` becomes just  `pt` instead
2. `zh-cn` and `zh-tw` become just `zh`, which does not exist in Moment.js, so an English text is used instead

A proposed solution:
1. Add a new attibute to `Hangfire.config`, which will store the full locale name.
2. Try to set a locale for Moment.js by using a full name first, and fall back to current behaviour if target locale was not found.