### PR TITLE
docs: use mailto scheme for security email in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Reporting security issues 
 
-In order to give the community time to respond and upgrade we strongly urge you report all security issues privately. Please email us at [security@hangfire.io](security@hangfire.io) with details and we will respond ASAP. Security issues always take precedence over bug fixes and feature work. We can and do mark releases as "urgent" if they contain serious security fixes. 
+In order to give the community time to respond and upgrade we strongly urge you report all security issues privately. Please email us at [security@hangfire.io](mailto:security@hangfire.io) with details and we will respond ASAP. Security issues always take precedence over bug fixes and feature work. We can and do mark releases as "urgent" if they contain serious security fixes. 


### PR DESCRIPTION
## Problem
`SECURITY.md` still writes the security contact as:

```markdown
Please email us at [security@hangfire.io](security@hangfire.io) with details
```

Without a `mailto:` scheme this renders as a relative URL. Verified with a GET:

```
curl -sL -o /dev/null -w "%{http_code} %{url_effective}\n" \
  "https://github.com/HangfireIO/Hangfire/blob/main/security@hangfire.io"
# 404
```

So the rendered link leads to a 404 page instead of opening a mail client.

`README.md` already received the `mailto:` prefix in 8c2e32e; `SECURITY.md` was left out.

## Solution
Use `mailto:security@hangfire.io` as the link target in `SECURITY.md`, matching the already-fixed README.

## Verification
Markdown-only change. Checked open and closed PRs for prior mailto/security-link fixes on SECURITY.md and found none.
