### PR TITLE
Fix grammar and spelling in user-facing messages

### DIFF
--- a/src/Hangfire.Core/AutomaticRetryAttribute.cs
+++ b/src/Hangfire.Core/AutomaticRetryAttribute.cs
@@ -378,7 +378,7 @@ namespace Hangfire
             if (LogEvents)
             {
                 _logger.WarnException(
-                    $"Failed to process the job '{context.BackgroundJob.Id}': an exception occured. Job was automatically deleted because the retry attempt count exceeded {Attempts}.",
+                    $"Failed to process the job '{context.BackgroundJob.Id}': an exception occurred. Job was automatically deleted because the retry attempt count exceeded {Attempts}.",
                     failedState.Exception);
             }
         }

--- a/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
+++ b/src/Hangfire.Core/Client/CoreBackgroundJobFactory.cs
@@ -113,7 +113,7 @@ namespace Hangfire.Client
                         // when its state is null, and since we shouldn't do anything when it's non-null,
                         // there will be no any race conditions.
                         var data = ctx.Context.Connection.GetJobData(ctx.BackgroundJob.Id);
-                        if (data == null) throw new InvalidOperationException($"Was unable to initialize a background job '{ctx.BackgroundJob.Id}', because it doesn't exists.");
+                        if (data == null) throw new InvalidOperationException($"Was unable to initialize a background job '{ctx.BackgroundJob.Id}', because it doesn't exist.");
 
                         if (!String.IsNullOrEmpty(data.State)) return;
                     }

--- a/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
+++ b/src/Hangfire.Core/Dashboard/Content/resx/Strings.resx
@@ -542,7 +542,7 @@
     <value>Disabled</value>
   </data>
   <data name="RecurringJobsPage_RecurringJobDisabled_Tooltip" xml:space="preserve">
-    <value>Cron expression is invalid or don't have any occurrences over the next 100 years</value>
+    <value>Cron expression is invalid or doesn't have any occurrences over the next 100 years</value>
   </data>
   <data name="ServersPage_Note_Text" xml:space="preserve">
     <value>Some of the servers don't have heartbeat reported within the last minute and may be aborted. If they don't report heartbeat in the near future, they will be removed automatically after timeout is exceeded, no manual action is required.

--- a/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
+++ b/src/Hangfire.Core/DisableConcurrentExecutionAttribute.cs
@@ -27,7 +27,7 @@ namespace Hangfire
     {
         public DisableConcurrentExecutionAttribute(int timeoutInSeconds)
         {
-            if (timeoutInSeconds < 0) throw new ArgumentException("Timeout argument value should be greater that zero.");
+            if (timeoutInSeconds < 0) throw new ArgumentException("Timeout argument value should be greater than zero.");
 
             TimeoutSec = timeoutInSeconds;
         }


### PR DESCRIPTION
Correct several long-standing typos in messages that are surfaced to users through logs, exceptions and the Dashboard UI:

- AutomaticRetryAttribute: "an exception occured" -> "an exception occurred" in the warning logged when a job is automatically deleted after exceeding the maximum number of retry attempts.

- CoreBackgroundJobFactory: "because it doesn't exists" -> "because it doesn't exist" in the InvalidOperationException thrown when a background job can't be initialized during creation retries.

- DisableConcurrentExecutionAttribute: "greater that zero" -> "greater than zero" in the ArgumentException thrown when a negative timeout value is passed to the constructor.

- Dashboard (Strings.resx): "Cron expression is invalid or don't have any occurrences" -> "Cron expression is invalid or doesn't have any occurrences" in the disabled recurring job resource files are not affected since each culture provides it  value for this key.

Only string literals are changed, so there is no behavior change, and no existing tests assert these exact messages.