### PR TITLE
Add unit tests for DisableConcurrentExecutionAttribute

### DIFF
--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.pt-BR.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.pt-BR.resx
@@ -544,6 +544,25 @@
   <data name="Common_Disabled" xml:space="preserve">
     <value>Inativo</value>
   </data>
+  <data name="RecurringJobsPage_RecurringJobDisabled_Tooltip" xml:space="preserve">
+    <value>A expressão Cron é inválida ou não possui nenhuma ocorrência nos próximos 100 anos</value>
+  </data>
+  <data name="ServersPage_Note_Text" xml:space="preserve">
+    <value>Alguns servidores não reportaram sinal no último minuto e podem ter sido abortados. Se não reportarem sinal em breve, serão removidos automaticamente após o tempo limite ser excedido, sem necessidade de ação manual.
+                    Tarefas incompletas em execução nesses servidores serão reenfileiradas automaticamente, mas você pode acelerar o processo verificando a página &lt;a href="{0}"&gt;Tarefas em processamento&lt;/a&gt;.</value>
+  </data>
+  <data name="ServersPage_Note_Title" xml:space="preserve">
+    <value>Servidores abortados serão removidos automaticamente</value>
+  </data>
+  <data name="ServersPage_Active" xml:space="preserve">
+    <value>Ativo</value>
+  </data>
+  <data name="ServersPage_Possibly_Aborted" xml:space="preserve">
+    <value>Possivelmente abortado</value>
+  </data>
+  <data name="Common_Error" xml:space="preserve">
+    <value>Erro</value>
+  </data>
   <data name="JobDetailsPage_Parameters" xml:space="preserve">
     <value>Parâmetros</value>
   </data>

--- a/tests/Hangfire.Core.Tests/DisableConcurrentExecutionAttributeFacts.cs
+++ b/tests/Hangfire.Core.Tests/DisableConcurrentExecutionAttributeFacts.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Hangfire.Common;
+using Moq;
+using Xunit;
+
+namespace Hangfire.Core.Tests
+{
+    public class DisableConcurrentExecutionAttributeFacts
+    {
+        private const int TimeoutInSeconds = 5;
+
+        private readonly PerformContextMock _context;
+        private readonly Mock<IDisposable> _distributedLock;
+
+        public DisableConcurrentExecutionAttributeFacts()
+        {
+            _context = new PerformContextMock();
+            _context.BackgroundJob.Job = Job.FromExpression(() => Sample());
+
+            _distributedLock = new Mock<IDisposable>();
+            _context.Connection
+                .Setup(x => x.AcquireDistributedLock(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Returns(_distributedLock.Object);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenTimeoutInSecondsIsNegative()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new DisableConcurrentExecutionAttribute(-1));
+        }
+
+        [Fact]
+        public void Ctor_CorrectlySets_TheTimeoutSecProperty()
+        {
+            var attribute = new DisableConcurrentExecutionAttribute(TimeoutInSeconds);
+
+            Assert.Equal(TimeoutInSeconds, attribute.TimeoutSec);
+        }
+
+        [Fact]
+        public void Ctor_CorrectlySets_BothResourceAndTimeoutSecProperties()
+        {
+            var attribute = new DisableConcurrentExecutionAttribute("my-resource", TimeoutInSeconds);
+
+            Assert.Equal("my-resource", attribute.Resource);
+            Assert.Equal(TimeoutInSeconds, attribute.TimeoutSec);
+        }
+
+        [Fact]
+        public void OnPerforming_AcquiresDistributedLock_BasedOnJobTypeAndMethodName()
+        {
+            var attribute = CreateAttribute();
+
+            attribute.OnPerforming(_context.GetPerformingContext());
+
+            _context.Connection.Verify(x => x.AcquireDistributedLock(
+                "DisableConcurrentExecutionAttributeFacts.Sample",
+                TimeSpan.FromSeconds(TimeoutInSeconds)));
+        }
+
+        [Fact]
+        public void OnPerforming_AcquiresDistributedLock_OnTheLowerCasedFormattedResource_WhenResourceIsSpecified()
+        {
+            _context.BackgroundJob.Job = Job.FromExpression(() => Sample("Some-Value"));
+            var attribute = new DisableConcurrentExecutionAttribute("Prefix-{0}", TimeoutInSeconds);
+
+            attribute.OnPerforming(_context.GetPerformingContext());
+
+            _context.Connection.Verify(x => x.AcquireDistributedLock(
+                "prefix-some-value",
+                TimeSpan.FromSeconds(TimeoutInSeconds)));
+        }
+
+        [Fact]
+        public void OnPerforming_ThrowsFormatException_WhenResourceFormatIsInvalid()
+        {
+            var attribute = new DisableConcurrentExecutionAttribute("resource-{1}", TimeoutInSeconds);
+
+            Assert.Throws<FormatException>(
+                () => attribute.OnPerforming(_context.GetPerformingContext()));
+        }
+
+        [Fact]
+        public void OnPerforming_StoresAcquiredDistributedLock_InTheItemsCollection()
+        {
+            var attribute = CreateAttribute();
+            var performingContext = _context.GetPerformingContext();
+
+            attribute.OnPerforming(performingContext);
+
+            Assert.Same(_distributedLock.Object, performingContext.Items["DistributedLock"]);
+        }
+
+        [Fact]
+        public void OnPerformed_ReleasesTheAcquiredDistributedLock()
+        {
+            var attribute = CreateAttribute();
+            attribute.OnPerforming(_context.GetPerformingContext());
+
+            attribute.OnPerformed(_context.GetPerformedContext());
+
+            _distributedLock.Verify(x => x.Dispose());
+        }
+
+        [Fact]
+        public void OnPerformed_ThrowsAnException_WhenDistributedLockWasNotAcquired()
+        {
+            var attribute = CreateAttribute();
+
+            Assert.Throws<InvalidOperationException>(
+                () => attribute.OnPerformed(_context.GetPerformedContext()));
+        }
+
+        private static DisableConcurrentExecutionAttribute CreateAttribute()
+        {
+            return new DisableConcurrentExecutionAttribute(TimeoutInSeconds);
+        }
+
+        [SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+        public static void Sample()
+        {
+        }
+
+        [SuppressMessage("Usage", "xUnit1013:Public method should be marked as test")]
+        [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+        public static void Sample(string value)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Cover constructor validation, distributed lock acquisition with both default and formatted resource identifiers, and lock release behavior.